### PR TITLE
updated csmd versioning to use major.cumulative.efix format instead of git commit

### DIFF
--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -105,7 +105,7 @@ Configuration::Configuration( int argc, char **argv, const RunMode *runmode )
     // shall not continue. The code for now will come here only when csm.role is not valid
   }
 
-  CSMLOGp( csmd, info, "CSMD" ) << _Role << "; Build: " << std::string( CSM_VERSION, 10 )
+  CSMLOGp( csmd, info, "CSMD" ) << _Role << "; Build: " << std::string( CSM_VERSION, strnlen( CSM_VERSION, 10 ) )
     << "; Config file: " << _CfgFile;
 
   #define RETRIES 5

--- a/csmnet/include/csm_network_config.h
+++ b/csmnet/include/csm_network_config.h
@@ -134,16 +134,14 @@
  */
 #define CSM_NETWORK_HEARTBEAT_INTERVAL ( 15 )
 
-
-#ifndef CSM_VERSION_ID
-/** @def CSM_VERSION_ID
- * @brief Version identification
+/** @def CSM_CUMULATIVE_FIX_MAX_BACK_LEVEL_SUPPORT
+ * @brief Sets the maximum back-level of supported cumulative fix versions
  *
- * Contains the version ID string for CSM to assure compatibility
- * between communication partners. If the build system is not
- * setting this ID, we set a default here.
+ * Major version has to match
+ * Cumulative Fix version may differ by this max level
+ * Efix version is supported regardless
+ *
  */
-//#define CSM_VERSION_ID "unknown"
-#endif
+#define CSM_CUMULATIVE_FIX_MAX_BACK_LEVEL_SUPPORT 1
 
 #endif // __CSM_NETWORK_CONFIG_H__

--- a/csmnet/src/CPP/csm_version_msg.cc
+++ b/csmnet/src/CPP/csm_version_msg.cc
@@ -25,3 +25,64 @@ csm::network::VersionMsg::VersionMsg( const std::string v,
 {
 }
 
+uint8_t
+csm::network::VersionMsg::GetVersionMajor() const
+{
+  size_t dotpos_major = 0;
+  try
+  {
+    dotpos_major = _Version.find('.');
+  }
+  catch ( std::out_of_range &e )
+  {
+    return 0;
+  }
+  char *endp;
+  std::string major_str = std::string( _Version, 0, dotpos_major );
+  long int major = std::strtol( major_str.c_str(), &endp, 10 );
+  if(( major == 0 ) && ( endp == major_str.c_str() ))
+    return 0;
+  return (uint8_t)major;
+}
+
+uint8_t
+csm::network::VersionMsg::GetVersionCumulFix() const
+{
+  size_t dotpos_major = 0;
+  size_t dotpos_cumulfix = 0;
+  try
+  {
+    dotpos_major = _Version.find('.');
+    dotpos_cumulfix = _Version.rfind('.');
+  }
+  catch ( std::out_of_range &e )
+  {
+    return 0;
+  }
+  char *endp;
+  std::string cumul_str = std::string( _Version, dotpos_major+1, dotpos_cumulfix );
+  long int cumul = std::strtol( cumul_str.c_str(), &endp, 10 );
+  if(( cumul == 0 ) && ( endp == cumul_str.c_str() ))
+    return 0;
+  return (uint8_t)cumul;
+}
+
+uint8_t
+csm::network::VersionMsg::GetVersionEfix() const
+{
+  size_t dotpos_cumulfix = 0;
+  try
+  {
+    dotpos_cumulfix = _Version.rfind('.');
+  }
+  catch ( std::out_of_range &e )
+  {
+    return 0;
+  }
+  char *endp;
+  std::string efix_str = std::string( _Version, dotpos_cumulfix+1, std::string::npos );
+  long int efix = std::strtol( efix_str.c_str(), &endp, 10 );
+  if(( efix == 0 ) && ( endp == efix_str.c_str() ))
+    return 0;
+  return (uint8_t)efix;
+}

--- a/csmnet/src/CPP/csm_version_msg.cc
+++ b/csmnet/src/CPP/csm_version_msg.cc
@@ -13,76 +13,113 @@
 
 ================================================================================*/
 
+#include <algorithm>
+
+#include "logging.h"
+#include "csm_network_config.h"
 #include "csm_version_msg.h"
 
 
 csm::network::VersionMsg* csm::network::VersionMsg::_version = NULL;
 
 
-csm::network::VersionMsg::VersionMsg( const std::string v,
-            const std::string h )
-: _Version( v ), _Hostname( h ), _Sequence(0)
-{
-}
 
-uint8_t
-csm::network::VersionMsg::GetVersionMajor() const
+unsigned
+csm::network::ExtractVersionMajor( const std::string &vStr )
 {
   size_t dotpos_major = 0;
   try
   {
-    dotpos_major = _Version.find('.');
+    dotpos_major = vStr.find('.');
   }
   catch ( std::out_of_range &e )
   {
     return 0;
   }
+  if( dotpos_major == std::string::npos )
+    return 0;
   char *endp;
-  std::string major_str = std::string( _Version, 0, dotpos_major );
+  std::string major_str = std::string( vStr, 0, dotpos_major );
   long int major = std::strtol( major_str.c_str(), &endp, 10 );
   if(( major == 0 ) && ( endp == major_str.c_str() ))
     return 0;
   return (uint8_t)major;
 }
 
-uint8_t
-csm::network::VersionMsg::GetVersionCumulFix() const
+unsigned
+csm::network::ExtractVersionCumulFix( const std::string &vStr )
 {
   size_t dotpos_major = 0;
   size_t dotpos_cumulfix = 0;
   try
   {
-    dotpos_major = _Version.find('.');
-    dotpos_cumulfix = _Version.rfind('.');
+    dotpos_major = vStr.find('.');
+    dotpos_cumulfix = vStr.rfind('.');
   }
   catch ( std::out_of_range &e )
   {
     return 0;
   }
+  if(( dotpos_major == std::string::npos ) || ( dotpos_cumulfix == std::string::npos ))
+    return 0;
   char *endp;
-  std::string cumul_str = std::string( _Version, dotpos_major+1, dotpos_cumulfix );
+  size_t len = dotpos_cumulfix - dotpos_major - 1;
+  std::string cumul_str = std::string( vStr, dotpos_major+1, len );
   long int cumul = std::strtol( cumul_str.c_str(), &endp, 10 );
   if(( cumul == 0 ) && ( endp == cumul_str.c_str() ))
     return 0;
   return (uint8_t)cumul;
 }
 
-uint8_t
-csm::network::VersionMsg::GetVersionEfix() const
+unsigned
+csm::network::ExtractVersionEfix( const std::string &vStr )
 {
   size_t dotpos_cumulfix = 0;
   try
   {
-    dotpos_cumulfix = _Version.rfind('.');
+    dotpos_cumulfix = vStr.rfind('.');
   }
   catch ( std::out_of_range &e )
   {
     return 0;
   }
+  if( dotpos_cumulfix == std::string::npos )
+    return 0;
   char *endp;
-  std::string efix_str = std::string( _Version, dotpos_cumulfix+1, std::string::npos );
+  std::string efix_str = std::string( vStr, dotpos_cumulfix+1, std::string::npos );
   long int efix = std::strtol( efix_str.c_str(), &endp, 10 );
   if(( efix == 0 ) && ( endp == efix_str.c_str() ))
     return 0;
   return (uint8_t)efix;
+}
+
+csm::network::VersionMsg::VersionMsg( const std::string v,
+            const std::string h )
+: _Hostname( h ), _Sequence(0)
+{
+  SetVersion( v );
+}
+
+void
+csm::network::VersionMsg::SetVersion( const std::string newVersion )
+{
+  _Version = newVersion;
+  _VersionNumbers[0] = csm::network::ExtractVersionMajor( _Version );
+  _VersionNumbers[1] = csm::network::ExtractVersionCumulFix( _Version );
+  _VersionNumbers[2] = csm::network::ExtractVersionEfix( _Version );
+}
+
+bool
+csm::network::VersionMsg::Acceptable( const csm::network::VersionStruct &vStruct )
+{
+  unsigned major = csm::network::ExtractVersionMajor( vStruct._Version );
+  bool supported = true;
+  supported &= ( major == _VersionNumbers[ 0 ] );
+
+  unsigned cumul = csm::network::ExtractVersionCumulFix( vStruct._Version );
+  LOG( csmnet, trace ) << "VersionMsg::Acceptable: this: " << _VersionNumbers[0] << "." << _VersionNumbers[1] << "." << _VersionNumbers[2]
+    << " comp: " << major << "." << cumul << "." << csm::network::ExtractVersionEfix( vStruct._Version );
+  supported &= (( cumul >= (unsigned)std::max( (int)_VersionNumbers[ 1 ] - CSM_CUMULATIVE_FIX_MAX_BACK_LEVEL_SUPPORT, 0) ) && ( cumul <= _VersionNumbers[ 1 ] ));
+
+  return supported;
 }

--- a/csmnet/src/CPP/csm_version_msg.cc
+++ b/csmnet/src/CPP/csm_version_msg.cc
@@ -22,7 +22,8 @@
 
 csm::network::VersionMsg* csm::network::VersionMsg::_version = NULL;
 
-
+#define SUPPORTED_CAST_100_COMMIT_PUB "675a5de990b20fcd"
+#define SUPPORTED_CAST_100_COMMIT_IBM "12194309a3636ef6"
 
 unsigned
 csm::network::ExtractVersionMajor( const std::string &vStr )
@@ -120,6 +121,18 @@ csm::network::VersionMsg::Acceptable( const csm::network::VersionStruct &vStruct
   LOG( csmnet, trace ) << "VersionMsg::Acceptable: this: " << _VersionNumbers[0] << "." << _VersionNumbers[1] << "." << _VersionNumbers[2]
     << " comp: " << major << "." << cumul << "." << csm::network::ExtractVersionEfix( vStruct._Version );
   supported &= (( cumul >= (unsigned)std::max( (int)_VersionNumbers[ 1 ] - CSM_CUMULATIVE_FIX_MAX_BACK_LEVEL_SUPPORT, 0) ) && ( cumul <= _VersionNumbers[ 1 ] ));
+
+  /*
+   * This code is to temporarily support the last CAST versions that used the git commit for the version between daemons
+   */
+  if(( supported == false ) && ( major == 0 ) && ( _VersionNumbers[0] == 1 ))
+  {
+    std::string shortVersion = std::string( vStruct._Version, 0, strlen( SUPPORTED_CAST_100_COMMIT_PUB ) );
+    LOG( csmnet, trace ) << "ShortIn: " << shortVersion << " pub: " << SUPPORTED_CAST_100_COMMIT_PUB;
+    int pubv = shortVersion.compare( SUPPORTED_CAST_100_COMMIT_PUB );
+    int ibmv = shortVersion.compare( SUPPORTED_CAST_100_COMMIT_IBM );
+    supported = (( 0 == pubv ) || ( 0 == ibmv ));
+  }
 
   return supported;
 }

--- a/csmnet/src/CPP/csm_version_msg.h
+++ b/csmnet/src/CPP/csm_version_msg.h
@@ -92,7 +92,9 @@ public:
   inline std::string GetVersion() const { return _Version; }
   inline std::string GetHostName() const { return _Hostname; }
   inline uint64_t GetSequence() const { return _Sequence; }
-
+  uint8_t GetVersionMajor() const;
+  uint8_t GetVersionCumulFix() const;
+  uint8_t GetVersionEfix() const;
 
   inline void Next() { ++_Sequence; }
 
@@ -100,6 +102,10 @@ public:
   {
     return ( 0 == _Version.compare( msg._Version ) );
   }
+
+#ifdef CSM_NETWORK_VERSION_MSG_TEST
+  inline void SetVersion( const std::string newVersion ) { _Version = newVersion; }
+#endif
 
 private:
   friend class boost::serialization::access;

--- a/csmnet/src/CPP/csm_version_msg.h
+++ b/csmnet/src/CPP/csm_version_msg.h
@@ -45,13 +45,16 @@ typedef struct {
   }
 } VersionStruct;
 
-
+unsigned ExtractVersionMajor( const std::string &vStr );
+unsigned ExtractVersionCumulFix( const std::string &vStr );
+unsigned ExtractVersionEfix( const std::string &vStr );
 
 class VersionMsg {
   static VersionMsg *_version;
   std::string _Version;
   std::string _Hostname;
   uint64_t _Sequence;
+  unsigned _VersionNumbers[ 3 ];
 
   VersionMsg( const std::string v,
               const std::string h );
@@ -92,9 +95,6 @@ public:
   inline std::string GetVersion() const { return _Version; }
   inline std::string GetHostName() const { return _Hostname; }
   inline uint64_t GetSequence() const { return _Sequence; }
-  uint8_t GetVersionMajor() const;
-  uint8_t GetVersionCumulFix() const;
-  uint8_t GetVersionEfix() const;
 
   inline void Next() { ++_Sequence; }
 
@@ -103,9 +103,13 @@ public:
     return ( 0 == _Version.compare( msg._Version ) );
   }
 
-#ifdef CSM_NETWORK_VERSION_MSG_TEST
-  inline void SetVersion( const std::string newVersion ) { _Version = newVersion; }
+  bool Acceptable( const csm::network::VersionStruct &vStruct );
+
+  // only enable version change/set for unit test
+#ifndef CSM_NETWORK_VERSION_MSG_TEST
+private:
 #endif
+  void SetVersion( const std::string newVersion );
 
 private:
   friend class boost::serialization::access;

--- a/csmnet/src/CPP/reliable_msg.cc
+++ b/csmnet/src/CPP/reliable_msg.cc
@@ -148,7 +148,7 @@ retry:
             << "; seq#: " << versionMsg._Sequence;
 
         // if not ACK, this is the initial version message
-        if(!(aMsgAddr._Msg.GetAck()) && (0 != versionMsg._Version.compare(CSM_VERSION)) )
+        if( !( aMsgAddr._Msg.GetAck() ) && ( csm::network::VersionMsg::Get()->Acceptable( versionMsg ) ))
         {
           LOG(csmnet,warning) << "Version mismatch. LOCAL: " << CSM_VERSION << "; REMOTE: " << aMsgAddr._Msg.GetData();
           aMsgAddr._Msg.SetErr();

--- a/csmnet/src/CPP/reliable_msg.cc
+++ b/csmnet/src/CPP/reliable_msg.cc
@@ -148,7 +148,7 @@ retry:
             << "; seq#: " << versionMsg._Sequence;
 
         // if not ACK, this is the initial version message
-        if( !( aMsgAddr._Msg.GetAck() ) && ( csm::network::VersionMsg::Get()->Acceptable( versionMsg ) ))
+        if( !( aMsgAddr._Msg.GetAck() ) && ( ! csm::network::VersionMsg::Get()->Acceptable( versionMsg ) ))
         {
           LOG(csmnet,warning) << "Version mismatch from peer" << versionMsg._Hostname << ". LOCAL: " << CSM_VERSION << "; REMOTE: " << versionMsg._Version;
           aMsgAddr._Msg.SetErr();

--- a/csmnet/src/CPP/reliable_msg.cc
+++ b/csmnet/src/CPP/reliable_msg.cc
@@ -126,7 +126,7 @@ retry:
           if( aMsgAddr.GetAddr()->GetAddrType() == CSM_NETWORK_TYPE_LOCAL )
           {
             versionMsg._Version = aMsgAddr._Msg.GetData();
-            versionMsg._Hostname = "localhost";
+            versionMsg._Hostname = aMsgAddr.GetAddr()->Dump();
             versionMsg._Sequence = 0;
           }
           else
@@ -137,7 +137,7 @@ retry:
             catch( ... )
             {
               versionMsg._Version = aMsgAddr._Msg.GetData();
-              versionMsg._Hostname = "notavail";
+              versionMsg._Hostname = aMsgAddr.GetAddr()->Dump();
               versionMsg._Sequence = 0;
             }
         }
@@ -150,7 +150,7 @@ retry:
         // if not ACK, this is the initial version message
         if( !( aMsgAddr._Msg.GetAck() ) && ( csm::network::VersionMsg::Get()->Acceptable( versionMsg ) ))
         {
-          LOG(csmnet,warning) << "Version mismatch. LOCAL: " << CSM_VERSION << "; REMOTE: " << aMsgAddr._Msg.GetData();
+          LOG(csmnet,warning) << "Version mismatch from peer" << versionMsg._Hostname << ". LOCAL: " << CSM_VERSION << "; REMOTE: " << versionMsg._Version;
           aMsgAddr._Msg.SetErr();
           aMsgAddr._Msg.SetCommandType( aMsgAddr._Msg.GetReservedID() ); // restore the command type to match what the sender version had
           aMsgAddr._Msg.SetReservedID( 0 );

--- a/csmnet/tests/CMakeLists.txt
+++ b/csmnet/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(CSM_NETWORK_TEST_CPP_SOURCES
   csm_network_header_test.cc
   csm_network_msg_test.cc
   csm_multicast_msg_test.cc
+  csm_version_msg_test.cc
   endpoint_ptp_test.cc
   buffer_state_test.cc
   address_test.cc

--- a/csmnet/tests/csm_version_msg_test.cc
+++ b/csmnet/tests/csm_version_msg_test.cc
@@ -1,0 +1,82 @@
+/*================================================================================
+
+    csmd/src/daemon/tests/csm_version_msg_test.cc
+
+  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+
+================================================================================*/
+
+#include <iostream>
+
+#include "logging.h"
+#include "csmutil/include/csm_test_utils.h"
+
+#define CSM_NETWORK_VERSION_MSG_TEST
+#include "csmutil/include/csm_version.h"
+#include "CPP/csm_version_msg.h"
+
+int main( int argc, char **argv )
+{
+  int ret = 0;
+
+  csm::network::VersionMsg *vmsg = csm::network::VersionMsg::Init("localhost");
+
+  ret += TESTFAIL( vmsg, nullptr );
+  if( ret != 0 )
+  {
+    LOG( csmd, error ) << "Failed to allocate/initialize version msg";
+    return ret;
+  }
+
+  ret += TEST( vmsg->GetHostName().compare( "localhost" ), 0 );
+  ret += TEST( vmsg->GetVersion().compare( CSM_VERSION ), 0 );
+  ret += TEST( vmsg->GetSequence(), 0 );
+
+  vmsg->Get(); // this should not touch any parts
+  ret += TEST( vmsg->GetHostName().compare( "localhost" ), 0 );
+  ret += TEST( vmsg->GetVersion().compare( CSM_VERSION ), 0 );
+  ret += TEST( vmsg->GetSequence(), 0 );
+
+  LOG( csmd, always ) << "Version: M=" << (int)vmsg->GetVersionMajor()
+      << " C=" << (int)vmsg->GetVersionCumulFix()
+      << " E=" << (int)vmsg->GetVersionEfix();
+  ret += TEST( vmsg->GetVersionMajor(), 1 );
+  ret += TEST( vmsg->GetVersionCumulFix(), 0 );
+  ret += TEST( vmsg->GetVersionEfix(), 1 );
+
+  // serialization would bump up the sequence #
+  std::string archive = csm::network::VersionMsg::ConvertToBytes( vmsg );
+  ret += TEST( vmsg->GetHostName().compare( "localhost" ), 0 );
+  ret += TEST( vmsg->GetVersion().compare( CSM_VERSION ), 0 );
+  ret += TEST( vmsg->GetSequence(), 1 );
+
+  LOG( csmd, always ) << "Serialized: " << archive;
+
+  csm::network::VersionStruct vstruct;
+  csm::network::VersionMsg::ConvertToClass( archive, vstruct );
+  ret += TEST( vmsg->GetHostName().compare( vstruct._Hostname ), 0);
+  LOG( csmd, always ) << "vmsg.host: " << vmsg->GetHostName() << " vstruct.host: " << vstruct._Hostname;
+  ret += TEST( vmsg->GetSequence() - 1, vstruct._Sequence );  // the archive contains the previous number
+  LOG( csmd, always ) << "vmsg.seq: " << vmsg->GetSequence() << " vstruct.seq: " << vstruct._Sequence;
+  ret += TEST( vmsg->GetVersion().compare( vstruct._Version ), 0 );
+  LOG( csmd, always ) << "vmsg.ver: " << vmsg->GetVersion() << " vstruct.ver: " << vstruct._Version;
+
+  vmsg->SetVersion( "UNKNOWN" );
+  archive = csm::network::VersionMsg::ConvertToBytes( vmsg );
+  LOG( csmd, always ) << "Serialized New: " << archive;
+
+  ret += TEST( vmsg->GetVersionMajor(), 0 );
+  ret += TEST( vmsg->GetVersionCumulFix(), 0 );
+  ret += TEST( vmsg->GetVersionEfix(), 0 );
+
+  LOG(csmd, info) << "Exit test: " << ret;
+
+  return ret;
+}

--- a/csmutil/include/CMakeLists.txt
+++ b/csmutil/include/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmutil/include/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2017. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -16,7 +16,7 @@ add_executable(csm_buildversion csm_buildversion.cc)
 
 add_custom_command(TARGET csm_buildversion
 	POST_BUILD
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/csm_buildversion ${CMAKE_CURRENT_SOURCE_DIR}/csm_version.h ${GITCOMMITID}
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/csm_buildversion ${CMAKE_CURRENT_SOURCE_DIR}/csm_version.h ${VERSION}
     COMMENT "Generating csm_version"
 )
 


### PR DESCRIPTION
Updated csmd to new version format and introduced back-level support for N-1 cumulative fix versions.
Also added 2 explicit git commits of the cast 1.0.0 branch that could be out there in the wild and would need to be supported.

Current limitation: the introduction of the jsrun command shifted the daemon-internal command IDs by one. Need to work on support for that.