### PR TITLE
Review/api checks

### DIFF
--- a/csmd/src/daemon/include/csm_api_acl.h
+++ b/csmd/src/daemon/include/csm_api_acl.h
@@ -173,7 +173,7 @@ private:
             if (!api.empty())
             {
               csmi_cmd_t cmd = csmi_cmd_get(api.c_str());
-              if (cmd < CSM_CMD_MAX)
+              if( csmi_cmd_is_valid( cmd ) )
               {
                 _api_to_grp_map[cmd] = grp;
                 CSMLOG( csmd, debug ) << "API=" << api << " GROUP=" << key;

--- a/csmd/src/daemon/include/csm_api_config.h
+++ b/csmd/src/daemon/include/csm_api_config.h
@@ -73,7 +73,7 @@ private:
         boost::algorithm::to_lower(key);
 
         csmi_cmd_t cmd = csmi_cmd_get( key.c_str() );
-        if (cmd < CSM_CMD_MAX)
+        if( csmi_cmd_is_valid( cmd ) )
         {
           int timeout = std::stoi( list.second.data() );
           if( timeout >= CSM_RECV_TIMEOUT_MIN )
@@ -190,6 +190,7 @@ public:
     _timeouts_serialized.clear();
     for( int n=0; n<CSM_CMD_INVALID; ++n )
     {
+      if( ! csmi_cmd_is_valid( n ) ) continue;
       int timeout = csm_get_timeout(n) / 1000;
       if(( timeout >= CSM_RECV_TIMEOUT_MIN ) && ( timeout != CSM_RECV_TIMEOUT_SECONDS ))
       {

--- a/csmd/src/daemon/src/csm_daemon_core.cc
+++ b/csmd/src/daemon/src/csm_daemon_core.cc
@@ -175,8 +175,7 @@ csm::daemon::CoreGeneric::GetEventHandler(const csm::daemon::CoreEvent &aEvent)
     csm::network::MessageAndAddress content = ev->GetContent();
     cmd = content._Msg.GetCommandType();
 
-    LOG(csmd, debug) << "CSM Command Type: " <<
-        ( cmd < CSM_CMD_MAX ? csmi_cmds_t_strs[cmd] : "NOT SET" ) ;
+    LOG(csmd, debug) << "CSM Command Type: " << csmi_cmds_to_str( cmd );
   }
   // if cmd is not CSM_CMD_MAX at this point, it means aEvent is a NetworkEvent.
 

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_base.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_base.h
@@ -85,7 +85,7 @@ protected:
   CSMI_BASE(csmi_cmd_t cmd, csm::daemon::HandlerOptions& options)
   :_cmdType(cmd), _handlerOptions(options), _newRequestCount(0)
   {    
-    if (cmd >= CSM_CMD_MAX) {
+    if ( ! csmi_cmd_is_valid( cmd ) ) {
       // bring down the daemon in this fatal error
       LOG(csmapi, error) << "CSMI_BASE(): not a valid csmi cmd";
       exit(-1);

--- a/csmi/src/common/src/csmi_serialization.c
+++ b/csmi/src/common/src/csmi_serialization.c
@@ -34,7 +34,7 @@ static cmd_serialization_t CSMI_MAPPING[] = {
 
 void csmi_callback_set(csmi_cmd_t cmd, packPrototype packFunc, unpackPrototype unpackFunc)
 {
-  if (cmd < CSM_CMD_MAX) {
+  if (csmi_cmd_is_valid( cmd )) {
     CSMI_MAPPING[cmd].packFunc = packFunc;
     CSMI_MAPPING[cmd].unpackFunc = unpackFunc;
   }
@@ -42,7 +42,7 @@ void csmi_callback_set(csmi_cmd_t cmd, packPrototype packFunc, unpackPrototype u
 
 void csmi_arg_callback_set(csmi_cmd_t cmd, packPrototype packFunc, unpackPrototype unpackFunc)
 {
-  if (cmd < CSM_CMD_MAX) {
+  if (csmi_cmd_is_valid( cmd )) {
     CSMI_MAPPING[cmd].argPackFunc = packFunc;
     CSMI_MAPPING[cmd].argUnpackFunc = unpackFunc;
   }
@@ -50,31 +50,31 @@ void csmi_arg_callback_set(csmi_cmd_t cmd, packPrototype packFunc, unpackPrototy
 
 packPrototype csmi_pack_get(csmi_cmd_t cmd)
 {
-  if (cmd < CSM_CMD_MAX) return CSMI_MAPPING[cmd].packFunc;
+  if (csmi_cmd_is_valid( cmd )) return CSMI_MAPPING[cmd].packFunc;
   else return NULL;
 }
 
 unpackPrototype csmi_unpack_get(csmi_cmd_t cmd)
 {
-  if (cmd < CSM_CMD_MAX) return CSMI_MAPPING[cmd].unpackFunc;
+  if (csmi_cmd_is_valid( cmd )) return CSMI_MAPPING[cmd].unpackFunc;
   else return NULL;
 }
 
 packPrototype csmi_argpack_get(csmi_cmd_t cmd)
 {
-  if (cmd < CSM_CMD_MAX) return CSMI_MAPPING[cmd].argPackFunc;
+  if (csmi_cmd_is_valid( cmd )) return CSMI_MAPPING[cmd].argPackFunc;
   else return NULL;
 }
 
 unpackPrototype csmi_argunpack_get(csmi_cmd_t cmd)
 {
-  if (cmd < CSM_CMD_MAX) return CSMI_MAPPING[cmd].argUnpackFunc;
+  if (csmi_cmd_is_valid( cmd )) return CSMI_MAPPING[cmd].argUnpackFunc;
   else return NULL;
 }
 
 const char *csmi_cmdname_get(csmi_cmd_t cmd)
 {
-  if (cmd < CSM_CMD_MAX) return CSMI_MAPPING[cmd].cmdName;
+  if (csmi_cmd_is_valid( cmd )) return CSMI_MAPPING[cmd].cmdName;
   else return NULL;
 }
 
@@ -82,31 +82,34 @@ csmi_cmd_t csmi_cmd_get(const char *name)
 {
   int ret;
   for (ret = 0; ret < CSM_CMD_MAX; ret++)
+  {
+    if( ! csmi_cmd_is_valid( ret ) ) continue;
     if ( strcasecmp(CSMI_MAPPING[(csmi_cmd_t) ret].cmdName, name) == 0 ) return (csmi_cmd_t) ret;
+  }
     
   return CSM_CMD_MAX;
 }
 
 const char *csmi_classname_get(csmi_cmd_t cmd)
 {
-  if (cmd < CSM_CMD_MAX) return CSMI_MAPPING[cmd].className;
+  if (csmi_cmd_is_valid( cmd )) return CSMI_MAPPING[cmd].className;
   else return NULL;
 }
 
 void csmi_classname_set(csmi_cmd_t cmd, const char *name) {
-  if (cmd < CSM_CMD_MAX) {
+  if (csmi_cmd_is_valid( cmd )) {
     CSMI_MAPPING[cmd].className = name;
   }
 }
 
 const char *csmi_dbtabname_get(csmi_cmd_t cmd)
 {
-  if (cmd < CSM_CMD_MAX) return CSMI_MAPPING[cmd].dbTabName;
+  if (csmi_cmd_is_valid( cmd )) return CSMI_MAPPING[cmd].dbTabName;
   else return NULL;
 }
 
 void csmi_dbtabname_set(csmi_cmd_t cmd, const char *name) {
-  if (cmd < CSM_CMD_MAX) {
+  if (csmi_cmd_is_valid( cmd )) {
     CSMI_MAPPING[cmd].dbTabName = name;
   }
 }

--- a/csmnet/include/csm_timing.h
+++ b/csmnet/include/csm_timing.h
@@ -95,7 +95,7 @@ extern int csmi_cmd_timeouts[];
 static inline
 int csm_get_timeout( int api_id )
 {
-  if( api_id % CSM_CMD_INVALID == api_id )
+  if( csmi_cmd_is_valid( api_id ) )
     return csmi_cmd_timeouts[ api_id ] * 1000;
   else
     return CSM_RECV_TIMEOUT_MILLISECONDS;

--- a/csmnet/src/C/csm_network_msg_c.h
+++ b/csmnet/src/C/csm_network_msg_c.h
@@ -134,7 +134,7 @@ int csm_header_validate( csm_network_header_t const *aHeader )
   if( ! aHeader ) return 0;
   valid &= (aHeader->_ProtocolVersion == CSM_NETWORK_PROTOCOL_VERSION);
   valid &= (aHeader->_Priority < CSM_NETWORK_PRIORITY_INVALID);
-  valid &= (aHeader->_CommandType < CSM_CMD_MAX);
+  valid &= ( csmi_cmd_is_valid( aHeader->_CommandType ));
 //  valid &= (aHeader->_MessageID != 0); // messageID = 0 causes the network stack to generate a new one
   valid &= (aHeader->_Flags == ( aHeader->_Flags & CSM_HEADER_FLAGS_MASK ) );
 

--- a/csmnet/tests/csm_network_msg_test.cc
+++ b/csmnet/tests/csm_network_msg_test.cc
@@ -163,7 +163,7 @@ int main( int argc, char **argv )
     if( ! tdata )
       datalen = 0;
 
-    bool expbool = (cmd < CSM_CMD_UNDEFINED ) || ( cmd >= CSM_CMD_MAX ) ||
+    bool expbool = ( ! csmi_cmd_is_valid( cmd ) ) ||
         ( prio > CSM_NETWORK_MAX_PRIORITY) ||
         ( uid == CSM_CREDENTIAL_ID_UNKNOWN ) || ( gid == CSM_CREDENTIAL_ID_UNKNOWN ) ||
         (flags != ( flags & CSM_HEADER_FLAGS_MASK ) );


### PR DESCRIPTION
With the introduction of reserved API cmd IDs, a lot of simple checks like cmd < CSM_CMD_MAX would have the potential to allow processing of the reserved IDs. To prevent this, I tried to replace this and similar checks with the new macro csmi_cmd_is_valid() to improve the filtering of invalid commands.

@mew2057 Please especially review the second commit 743faf8 because that touches your area of API serialization to make sure I didn't do anything stupid there.