### PR TITLE
Fixing bug with String deserialization where Strings weren't properly…

### DIFF
--- a/csmi/src/common/include/csm_serialization_x_macros.h
+++ b/csmi/src/common/include/csm_serialization_x_macros.h
@@ -278,7 +278,10 @@
          target->name = (char*) malloc(size_dump);           \
          memcpy( target->name, buffer + *offset, size_dump); \
          *offset += size_dump;}                              \
-        else *offset = len + 2;
+        else {                                               \
+            target->name = NULL;                             \
+            *offset = len + 2;                               \
+        }
 
     // FIXME Should this just assume based on the length member?
     // This should be identical to unpack string.


### PR DESCRIPTION
… nulled.

Fixing a defect were bad buffers result in a segmentation fault due to improper string initialization.