### PR TITLE
review/cleanup of internal API commands

### DIFF
--- a/csmd/src/daemon/tests/csm_daemon_echo_test.cc
+++ b/csmd/src/daemon/tests/csm_daemon_echo_test.cc
@@ -125,7 +125,7 @@ int client( void )
     {
       csm::network::Message msg;
       // will return all the nodes in the "nodes" db table without supplying arugments
-      bool hdrvalid = msg.Init(CSM_TEST_node_attributes_query,
+      bool hdrvalid = msg.Init(CSM_CMD_node_attributes_query,
                                0,
                                CSM_PRIORITY_DEFAULT,
                                9876543,

--- a/csmi/src/common/include/csm_cmds_internal_def.h
+++ b/csmi/src/common/include/csm_cmds_internal_def.h
@@ -14,25 +14,16 @@
 ================================================================================*/
 //Internal CMDs
 #define CSM_FIRST_INTERNAL CSM_CTRL_reconfig
-cmd(CSM_CMD_API_DIVIDE) // Divider for filtration
 
-cmd(CSM_CTRL_reconfig)  // 38
+cmd(CSM_CTRL_reconfig) // (201)
 cmd(CSM_CTRL_cmd)
-//below is for internal testing purpose
-cmd(CSM_TEST_node_attributes_query)
-// MTC for multi-cast testing
-cmd(CSM_TEST_MTC)
-cmd(CSM_infrastructure_test)  // 42
-cmd(CSM_environmental_data)
-cmd(CSM_error_inject)
-cmd(CSM_DB_UNKNOWN)
-cmd(CSM_DAEMON_UNKNOWN)
-// for CSMI testing
-cmd(CSM_CMD_ECHO)
-// for heart beat msgs
-cmd(CSM_CMD_HEARTBEAT)    // 47
-cmd(CSM_CMD_STATUS)
-cmd(CSM_CMD_CONNECTION_CTRL)
-cmd(CSM_CMD_NODESET_UPDATE)
-// use CSM_CMD_ERROR when the CommandType is unknown
-cmd(CSM_CMD_ERROR)
+cmd(CSM_infrastructure_test)
+cmd(CSM_TEST_MTC) // MTC for multi-cast testing
+cmd(CSM_error_inject) // (205) injecting errors into the infrastructure for testing
+cmd(CSM_environmental_data) // env data from compute to agg
+cmd(CSM_CMD_ECHO)  // for testing of comm and handling
+cmd(CSM_CMD_HEARTBEAT) // keep-alive messages between peers
+cmd(CSM_CMD_STATUS) // connection creation/teardown signalling
+cmd(CSM_CMD_CONNECTION_CTRL) // (210) connection status changes between compute and agg
+cmd(CSM_CMD_NODESET_UPDATE) // compute node set update messages between agg and master
+cmd(CSM_CMD_ERROR) // use CSM_CMD_ERROR when the CommandType is unknown

--- a/csmi/src/common/tests/test_csmi_corner_cases.c
+++ b/csmi/src/common/tests/test_csmi_corner_cases.c
@@ -25,8 +25,7 @@
 
 int csmi_undef_hdl(csm_api_object **csm_obj)
 {
-
-  csmi_cmd_t ExpectedCmd = CSM_DB_UNKNOWN;
+  csmi_cmd_t ExpectedCmd = CSM_error_inject;
   int errcode;
   uint32_t recvDataLen=0;
   char *recvData=NULL;
@@ -45,7 +44,7 @@ int csmi_undef_hdl(csm_api_object **csm_obj)
 int csmi_undef_cmd(csm_api_object **csm_obj)
 {
 
-  csmi_cmd_t ExpectedCmd = CSM_DAEMON_UNKNOWN;
+  csmi_cmd_t ExpectedCmd = CSM_error_inject;
   int errcode;
   uint32_t recvDataLen=0;
   char *recvData=NULL;

--- a/csmnet/src/CPP/endpoint_unix.cc
+++ b/csmnet/src/CPP/endpoint_unix.cc
@@ -653,7 +653,7 @@ csm::network::EndpointUnix::RecvFrom( csm::network::MessageAndAddress &aMsgAddr 
     throw csm::network::ExceptionRecv( "Data Length Error", EBADMSG );
 
   // FIXME Should this always print? 
-  if ( aMsgAddr._Msg.GetCommandType() < CSM_CMD_API_DIVIDE  )
+  if ( aMsgAddr._Msg.GetCommandType() < CSM_CMD_MAX_REGULAR  )
   {
       LOG (csmapi,info)              << cmd_to_string( aMsgAddr._Msg.GetCommandType())
           << "["                     << aMsgAddr._Msg.GetReservedID() 


### PR DESCRIPTION
Since we're reworking the API enums to be stable in the future and that rips up the enum anyway, I think, it's the right time to clean up the internal API section and remove unused/old stuff.
