### PR TITLE
Improvement to csm_jsrun_cmd

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationDelete.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationDelete.cc
@@ -25,7 +25,6 @@
 
 #include "csmi_stateful_db/CSMIStatefulDBRecvSend.h"
 
-
 #define STATE_NAME "CSMIAllocationDelete"
 
 // Use this to make changing struct names easier.

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.cc
@@ -33,6 +33,7 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
     jsrunPayload->user_id        = _Data->user_id;
     jsrunPayload->allocation_id  = _Data->allocation_id;
     jsrunPayload->kv_pairs       = strdup(_Data->kv_pairs);
+    jsrunPayload->jsm_path       = strdup(_Data->jsm_path);
     jsrunPayload->hostname       = strdup("");
 
     csm_serialize_struct( csmi_jsrun_cmd_payload_t, jsrunPayload,

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.h
@@ -33,15 +33,17 @@ struct csmi_jsrun_cmd_context_t {
     uint32_t num_nodes;
     int64_t  allocation_id;
     char*    kv_pairs;
+    char*    jsm_path;
     char**   compute_nodes;
 
     csmi_jsrun_cmd_context_t() :
-        user_id(0), num_nodes(0), allocation_id(0), kv_pairs(nullptr),
+        user_id(0), num_nodes(0), allocation_id(0), kv_pairs(nullptr), jsm_path(nullptr),
         compute_nodes(nullptr) {}
 
     ~csmi_jsrun_cmd_context_t()
     {
         if ( kv_pairs ) free(kv_pairs);
+        if ( jsm_path ) free(jsm_path);
 
         if (compute_nodes != nullptr &&  num_nodes > 0 )
         {

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
@@ -127,6 +127,19 @@ public:
      */
     void MigratePid( pid_t pid ) const;
 
+
+    /**
+     * @brief Wait for the pid to appear in the task list of the allocation cgroup*
+     * This function is to be used in conjunction with @ref MigratePid asynchronously.
+     *
+     * @param[in] pid The process id to to scan the tasks file for.
+     * @param[in] sleepAttempts The number of times to wait for the pid write to be a success.
+     * @param[in] sleepTime The time in seconds to wait between pid tests.
+     *
+     * @return True if the pid was successfully migrated.
+     */
+    bool WaitPidMigration(pid_t pid, uint32_t sleepAttempts=3, uint32_t sleepTime=1) const;
+
     /**
      * @brief Performs the configuration step on the cgroups created by @ref SetupCGroups.
      * Restricts memory and number of processors.
@@ -269,7 +282,6 @@ private:
      *  @return True if the file exists, and is of the correct type (dir or not dir).
      */
     bool CheckFile( const char* path, bool isDir = false ) const;
-
 
     /**
      * @brief Builds the core isolation strings for the allocation and system cgroups.

--- a/csmi/include/csm_api_version.h
+++ b/csmi/include/csm_api_version.h
@@ -26,7 +26,7 @@ extern "C" {
 /// TODO ADD MASKING MACROS!
 
 ///< The version id for CSM (uint64_t), this is the version counter for this API.
-#define CSM_VERSION_ID CSM_VERSION_1_0_0
+#define CSM_VERSION_ID CSM_VERSION_1_1_0
 
 ///< The development level.
 #define CSM_DEVELOPMENT CSM_VERSION_ID
@@ -35,6 +35,7 @@ extern "C" {
 #define CSM_MIN_VERSION CSM_VERSION_0_4_1
 
 /// VERSION START
+#define CSM_VERSION_1_1_0 65792
 #define CSM_VERSION_1_0_0 65536
 #define CSM_VERSION_0_4_1 1025
 

--- a/csmi/include/csm_types/struct_defs/wm/csm_jsrun_cmd_input.def
+++ b/csmi/include/csm_types/struct_defs/wm/csm_jsrun_cmd_input.def
@@ -48,13 +48,13 @@
 #endif 
 
 // CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, extra ) /**< comment */
-CSMI_VERSION_START(CSM_DEVELOPMENT)
+CSMI_VERSION_START(CSM_VERSION_1_1_0)
 
 CSMI_STRUCT_MEMBER(int64_t,  allocation_id, BASIC , ,    0, ) /**< The Allocation id for the JSM run. Exported to **CSM_ALLOCATION_ID**. */
 CSMI_STRUCT_MEMBER( char*  ,  kv_pairs     , STRING, , NULL, ) /**< Arguments to the JSM run: Supports alphanumeric, ',' , and  '='. Exported to **CSM_JSM_ARGS**. */
-CSMI_STRUCT_MEMBER(char*  ,  jsm_path     , STRING, , NULL, ) /**< The fully qualified path to the JSM executable, if NULL ignored and the default path is used ( ). */
+CSMI_STRUCT_MEMBER(char*  ,  jsm_path     , STRING, , NULL, ) /**< The fully qualified path to the JSM executable, if NULL ignored and the default path is used ( /opt/ibm/spectrum_mpi/jsm_pmix/bin/jsm ). */
 
-CSMI_VERSION_END(0)
+CSMI_VERSION_END(757d79d8d3d06d33ca5da9c9ca79808d)
 #undef CSMI_VERSION_START
 #undef CSMI_VERSION_END
 #undef CSMI_STRUCT_MEMBER

--- a/csmi/include/csm_types/struct_defs/wm/csm_jsrun_cmd_input.def
+++ b/csmi/include/csm_types/struct_defs/wm/csm_jsrun_cmd_input.def
@@ -48,12 +48,13 @@
 #endif 
 
 // CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, extra ) /**< comment */
-CSMI_VERSION_START(CSM_VERSION_1_0_0)
+CSMI_VERSION_START(CSM_DEVELOPMENT)
 
 CSMI_STRUCT_MEMBER(int64_t,  allocation_id, BASIC , ,    0, ) /**< The Allocation id for the JSM run. Exported to **CSM_ALLOCATION_ID**. */
 CSMI_STRUCT_MEMBER( char*  ,  kv_pairs     , STRING, , NULL, ) /**< Arguments to the JSM run: Supports alphanumeric, ',' , and  '='. Exported to **CSM_JSM_ARGS**. */
+CSMI_STRUCT_MEMBER(char*  ,  jsm_path     , STRING, , NULL, ) /**< The fully qualified path to the JSM executable, if NULL ignored and the default path is used ( ). */
 
-CSMI_VERSION_END(fa4c90b0376401302778efab128ea926)
+CSMI_VERSION_END(0)
 #undef CSMI_VERSION_START
 #undef CSMI_VERSION_END
 #undef CSMI_STRUCT_MEMBER

--- a/csmi/include/csm_types/struct_defs/wm/csmi_jsrun_cmd_payload.def
+++ b/csmi/include/csm_types/struct_defs/wm/csmi_jsrun_cmd_payload.def
@@ -50,14 +50,15 @@
 #endif 
 
 // CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, extra ) /**< comment */
-CSMI_VERSION_START(CSM_DEVELOPMENT)
+CSMI_VERSION_START(CSM_VERSION_1_1_0)
 
 CSMI_STRUCT_MEMBER(int64_t , allocation_id, BASIC , , 0, ) /**< The allocation id for the spawn. */
 CSMI_STRUCT_MEMBER(uint32_t, user_id      , BASIC , , 0, ) /**< The user id for the spawn. */
 CSMI_STRUCT_MEMBER(char*   , kv_pairs     , STRING, , NULL, ) /**< The arguments for JSRUN execution. */
 CSMI_STRUCT_MEMBER(char*   , hostname     , STRING, , NULL, ) /**< The hostname of the node. */
-CSMI_STRUCT_MEMBER(char*  ,  jsm_path     , STRING, , NULL, ) /**< The fully qualified path to the JSM executable, if NULL ignored and default path used. */
-CSMI_VERSION_END(0)
+CSMI_STRUCT_MEMBER(char*  ,  jsm_path     , STRING, , NULL, ) /**< The fully qualified path to the JSM executable, if NULL ignored and the default path is used ( /opt/ibm/spectrum_mpi/jsm_pmix/bin/jsm ). */
+
+CSMI_VERSION_END(d2e78619fffe49da8b81bba29ef28715)
 #undef CSMI_VERSION_START
 #undef CSMI_VERSION_END
 #undef CSMI_STRUCT_MEMBER

--- a/csmi/include/csm_types/struct_defs/wm/csmi_jsrun_cmd_payload.def
+++ b/csmi/include/csm_types/struct_defs/wm/csmi_jsrun_cmd_payload.def
@@ -50,13 +50,14 @@
 #endif 
 
 // CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, extra ) /**< comment */
-CSMI_VERSION_START(CSM_VERSION_1_0_0)
+CSMI_VERSION_START(CSM_DEVELOPMENT)
 
 CSMI_STRUCT_MEMBER(int64_t , allocation_id, BASIC , , 0, ) /**< The allocation id for the spawn. */
 CSMI_STRUCT_MEMBER(uint32_t, user_id      , BASIC , , 0, ) /**< The user id for the spawn. */
 CSMI_STRUCT_MEMBER(char*   , kv_pairs     , STRING, , NULL, ) /**< The arguments for JSRUN execution. */
 CSMI_STRUCT_MEMBER(char*   , hostname     , STRING, , NULL, ) /**< The hostname of the node. */
-CSMI_VERSION_END(81e83239b5e6ca3a521212dafac0831d)
+CSMI_STRUCT_MEMBER(char*  ,  jsm_path     , STRING, , NULL, ) /**< The fully qualified path to the JSM executable, if NULL ignored and default path used. */
+CSMI_VERSION_END(0)
 #undef CSMI_VERSION_START
 #undef CSMI_VERSION_END
 #undef CSMI_STRUCT_MEMBER

--- a/csmi/include/csm_types/struct_defs/wm/type_order.def
+++ b/csmi/include/csm_types/struct_defs/wm/type_order.def
@@ -42,5 +42,5 @@ csmi_allocation_mcast_payload_request.def 12 5db406e1f96595a4dabc8fece25d0381
 csmi_allocation_mcast_payload_response.def 14 a3e0c5482ee192cf0c868e323031ad4f
 csmi_allocation_step_mcast_context.def 6 38b2fb2e0eef7c4d9bd61e47bfa5d54b
 csmi_allocation_step_mcast_payload.def 5 e16f9784d4fcd125ee911554ff9b3a2a
-csmi_jsrun_cmd_payload.def 4 
-csm_jsrun_cmd_input.def 2 
+csmi_jsrun_cmd_payload.def 5 d2e78619fffe49da8b81bba29ef28715
+csm_jsrun_cmd_input.def 3 757d79d8d3d06d33ca5da9c9ca79808d

--- a/csmi/include/csm_types/struct_defs/wm/type_order.def
+++ b/csmi/include/csm_types/struct_defs/wm/type_order.def
@@ -42,5 +42,5 @@ csmi_allocation_mcast_payload_request.def 12 5db406e1f96595a4dabc8fece25d0381
 csmi_allocation_mcast_payload_response.def 14 a3e0c5482ee192cf0c868e323031ad4f
 csmi_allocation_step_mcast_context.def 6 38b2fb2e0eef7c4d9bd61e47bfa5d54b
 csmi_allocation_step_mcast_payload.def 5 e16f9784d4fcd125ee911554ff9b3a2a
-csmi_jsrun_cmd_payload.def 4 81e83239b5e6ca3a521212dafac0831d
-csm_jsrun_cmd_input.def 2 fa4c90b0376401302778efab128ea926
+csmi_jsrun_cmd_payload.def 4 
+csm_jsrun_cmd_input.def 2 

--- a/csmi/include/csmi_type_wm.h
+++ b/csmi/include/csmi_type_wm.h
@@ -690,7 +690,7 @@ typedef struct {
     uint64_t _metadata; /** The number of fields in the struct.*/
     int64_t allocation_id; /**< The Allocation id for the JSM run. Exported to **CSM_ALLOCATION_ID**. */
     char* kv_pairs; /**< Arguments to the JSM run: Supports alphanumeric, ',' , and  '='. Exported to **CSM_JSM_ARGS**. */
-    char* jsm_path; /**< The fully qualified path to the JSM executable, if NULL ignored and default path used. */
+    char* jsm_path; /**< The fully qualified path to the JSM executable, if NULL ignored and the default path is used ( /opt/ibm/spectrum_mpi/jsm_pmix/bin/jsm ). */
 } csm_jsrun_cmd_input_t;
 /** @} */
 

--- a/csmi/include/csmi_type_wm.h
+++ b/csmi/include/csmi_type_wm.h
@@ -690,6 +690,7 @@ typedef struct {
     uint64_t _metadata; /** The number of fields in the struct.*/
     int64_t allocation_id; /**< The Allocation id for the JSM run. Exported to **CSM_ALLOCATION_ID**. */
     char* kv_pairs; /**< Arguments to the JSM run: Supports alphanumeric, ',' , and  '='. Exported to **CSM_JSM_ARGS**. */
+    char* jsm_path; /**< The fully qualified path to the JSM executable, if NULL ignored and default path used. */
 } csm_jsrun_cmd_input_t;
 /** @} */
 

--- a/csmi/include/struct_generator/generate_struct.pl
+++ b/csmi/include/struct_generator/generate_struct.pl
@@ -264,6 +264,7 @@ while ( <$file> ) {
         $output_h_type  = $o_int_h_types;
         $output_h_funct = $o_int_h_types;
         $o_python_classes = "/dev/null";
+        chomp;
     #    $output_c_funct = $o_int_c_map;
     }
     else

--- a/csmi/src/wm/cmd/jsrun_cmd.c
+++ b/csmi/src/wm/cmd/jsrun_cmd.c
@@ -36,6 +36,7 @@ struct option longopts[] = {
 	{"verbose",       required_argument, 0, 'v'},
 	{"allocation_id", required_argument, 0, 'a'},
 	{"kv_pairs",      required_argument, 0, 'k'},
+	{"jsm_path",      required_argument, 0, 'p'},
 	{0,0,0,0}
 };
 
@@ -66,6 +67,7 @@ static void help()
     puts("    -----------------------|---------------------|--------------");
     puts("    -k, --kv_pairs         | \"gpus=0,mem=1024\" | (String) A comma separated list of alphanumeric ");
     puts("                                                   key value pairs (indicated by equals signs).");
+    puts("    -p, --jsm_path         | \"/path/to/jsm\"    | (String) A linux path to the jsm executable.");
     puts("                           |                     | ");
 	puts("");
 	puts("GENERAL OPTIONS:");
@@ -86,11 +88,12 @@ int main(int argc, char *argv[])
     API_PARAMETER_INPUT_TYPE input;    
     input.allocation_id = 0;
     input.kv_pairs      = NULL;
+    input.jsm_path      = NULL;
 
 	csm_api_object   *csm_obj = NULL;
 	char             *arg_check = NULL; ///< Used in verifying the long arg values.
 
-	while ((opt = getopt_long(argc, argv, "hv:a:k:", longopts, &indexptr)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hv:a:k:p:", longopts, &indexptr)) != -1) {
 		switch(opt){
 			case 'h':
                 USAGE();
@@ -108,7 +111,11 @@ int main(int argc, char *argv[])
                 csm_optarg_test( "-k, --kv_pairs", optarg, USAGE );
                 input.kv_pairs = strdup(optarg);
                 break;
-			default:       
+            case 'p':
+                csm_optarg_test( "-p, --jsm_path", optarg, USAGE );
+                input.jsm_path = strdup(optarg);
+                break;
+			default:      
                 csmutil_logging(error, "unknown arg: '%c'\n", opt);
                 USAGE();
                 return CSMERR_INVALID_PARAM;

--- a/csmi/src/wm/include/csmi_wm_type_internal.h
+++ b/csmi/src/wm/include/csmi_wm_type_internal.h
@@ -282,6 +282,7 @@ typedef struct {
     uint32_t user_id; /**< The user id for the spawn. */
     char* kv_pairs; /**< The arguments for JSRUN execution. */
     char* hostname; /**< The hostname of the node. */
+    char* jsm_path; /**< The fully qualified path to the JSM executable, if NULL ignored and default path used. */
 } csmi_jsrun_cmd_payload_t;
  /**  @brief Serializes the supplied structure into a char buffer.
 *

--- a/csmi/src/wm/include/csmi_wm_type_internal.h
+++ b/csmi/src/wm/include/csmi_wm_type_internal.h
@@ -282,7 +282,7 @@ typedef struct {
     uint32_t user_id; /**< The user id for the spawn. */
     char* kv_pairs; /**< The arguments for JSRUN execution. */
     char* hostname; /**< The hostname of the node. */
-    char* jsm_path; /**< The fully qualified path to the JSM executable, if NULL ignored and default path used. */
+    char* jsm_path; /**< The fully qualified path to the JSM executable, if NULL ignored and the default path is used ( /opt/ibm/spectrum_mpi/jsm_pmix/bin/jsm ). */
 } csmi_jsrun_cmd_payload_t;
  /**  @brief Serializes the supplied structure into a char buffer.
 *

--- a/csmi/src/wm/src/csmi_wm_internal.c
+++ b/csmi/src/wm/src/csmi_wm_internal.c
@@ -841,10 +841,10 @@ const csmi_struct_mapping_t map_csmi_allocation_step_mcast_payload_t= {
 
 const csmi_struct_node_t csmi_jsrun_cmd_payload_tree[7] = {{"allocation_id",offsetof(csmi_jsrun_cmd_payload_t,allocation_id),0,NULL,0x99d3da77,40},
 {"user_id",offsetof(csmi_jsrun_cmd_payload_t,user_id),0,NULL,0x45c27210,24},
+{"jsm_path",offsetof(csmi_jsrun_cmd_payload_t,jsm_path),0,NULL,0xe89734bb,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"kv_pairs",offsetof(csmi_jsrun_cmd_payload_t,kv_pairs),0,NULL,0x9c4b0fc4,4},
-{NULL,0,0,NULL,0,0},
-{NULL,0,0,NULL,0,0},
-{NULL,0,0,NULL,0,0},
 {"hostname",offsetof(csmi_jsrun_cmd_payload_t,hostname),0,NULL,0xeba474a4,4}}
 ;
 
@@ -858,9 +858,9 @@ const csmi_struct_mapping_t map_csmi_jsrun_cmd_payload_t= {
     cast_csmi_jsrun_cmd_payload_t
 };
 
-const csmi_struct_node_t csm_jsrun_cmd_input_tree[3] = {{"allocation_id",offsetof(csm_jsrun_cmd_input_t,allocation_id),0,NULL,0x99d3da77,40},
-{NULL,0,0,NULL,0,0},
-{"kv_pairs",offsetof(csm_jsrun_cmd_input_t,kv_pairs),0,NULL,0x9c4b0fc4,4}}
+const csmi_struct_node_t csm_jsrun_cmd_input_tree[3] = {{"kv_pairs",offsetof(csm_jsrun_cmd_input_t,kv_pairs),0,NULL,0x9c4b0fc4,4},
+{"allocation_id",offsetof(csm_jsrun_cmd_input_t,allocation_id),0,NULL,0x99d3da77,40},
+{"jsm_path",offsetof(csm_jsrun_cmd_input_t,jsm_path),0,NULL,0xe89734bb,4}}
 ;
 
 void* cast_csm_jsrun_cmd_input_t(void* ptr,size_t index) { 

--- a/csmi/src/wm/src/csmi_wm_python.cc
+++ b/csmi/src/wm/src/csmi_wm_python.cc
@@ -104,7 +104,6 @@ tuple wrap_csm_allocation_query_details(
     return make_tuple(return_code, oid, *output);
 }
 
-
 tuple wrap_csm_allocation_update_history(
     csm_allocation_update_history_input_t input)
 {
@@ -302,6 +301,21 @@ tuple wrap_csm_cgroup_login(
     return make_tuple(return_code, oid);
 }
 
+tuple wrap_csm_jsrun_cmd(
+    csm_jsrun_cmd_input_t input)
+{
+    // Always sets the metadata.
+    input._metadata=CSM_VERSION_ID;
+
+    // Output objs
+    csm_api_object * updated_handle;
+
+    // Run the API
+    int return_code = csm_jsrun_cmd( (csm_api_object**)&updated_handle, &input );
+    int64_t oid = CSMIObj::GetInstance().StoreCSMObj(updated_handle);
+    
+    return make_tuple(return_code, oid);
+}
 
 //BOOST_PYTHON_MODULE(wm_structs)
 BOOST_PYTHON_MODULE(lib_csm_wm_py)
@@ -382,6 +396,11 @@ BOOST_PYTHON_MODULE(lib_csm_wm_py)
     def("cgroup_login",
         wrap_csm_cgroup_login,
         CSM_GEN_DOCSTRING("Mechanism to move a user into a cgroup.",""));
+
+
+    def("jsrun_cmd",
+        wrap_csm_jsrun_cmd,
+        CSM_GEN_DOCSTRING("Executes a jsrun command as a remote user.",""));
 
     // STRUCTS_BEGIN
     enum_<csmi_state_t>("csmi_state_t")
@@ -681,6 +700,7 @@ BOOST_PYTHON_MODULE(lib_csm_wm_py)
 
     class_<csm_jsrun_cmd_input_t,csm_jsrun_cmd_input_t*>("jsrun_cmd_input_t")
 		.add_property("allocation_id", &csm_jsrun_cmd_input_t::allocation_id,&csm_jsrun_cmd_input_t::allocation_id," The Allocation id for the JSM run. Exported to **CSM_ALLOCATION_ID**. ")
-		STRING_PROPERTY(csm_jsrun_cmd_input_t, char*, kv_pairs, , NULL, );
+		STRING_PROPERTY(csm_jsrun_cmd_input_t, char*, kv_pairs, , NULL, )
+		STRING_PROPERTY(csm_jsrun_cmd_input_t, char*, jsm_path, , NULL, );
 
 };


### PR DESCRIPTION
- Added a new field to the input struct *jsm_path*.
- Implemented the allocation cgroup jsm placement.
- Bumped the CSM API version number to *1.1.0*