### PR TITLE
Add a flag for csm_cgroup_login to migrate pids on invocation or not.

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMICGROUPLogin.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMICGROUPLogin.cc
@@ -73,8 +73,13 @@ bool CGLoginInitState::HandleNetworkMessage(
             {
                 errCode = CSMI_SUCCESS;
 
-                std::string alloc = line.substr(delim +1);
-                migrate_pid(state_args->pid, strtoll( alloc.c_str(), nullptr, 10 ));
+                if(state_args->migrate_pid)
+                {
+                    std::string alloc = line.substr(delim +1);
+                    migrate_pid(state_args->pid, strtoll( alloc.c_str(), nullptr, 10 ));
+                }
+                
+                break; // once user has been located in active list, we are done.
             }
         }
     }

--- a/csmi/include/csm_types/struct_defs/wm/csm_cgroup_login_input.def
+++ b/csmi/include/csm_types/struct_defs/wm/csm_cgroup_login_input.def
@@ -54,8 +54,12 @@ CSMI_VERSION_START(CSM_VERSION_0_4_1)
 CSMI_STRUCT_MEMBER(int64_t, allocation_id,  BASIC, ,   -1, ) /**< Allocation ID to prefer (rejected if >0 and not found in daemon). */
 CSMI_STRUCT_MEMBER(pid_t,             pid,  BASIC, ,    0, ) /**< The process id to push to the allocation cgroup. */
 CSMI_STRUCT_MEMBER(char*,       user_name, STRING, , NULL, ) /**< User name for logging in. */
-
 CSMI_VERSION_END(7abc0fd516f773957ae20e5d59fa90e2)
+
+CSMI_VERSION_START(CSM_DEVELOPMENT)
+CSMI_STRUCT_MEMBER(char,      migrate_pid,  BASIC, ,    0, ) /**< Flag to migrate pid in to cgroup if true. */
+CSMI_VERSION_END(0)
+
 #undef CSMI_VERSION_START
 #undef CSMI_VERSION_END
 #undef CSMI_STRUCT_MEMBER

--- a/csmi/include/csmi_type_wm.h
+++ b/csmi/include/csmi_type_wm.h
@@ -681,6 +681,7 @@ typedef struct {
     int64_t allocation_id; /**< Allocation ID to prefer (rejected if >0 and not found in daemon). */
     pid_t pid; /**< The process id to push to the allocation cgroup. */
     char* user_name; /**< User name for logging in. */
+    char migrate_pid; /**< Flag to migrate pid in to cgroup if true. */
 } csm_cgroup_login_input_t;
 /**
  * @brief An input wrapper for @ref csm_jsrun_cmd.

--- a/csmi/src/wm/src/csmi_wm_internal.c
+++ b/csmi/src/wm/src/csmi_wm_internal.c
@@ -669,9 +669,12 @@ const csmi_struct_mapping_t map_csm_allocation_delete_input_t= {
     cast_csm_allocation_delete_input_t
 };
 
-const csmi_struct_node_t csm_cgroup_login_input_tree[3] = {{"allocation_id",offsetof(csm_cgroup_login_input_t,allocation_id),0,NULL,0x99d3da77,40},
+const csmi_struct_node_t csm_cgroup_login_input_tree[6] = {{"allocation_id",offsetof(csm_cgroup_login_input_t,allocation_id),0,NULL,0x99d3da77,40},
 {"pid",offsetof(csm_cgroup_login_input_t,pid),0,NULL,0xb889d42,64},
-{"user_name",offsetof(csm_cgroup_login_input_t,user_name),0,NULL,0xc029f5a4,4}}
+{"user_name",offsetof(csm_cgroup_login_input_t,user_name),0,NULL,0xc029f5a4,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{"migrate_pid",offsetof(csm_cgroup_login_input_t,migrate_pid),0,NULL,0xb05bda0a,68}}
 ;
 
 void* cast_csm_cgroup_login_input_t(void* ptr,size_t index) { 
@@ -679,7 +682,7 @@ void* cast_csm_cgroup_login_input_t(void* ptr,size_t index) {
     return ptr_cast ? ptr_cast[index] : NULL;
 };
 const csmi_struct_mapping_t map_csm_cgroup_login_input_t= {
-    3,
+    6,
     csm_cgroup_login_input_tree,
     cast_csm_cgroup_login_input_t
 };

--- a/csmi/src/wm/src/csmi_wm_python.cc
+++ b/csmi/src/wm/src/csmi_wm_python.cc
@@ -677,7 +677,8 @@ BOOST_PYTHON_MODULE(lib_csm_wm_py)
     class_<csm_cgroup_login_input_t,csm_cgroup_login_input_t*>("cgroup_login_input_t")
 		.add_property("allocation_id", &csm_cgroup_login_input_t::allocation_id,&csm_cgroup_login_input_t::allocation_id," Allocation ID to prefer (rejected if >0 and not found in daemon). ")
 		.add_property("pid", &csm_cgroup_login_input_t::pid,&csm_cgroup_login_input_t::pid," The process id to push to the allocation cgroup. ")
-		STRING_PROPERTY(csm_cgroup_login_input_t, char*, user_name, , NULL, );
+		STRING_PROPERTY(csm_cgroup_login_input_t, char*, user_name, , NULL, )
+		.add_property("migrate_pid", &csm_cgroup_login_input_t::migrate_pid,&csm_cgroup_login_input_t::migrate_pid," Flag to migrate pid in to cgroup if true. ");
 
     class_<csm_jsrun_cmd_input_t,csm_jsrun_cmd_input_t*>("jsrun_cmd_input_t")
 		.add_property("allocation_id", &csm_jsrun_cmd_input_t::allocation_id,&csm_jsrun_cmd_input_t::allocation_id," The Allocation id for the JSM run. Exported to **CSM_ALLOCATION_ID**. ")


### PR DESCRIPTION
Add 'account' function to pam module where we do not migrate pids, but
do return success/fail.
Modify 'session' function to migrate pids, but always return pam_success
Removed printing of 'permission denied' as it is not appropriate to
print in the middle of the pam stack.

wrap struct changes for migrate_pid flag in CSM_DEVELOPMENT version macros
commit struct changes generated by the regenerate_headers.sh script

Fixes issue #15 .

This is not yet ready for merge.  Current issues are:
1) This requires pull request #24 in order to build, but with that merged in build has been confirmed.
2) The function is untested as I don't have an environment running 4/27 software to test in yet.  Hopefully later this week.
3) API version is still using CSM_DEVELOPMENT for addition to struct.  I'm not sure what the process is for the project to rev the API version, but that will need to be handled before this can be released.
4) Our CCLA is still in approval process by DoE.