### PR TITLE
fixing uninitialized chars in version string output

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test.h
@@ -271,7 +271,10 @@ public:
     CSMI_BASE::ConvertToClass<HealthCheckData>( in_out_msg.GetData(), data );
 
     std::string hostname = csm::daemon::Configuration::Instance()->GetHostname();    
-    data._local = HealthNodeInfo( CSMDaemonRole_to_string( _handlerOptions.GetRole()), hostname, std::string(CSM_VERSION, 7), 0, true );
+    data._local = HealthNodeInfo( CSMDaemonRole_to_string( _handlerOptions.GetRole()),
+                                  hostname,
+                                  std::string(CSM_VERSION, 0, strnlen( CSM_VERSION, 10 )),
+                                  0, true );
     data._local.SetDaemonID( csm::daemon::Configuration::Instance()->GetDaemonState()->GetDaemonID() );
     
     in_out_msg.SetData( CSMI_BASE::ConvertToBytes<HealthCheckData>(data) );

--- a/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test_agent.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test_agent.cc
@@ -77,7 +77,7 @@ void CSM_INFRASTRUCTURE_TEST_AGENT::Process( const csm::daemon::CoreEvent &aEven
     }
 
     ComputeInfo data = ComputeInfo( config->GetHostname(),
-                                    std::string(CSM_VERSION, 7) );
+                                    std::string(CSM_VERSION, 0, strnlen( CSM_VERSION, 10 )) );
     data.SetConnectionType( conn_type );
     data.SetDaemonID( GetDaemonState()->GetDaemonID() );
     csm::network::Message msg = GetNetworkMessage(aEvent);

--- a/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test_master.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test_master.cc
@@ -80,7 +80,7 @@ void CSM_INFRASTRUCTURE_TEST_MASTER::Process( const csm::daemon::CoreEvent &aEve
       data = CreateHCDAndSetLDaemon(msg);
       data._master = HealthNodeInfo( CSMDaemonRole_to_string( CSM_DAEMON_ROLE_MASTER ),
                                      csm::daemon::Configuration::Instance()->GetHostname(),
-                                     std::string(CSM_VERSION, 7),
+                                     std::string(CSM_VERSION, 0, strnlen( CSM_VERSION, 10 )),
                                      0, true );
       data._master.SetDaemonID( csm::daemon::Configuration::Instance()->GetDaemonState()->GetDaemonID() );
       

--- a/csmnet/src/CPP/reliable_msg.cc
+++ b/csmnet/src/CPP/reliable_msg.cc
@@ -155,7 +155,7 @@ retry:
           aMsgAddr._Msg.SetCommandType( aMsgAddr._Msg.GetReservedID() ); // restore the command type to match what the sender version had
           aMsgAddr._Msg.SetReservedID( 0 );
           KeepErrorFlag = true;
-          aMsgAddr._Msg.SetData( std::string("VERSION MISMATCH. Required: ") + std::string(CSM_VERSION, 0, 7));
+          aMsgAddr._Msg.SetData( std::string("VERSION MISMATCH. Required: ") + std::string(CSM_VERSION, 0, strnlen( CSM_VERSION, 10 )));
           event_type = csm::network::NET_CTL_DISCONNECT;
           disconnect = true;
         }


### PR DESCRIPTION
In earlier versions, we always shortened the git commit id when we printed the version. Now, we have version numbers where the length might be shorter than the existing forced limit. That causes trailing 0-bytes or maybe even uninitialized chars in the output of e.g. the health check or the daemon log.
This set of patches will limit the length to 10 chars but also never enforces the 10 if the version string is shorter.

@pdlun92 thanks for reporting this. Your check of the health-check output should no longer see the warning about binary file.