### PR TITLE
CSM Inventory: fix potential seg fault issue

### DIFF
--- a/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
+++ b/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
@@ -562,8 +562,8 @@ int main(int argc, char *argv[])
         }
 		
 		//prevent a reading from output if API fails
-		// if(return_value == CSMI_SUCCESS)
-		// {
+		if(return_value == CSMI_SUCCESS)
+		{
 			std::cout << "# total ib inventory collected: " << IBinput->inventory_count << std::endl;
 			std::cout << "# new ib records inserted into database: " << IBoutput->insert_count << std::endl;
 			std::cout << "# old ib records updated in database: " << IBoutput->update_count << std::endl;
@@ -572,7 +572,7 @@ int main(int argc, char *argv[])
 				std::cout <<  "# WARNING: inserted records and updated records do not match total inventory collected."  << std::endl;
 				std::cout <<  "# records dropped: " << IBinput->inventory_count - IBoutput->insert_count - IBoutput->update_count << std::endl;
 			}
-		// }
+		}
 		
 		
 		

--- a/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
+++ b/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
@@ -561,14 +561,20 @@ int main(int argc, char *argv[])
 				printf("%s FAILED: errcode: %d errmsg: %s\n",argv[0], return_value,  csm_api_object_errmsg_get(csm_obj));
         }
 		
-		std::cout << "# total ib inventory collected: " << IBinput->inventory_count << std::endl;
-		std::cout << "# new ib records inserted into database: " << IBoutput->insert_count << std::endl;
-		std::cout << "# old ib records updated in database: " << IBoutput->update_count << std::endl;
+		//prevent a reading from output if API fails
+		// if(return_value == CSMI_SUCCESS)
+		// {
+			std::cout << "# total ib inventory collected: " << IBinput->inventory_count << std::endl;
+			std::cout << "# new ib records inserted into database: " << IBoutput->insert_count << std::endl;
+			std::cout << "# old ib records updated in database: " << IBoutput->update_count << std::endl;
+			
+			if(((unsigned)IBoutput->insert_count + IBoutput->update_count) != IBinput->inventory_count){
+				std::cout <<  "# WARNING: inserted records and updated records do not match total inventory collected."  << std::endl;
+				std::cout <<  "# records dropped: " << IBinput->inventory_count - IBoutput->insert_count - IBoutput->update_count << std::endl;
+			}
+		// }
 		
-		if(((unsigned)IBoutput->insert_count + IBoutput->update_count) != IBinput->inventory_count){
-			std::cout <<  "# WARNING: inserted records and updated records do not match total inventory collected."  << std::endl;
-			std::cout <<  "# records dropped: " << IBinput->inventory_count - IBoutput->insert_count - IBoutput->update_count << std::endl;
-		}
+		
 		
 
         // Use CSM API free to release arguments. We no longer need them.


### PR DESCRIPTION
If inventory collection API fails, then it would cause a segfault. This code checks for success. And only runs the code in case of a success, therefore avoiding a potential read of values that don't exist. eliminating a potential segfault. 