### PR TITLE
GCC Warning Cleanup (-Wextra)

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationDelete.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationDelete.cc
@@ -376,10 +376,13 @@ csm::db::DBReqContent* CSMIAllocationDelete_Master::DeleteRowStatement(
             "$9::bigint[],$10::bigint[],$11::bigint[],$12::bigint[]);";
 
         dbReq = new csm::db::DBReqContent( stmt, paramCount );
+
+
+        csmi_state_t error_code = (csmi_cmd_err_t) ctx->GetErrorCode() == CSMI_SUCCESS ? 
+            CSM_COMPLETE : CSM_FAILED;
         
         dbReq->AddNumericParam<int64_t>(allocation->allocation_id);
-        dbReq->AddTextParam(csm_get_string_from_enum(csmi_state_t,
-            ctx->GetErrorCode() == CSMI_SUCCESS ? CSM_COMPLETE : CSM_FAILED ));
+        dbReq->AddTextParam(csm_get_string_from_enum(csmi_state_t, error_code));
         dbReq->AddTextArrayParam(allocation->compute_nodes, allocation->num_nodes);
         dbReq->AddNumericArrayParam<int64_t>(allocation->ib_rx,      allocation->num_nodes);
         dbReq->AddNumericArrayParam<int64_t>(allocation->ib_tx,      allocation->num_nodes);

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQuery.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQuery.cc
@@ -186,6 +186,7 @@ void CSMIAllocationStepQuery::CreateStepStruct(
 	s->num_gpus             = strtol (fields->data[15], nullptr, 10);
 	s->projected_memory     = strtol (fields->data[16], nullptr, 10);
 	s->num_nodes            = strtol (fields->data[17], nullptr, 10);
+    if( s->num_nodes < 0 ) s->num_nodes = 0; // Zero for serialization.
 	s->num_processors       = strtol (fields->data[18], nullptr, 10);
 	s->num_tasks            = strtol (fields->data[19], nullptr, 10);
 	s->status               = (csmi_step_status_t)csm_get_enum_from_string(csmi_step_status_t, fields->data[20]);

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryActiveAll.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryActiveAll.cc
@@ -134,12 +134,13 @@ void CSMIAllocationStepQueryActiveAll::CreateStepStruct(
     s->argument             = strdup(fields->data[6]);
     s->environment_variable = strdup(fields->data[7]);
     s->num_nodes            = atol(fields->data[8 ]);
+    if( s->num_nodes < 0 ) s->num_nodes = 0; // Zero for serialization.
     s->num_processors       = atol(fields->data[9 ]);
     s->num_gpus             = atol(fields->data[10]);
     s->projected_memory     = atol(fields->data[11]);
     s->num_tasks            = atol(fields->data[12]);
     s->user_flags         = strdup(fields->data[13]);
-                                                
+
     *step = s; 
 
     LOG( csmapi, debug ) << STATE_NAME ":CreateStepStruct: Exit";

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -412,6 +412,7 @@ void CSMIAllocationStepQueryDetails::CreateStepStruct(
 	s->num_gpus             = strtol(fields->data[15], nullptr, 10);
 	s->projected_memory     = strtol(fields->data[16], nullptr, 10);
 	s->num_nodes            = strtol(fields->data[17], nullptr, 10);
+    if ( s->num_nodes < 0 ) s->num_nodes = 0; // Zero for serialization's sake.
 	s->num_processors       = strtol(fields->data[18], nullptr, 10);
 	s->num_tasks            = strtol(fields->data[19], nullptr, 10);
 	s->status               = (csmi_step_status_t)csm_get_enum_from_string(csmi_step_status_t, fields->data[20]);

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.cc
@@ -202,7 +202,7 @@ bool GetGPFSUsage(int64_t &gpfs_read, int64_t &gpfs_write)
     return success;
 }
 
-bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t gpu_energy)
+bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t& gpu_energy)
 {
     // Generate the value map for the query.
     std::unordered_map<std::string, int64_t> valueMap = {

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.h
@@ -61,7 +61,7 @@ bool GetGPFSUsage(int64_t &gpfs_read, int64_t &gpfs_write);
  * @return True  - The data was read successfully.
  * @return False - The data could not be read.
  */
-bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t gpu_energy );
+bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t& gpu_energy );
 
 /** @brief Retrieves the power capacity of the node using the OCC /sys/fs utility.
  * This function queries the OCC file to determine the power cap.

--- a/csmi/src/bb/cmd/bb_lv_query.c
+++ b/csmi/src/bb/cmd/bb_lv_query.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	

--- a/csmi/src/bb/cmd/bb_vg_create.c
+++ b/csmi/src/bb/cmd/bb_vg_create.c
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/bb/cmd/bb_vg_delete.c
+++ b/csmi/src/bb/cmd/bb_vg_delete.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int option_index = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/bb/cmd/bb_vg_query.c
+++ b/csmi/src/bb/cmd/bb_vg_query.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/bb/cmd/fernando_bb_lv_create.c
+++ b/csmi/src/bb/cmd/fernando_bb_lv_create.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	//int i = 0;
+	//uint32_t i = 0;
 
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	

--- a/csmi/src/bb/cmd/fernando_bb_lv_update.c
+++ b/csmi/src/bb/cmd/fernando_bb_lv_update.c
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	//int i = 0;
+	//uint32_t i = 0;
 
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	

--- a/csmi/src/bb/src/csmi_bb_cmd.c
+++ b/csmi/src/bb/src/csmi_bb_cmd.c
@@ -64,7 +64,7 @@
         }                                                               \
     }
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_cmd;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_cmd;
 
 void csmi_bb_cmd_destroy(csm_api_object *handle);
 

--- a/csmi/src/bb/src/csmi_bb_lv_create.c
+++ b/csmi/src/bb/src/csmi_bb_lv_create.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_bb_lv_create_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_BbLvCreate_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_create;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_create;
 
 int csm_bb_lv_create(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE* input)
 {

--- a/csmi/src/bb/src/csmi_bb_lv_delete.c
+++ b/csmi/src/bb/src/csmi_bb_lv_delete.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_bb_lv_delete_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_BbLvDelete_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_delete;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_delete;
 
 
 int csm_bb_lv_delete(csm_api_object **csm_obj, csm_bb_lv_delete_input_t* input)

--- a/csmi/src/bb/src/csmi_bb_lv_query.c
+++ b/csmi/src/bb/src/csmi_bb_lv_query.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_bb_lv_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_bb_lv_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_query;
 
 void csmi_bb_lv_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/bb/src/csmi_bb_lv_update.c
+++ b/csmi/src/bb/src/csmi_bb_lv_update.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_bb_lv_update_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_BbLvUpdate_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_update;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_lv_update;
 
 int csm_bb_lv_update(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE* input)
 {

--- a/csmi/src/bb/src/csmi_bb_vg_create.c
+++ b/csmi/src/bb/src/csmi_bb_vg_create.c
@@ -36,7 +36,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_bb_vg_create_input_t
 #define API_PARAMETER_OUTPUT_TYPE 
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_vg_create;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_vg_create;
 
 int csm_bb_vg_create(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE *input)
 {

--- a/csmi/src/bb/src/csmi_bb_vg_create.c
+++ b/csmi/src/bb/src/csmi_bb_vg_create.c
@@ -49,7 +49,7 @@ int csm_bb_vg_create(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE *input)
     uint32_t  return_buffer_length = 0;
     int       error_code           = CSMI_SUCCESS;
     int64_t   ssd_allocation_total = 0;
-    int32_t   ssd_idx;
+    uint32_t  ssd_idx;
     
     // EARLY RETURN
     // Create a csm_api_object and sets its csmi cmd and the destroy function

--- a/csmi/src/bb/src/csmi_bb_vg_delete.c
+++ b/csmi/src/bb/src/csmi_bb_vg_delete.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_bb_vg_delete_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_bb_vg_delete_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_vg_delete;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_vg_delete;
 
 void csmi_bb_vg_delete_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/bb/src/csmi_bb_vg_query.c
+++ b/csmi/src/bb/src/csmi_bb_vg_query.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_bb_vg_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_bb_vg_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_bb_vg_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_bb_vg_query;
 
 void csmi_bb_vg_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/bb/tests/test_csmi_bb_cmd.c
+++ b/csmi/src/bb/tests/test_csmi_bb_cmd.c
@@ -44,7 +44,7 @@ int csmi_client(int argc, char *argv[])
 	/*Helper Variables*/
 	int returnValue = 0;
 	/*For for loops*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Variables*/
 	csm_api_object *csm_obj = NULL;

--- a/csmi/src/bb/tests/test_csmi_bb_cmd_badCMDname.c
+++ b/csmi/src/bb/tests/test_csmi_bb_cmd_badCMDname.c
@@ -34,7 +34,7 @@ int csmi_client(int argc, char *argv[])
 	/*Helper Variables*/
 	int returnValue = 0;
 	/*For for loops*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Variables*/
 	csm_api_object *csm_obj = NULL;

--- a/csmi/src/bb/tests/test_csmi_bb_vg_create.c
+++ b/csmi/src/bb/tests/test_csmi_bb_vg_create.c
@@ -42,7 +42,7 @@ int csmi_client(int argc, char *argv[])
 	//csmutil_logging_level_set("info");
 	
 	//Helper Variables*/
-	int32_t i = 0;
+	uint32_t i = 0;
 
 	/*Variables*/
 	csm_api_object *csm_obj = NULL;

--- a/csmi/src/common/include/csm_serialization_x_macros.h
+++ b/csmi/src/common/include/csm_serialization_x_macros.h
@@ -117,7 +117,7 @@
         len += sizeof(target->length_member);                       \
                                                                     \
         if ( target->name )                                         \
-            for( i=0; i < target->length_member; i++)               \
+            for( i=0; i < (size_t)target->length_member; i++)               \
                 len += UINT32_T_SIZE + STR_LENGTH(target->name[i]);
 
 #define LEN_ARRAY_STR_FIXED(type, name, length, metadata)       \
@@ -137,7 +137,7 @@
         len += sizeof(target->length_member);                             \
                                                                           \
         if( target->name )                                                \
-            for ( i=0; i < target->length_member; i++ )                   \
+            for ( i=0; i < (size_t)target->length_member; i++ )            \
                 len += len_##metadata( target->name[i], version_id ) ;               
 
 #define LEN_ARRAY_STRUCT_FIXED(type, name, length, metadata)          \
@@ -216,7 +216,7 @@
 #define PACK_ARRAY_STR(type, name, length_member, metadata)         \
         if ( target->name ){                                            \
             PACK_ELEMENT(target->length_member);                        \
-            for( i=0; i < target->length_member; i++ ) {                \
+            for( i=0; i < (size_t)target->length_member; i++ ) {        \
                 PACK_STRING(type, name[i], length_member, metadata)     \
             }                                                           \
         }                                                               \
@@ -390,7 +390,7 @@
     // Reuse the fixed length macro.
 #define FREE_ARRAY_ARRAY_STR(type, name, length_member, metadata) \
         if (target->name) {                                           \
-            for ( i=0; i < target->length_member; i++ ) {             \
+            for ( i=0; i < (size_t)target->length_member; i++ ) {             \
                 free(target->name[i]);                                \
             }                                                         \
             free(target->name);                                       \
@@ -408,7 +408,7 @@
     //TODO 
 #define FREE_ARRAY_ARRAY_STRUCT(type, name, length_member, metadata) \
         if (target->name) {                                              \
-            for ( i=0; i < target->length_member; i++ ) {                \
+            for ( i=0; i < (size_t)target->length_member; i++ ) {                \
                 free_##metadata(target->name[i]);                        \
                 free(target->name[i]);                                   \
             }                                                            \

--- a/csmi/src/common/src/csm_api_common.c
+++ b/csmi/src/common/src/csm_api_common.c
@@ -171,9 +171,9 @@ int csmi_net_unix_Send(csm_net_msg_t *msg)
       return -1;
     }
     
-    if ( (rc = csm_net_unix_Send(ep->_ep, msg)) == (size_t)-1 )
+    if ( (rc = csm_net_unix_Send(ep->_ep, msg)) == -1 )
     {
-        rc = -1;
+        //rc = -1;
         perror("csm_net_unix_Send");
         csmutil_logging(error, "%s-%d: csm_net_unix_send() failed\n", __FILE__, __LINE__);
     }

--- a/csmi/src/common/src/csmi_common_serialization.c
+++ b/csmi/src/common/src/csmi_common_serialization.c
@@ -200,7 +200,7 @@ int csm_deserialize_str_array( char** array[], uint32_t* array_len, const char* 
 int csm_enum_from_string(char *enum_str, const char *enum_strs[])
 {
     int retval = -1; ///< The enum value of the string.
-    int i = 0;       ///< While loop counter.
+    uint32_t i = 0;       ///< While loop counter.
 
     // If a null string was supplied return -1
     if (!enum_str || !enum_str[0])

--- a/csmi/src/common/src/csmi_common_serialization.c
+++ b/csmi/src/common/src/csmi_common_serialization.c
@@ -120,7 +120,7 @@ int csm_serialize_str_array( char** array, uint32_t array_len, char** return_buf
 {
     if ( !array && array_len != 0) return 1;
 
-    int i;
+    uint32_t i;
     int offset = 0;
     int size_dump=0;
     *return_buffer_len = UINT32_T_SIZE;

--- a/csmi/src/common/src/csmi_serialization.c
+++ b/csmi/src/common/src/csmi_serialization.c
@@ -170,7 +170,7 @@ char *csmi_err_pack(const int errcode, const char *errmsg, uint32_t *buf_len)
 {
   char *buf = NULL;
   int len;
-  int offset = 0;
+  uint32_t offset = 0;
   
   *buf_len = sizeof(errcode);
   if (errmsg) *buf_len += strnlen(errmsg, MAX_ERR_MSG_LEN) + sizeof(len);
@@ -205,10 +205,10 @@ char *csmi_err_pack(const int errcode, const char *errmsg, uint32_t *buf_len)
 csmi_err_t* csmi_err_unpack(const char *buf, const uint32_t buf_len) 
 {
   int errcode;
-  int offset = 0;
+  uint32_t offset = 0;
   csmi_err_t *cdata=NULL;
   static const size_t min_buf_size = sizeof(cdata->errcode);
-  int len;
+  uint32_t len;
 
   if (buf == NULL || buf_len < min_buf_size) {
     csmutil_logging(warning,"csmi_err_unpack: buf not valid");

--- a/csmi/src/common/src/csmi_struct_hash.c
+++ b/csmi/src/common/src/csmi_struct_hash.c
@@ -190,7 +190,7 @@ void csmi_printer_internal(
     const csmi_struct_mapping_t* sub_map;   // A sub mapping for contained structs.
     size_t array_size = 0;                  // The size of an array.
 
-    int array_index = 0;
+    size_t array_index = 0;
     int type = 0;
     int offset = 0;
     void* member = NULL;

--- a/csmi/src/diag/cmd/diag_run_query.c
+++ b/csmi/src/diag/cmd/diag_run_query.c
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/* For for loops.*/
-	int i = 0;
+	uint32_t i = 0;
 	char *arg_check = NULL; ///< Used in verifying the long arg values.
 	
 	/*Set up data to call API*/

--- a/csmi/src/diag/src/csmi_diag_result_create.c
+++ b/csmi/src/diag/src/csmi_diag_result_create.c
@@ -33,7 +33,7 @@
 
 #define API_PARAMETER_INPUT_TYPE csm_diag_result_create_input_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_diag_result_create;
+static const csmi_cmd_t expected_cmd = CSM_CMD_diag_result_create;
 
 int csm_diag_result_create(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE *input)
 {

--- a/csmi/src/diag/src/csmi_diag_run_begin.c
+++ b/csmi/src/diag/src/csmi_diag_run_begin.c
@@ -33,7 +33,7 @@
 
 #define API_PARAMETER_INPUT_TYPE csm_diag_run_begin_input_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_diag_run_begin;
+static const csmi_cmd_t expected_cmd = CSM_CMD_diag_run_begin;
 
 int csm_diag_run_begin(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE *input)
 {

--- a/csmi/src/diag/src/csmi_diag_run_end.c
+++ b/csmi/src/diag/src/csmi_diag_run_end.c
@@ -33,7 +33,7 @@
 
 #define API_PARAMETER_INPUT_TYPE csm_diag_run_end_input_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_diag_run_end;
+static const csmi_cmd_t expected_cmd = CSM_CMD_diag_run_end;
 
 int csm_diag_run_end(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE* input)
 {

--- a/csmi/src/diag/src/csmi_diag_run_query.c
+++ b/csmi/src/diag/src/csmi_diag_run_query.c
@@ -32,7 +32,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_diag_run_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_diag_run_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_diag_run_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_diag_run_query;
 
 void csmi_diag_run_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/diag/src/csmi_diag_run_query_details.c
+++ b/csmi/src/diag/src/csmi_diag_run_query_details.c
@@ -34,7 +34,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_diag_run_query_details_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_diag_run_query_details_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_diag_run_query_details;
+static const csmi_cmd_t expected_cmd = CSM_CMD_diag_run_query_details;
 
 void csmi_diag_run_query_details_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/cmd/ib_cable_query.c
+++ b/csmi/src/inv/cmd/ib_cable_query.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/ib_cable_query_history.c
+++ b/csmi/src/inv/cmd/ib_cable_query_history.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/ib_cable_update.c
+++ b/csmi/src/inv/cmd/ib_cable_update.c
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/node_attributes_query.c
+++ b/csmi/src/inv/cmd/node_attributes_query.c
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/node_attributes_query_details.c
+++ b/csmi/src/inv/cmd/node_attributes_query_details.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/node_attributes_query_history.c
+++ b/csmi/src/inv/cmd/node_attributes_query_history.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/node_attributes_update.c
+++ b/csmi/src/inv/cmd/node_attributes_update.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	csm_node_attributes_update_input_t* input = NULL;

--- a/csmi/src/inv/cmd/node_delete.c
+++ b/csmi/src/inv/cmd/node_delete.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/node_query_state_history.c
+++ b/csmi/src/inv/cmd/node_query_state_history.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	/*For format printing later. */
 	char YAML = 0;
 

--- a/csmi/src/inv/cmd/switch_attributes_query.c
+++ b/csmi/src/inv/cmd/switch_attributes_query.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	csm_switch_attributes_query_input_t* input = NULL;

--- a/csmi/src/inv/cmd/switch_attributes_query_details.c
+++ b/csmi/src/inv/cmd/switch_attributes_query_details.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/cmd/switch_attributes_query_history.c
+++ b/csmi/src/inv/cmd/switch_attributes_query_history.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	csm_switch_attributes_query_history_input_t* input = NULL;

--- a/csmi/src/inv/cmd/switch_attributes_update.c
+++ b/csmi/src/inv/cmd/switch_attributes_update.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 
 	/*Set up data to call API*/
 	csm_switch_attributes_update_input_t* input = NULL;

--- a/csmi/src/inv/src/csmi_ib_cable_inventory_collection.c
+++ b/csmi/src/inv/src/csmi_ib_cable_inventory_collection.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ib_cable_inventory_collection_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ib_cable_inventory_collection_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_inventory_collection;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_inventory_collection;
 
 void csmi_ib_cable_inventory_collection_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_ib_cable_query.c
+++ b/csmi/src/inv/src/csmi_ib_cable_query.c
@@ -32,7 +32,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ib_cable_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ib_cable_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_query;
 
 void csmi_ib_cable_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_ib_cable_query_history.c
+++ b/csmi/src/inv/src/csmi_ib_cable_query_history.c
@@ -32,7 +32,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ib_cable_query_history_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ib_cable_query_history_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_query_history;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_query_history;
 
 void csmi_ib_cable_query_history_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_ib_cable_update.c
+++ b/csmi/src/inv/src/csmi_ib_cable_update.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ib_cable_update_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ib_cable_update_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_update;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ib_cable_update;
 
 void csmi_ib_cable_update_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_node_attributes_query.c
+++ b/csmi/src/inv/src/csmi_node_attributes_query.c
@@ -32,7 +32,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_node_attributes_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_attributes_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_query;
 
 void csmi_node_attributes_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_node_attributes_query_details.c
+++ b/csmi/src/inv/src/csmi_node_attributes_query_details.c
@@ -32,7 +32,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_node_attributes_query_details_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_attributes_query_details_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_query_details;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_query_details;
 
 void csmi_node_attributes_query_details_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_node_attributes_query_history.c
+++ b/csmi/src/inv/src/csmi_node_attributes_query_history.c
@@ -27,7 +27,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_node_attributes_query_history_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_attributes_query_history_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_query_history;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_query_history;
 
 void csmi_node_attributes_query_history_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_node_attributes_update.c
+++ b/csmi/src/inv/src/csmi_node_attributes_update.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE  csm_node_attributes_update_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_attributes_update_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_update;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_attributes_update;
 
 void csmi_node_attributes_update_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_node_delete.c
+++ b/csmi/src/inv/src/csmi_node_delete.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE  csm_node_delete_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_delete_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_delete;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_delete;
 
 void csmi_node_delete_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_node_query_state_history.c
+++ b/csmi/src/inv/src/csmi_node_query_state_history.c
@@ -27,7 +27,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_node_query_state_history_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_query_state_history_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_query_state_history;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_query_state_history;
 
 void csmi_node_query_state_history_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_switch_attributes_query.c
+++ b/csmi/src/inv/src/csmi_switch_attributes_query.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_switch_attributes_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_switch_attributes_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_query;
 
 void csmi_switch_attributes_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_switch_attributes_query_details.c
+++ b/csmi/src/inv/src/csmi_switch_attributes_query_details.c
@@ -32,7 +32,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_switch_attributes_query_details_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_switch_attributes_query_details_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_query_details;
+static const csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_query_details;
 
 void csmi_switch_attributes_query_details_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_switch_attributes_query_history.c
+++ b/csmi/src/inv/src/csmi_switch_attributes_query_history.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_switch_attributes_query_history_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_switch_attributes_query_history_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_query_history;
+static const csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_query_history;
 
 void csmi_switch_attributes_query_history_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_switch_attributes_update.c
+++ b/csmi/src/inv/src/csmi_switch_attributes_update.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_switch_attributes_update_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_switch_attributes_update_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_update;
+static const csmi_cmd_t expected_cmd = CSM_CMD_switch_attributes_update;
 
 void csmi_switch_attributes_update_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_switch_children_inventory_collection_temp.c
+++ b/csmi/src/inv/src/csmi_switch_children_inventory_collection_temp.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_switch_inventory_collection_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_switch_children_inventory_collection_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_switch_children_inventory_collection;
+static const csmi_cmd_t expected_cmd = CSM_CMD_switch_children_inventory_collection;
 
 void csmi_switch_children_inventory_collection_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/src/csmi_switch_inventory_collection.c
+++ b/csmi/src/inv/src/csmi_switch_inventory_collection.c
@@ -34,7 +34,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_switch_inventory_collection_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_switch_inventory_collection_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_switch_inventory_collection;
+static const csmi_cmd_t expected_cmd = CSM_CMD_switch_inventory_collection;
 
 void csmi_switch_inventory_collection_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/inv/tests/test_csmi_node_attributes_query.c
+++ b/csmi/src/inv/tests/test_csmi_node_attributes_query.c
@@ -119,7 +119,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/inv/tests/test_csmi_node_attributes_update.c
+++ b/csmi/src/inv/tests/test_csmi_node_attributes_update.c
@@ -35,7 +35,7 @@ int csmi_client(int argc, char *argv[])
 	/*Comment out these variables for now because they are not used and it throws an error in the compile.*/
 	
 	int retval;
-	//int i;
+	//uint32_t i;
 	//int nodeCount;
 	//csm_node_attributes_update_t *nodeAttributes;
 	//char **nodeList;

--- a/csmi/src/ras/cmd/csm_ras_event_query.c
+++ b/csmi/src/ras/cmd/csm_ras_event_query.c
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
     int option_index = 0;
 	/* For for loops.*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/ras/cmd/ras_event_query_allocation.c
+++ b/csmi/src/ras/cmd/ras_event_query_allocation.c
@@ -72,7 +72,7 @@ static void help()
 int main(int argc, char *argv[])
 {
 	/*Helper Variables*/
-	int i;
+	uint32_t i;
 	int opt;
 	int indexptr = 0;
 	int return_value = 0;

--- a/csmi/src/ras/cmd/ras_msg_type_delete.c
+++ b/csmi/src/ras/cmd/ras_msg_type_delete.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 	int opt;
 	/* getopt_long stores the option index here. */
     int option_index = 0;
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/ras/cmd/ras_msg_type_query.c
+++ b/csmi/src/ras/cmd/ras_msg_type_query.c
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
     int option_index = 0;
 	/* For for loops.*/
-	int i = 0;
+	uint32_t i = 0;
 	
 	/*Set up data to call API*/
 	API_PARAMETER_INPUT_TYPE* input = NULL;

--- a/csmi/src/ras/src/csmi_ras_event_create.c
+++ b/csmi/src/ras/src/csmi_ras_event_create.c
@@ -24,7 +24,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ras_event_create_input_t
 #define API_PARAMETER_OUTPUT_TYPE
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_event_create;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_event_create;
 
 int csm_ras_event_create(
     csm_api_object **csm_obj, 

--- a/csmi/src/ras/src/csmi_ras_event_query.c
+++ b/csmi/src/ras/src/csmi_ras_event_query.c
@@ -25,7 +25,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ras_event_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ras_event_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_event_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_event_query;
 
 void csm_ras_event_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/ras/src/csmi_ras_event_query_allocation.c
+++ b/csmi/src/ras/src/csmi_ras_event_query_allocation.c
@@ -24,7 +24,7 @@
 #define API_PARAMETER_INPUT_TYPE    csm_ras_event_query_allocation_input_t
 #define API_PARAMETER_OUTPUT_TYPE   csm_ras_event_query_allocation_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_event_query_allocation; ///< The expected command, used in verifying network communication.
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_event_query_allocation; ///< The expected command, used in verifying network communication.
 
 void csmi_ras_event_query_allocation_destroy(csm_api_object *handle);
 

--- a/csmi/src/ras/src/csmi_ras_msg_type_create.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_create.c
@@ -31,7 +31,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ras_msg_type_create_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ras_msg_type_create_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_create;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_create;
 
 void csm_ras_msg_type_create_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/ras/src/csmi_ras_msg_type_create.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_create.c
@@ -172,7 +172,7 @@ void csm_ras_msg_type_create_destroy(csm_api_object *csm_obj)
 	csmi_api_internal *csmi_hdl;
     API_PARAMETER_OUTPUT_TYPE *output = NULL;
 	/* Helper variables. */
-    //int i = 0;
+    //uint32_t i = 0;
     
 	/* Verify it exists */
     if (csm_obj == NULL || csm_obj->hdl == NULL)

--- a/csmi/src/ras/src/csmi_ras_msg_type_delete.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_delete.c
@@ -31,7 +31,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ras_msg_type_delete_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ras_msg_type_delete_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_delete;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_delete;
 
 void csm_ras_msg_type_delete_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/ras/src/csmi_ras_msg_type_delete.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_delete.c
@@ -93,10 +93,10 @@ int csm_ras_msg_type_delete(
                 (*output)->not_deleted_msg_ids = (char**)calloc((*output)->not_deleted_msg_ids_count, sizeof(char*));
                 
                 // FIXME This is not great can be nearly O(N^2)
-                int i;
+                uint32_t i;
                 int not_deleted_msg_ids_COUNTER = 0;
                 for(i = 0; i < input->msg_ids_count; i ++){
-                	int j = 0;
+                	uint32_t j = 0;
                 	char foundMatch = 0;
                 	for(j = 0; j < (*output)->deleted_msg_ids_count; j++){
                 		if(strcmp(input->msg_ids[i], (*output)->deleted_msg_ids[j]) == 0){
@@ -148,7 +148,7 @@ void csm_ras_msg_type_delete_destroy(csm_api_object *csm_obj)
 	csmi_api_internal *csmi_hdl;
     API_PARAMETER_OUTPUT_TYPE *output = NULL;
 	/* Helper variables. */
-    //int i = 0;
+    //uint32_t i = 0;
     
 	/* Verify it exists */
     if (csm_obj == NULL || csm_obj->hdl == NULL)

--- a/csmi/src/ras/src/csmi_ras_msg_type_query.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_query.c
@@ -108,7 +108,7 @@ void csmi_ras_msg_type_query_destroy(csm_api_object *csm_obj)
 	csmi_api_internal *csmi_hdl;
     API_PARAMETER_OUTPUT_TYPE *output = NULL;
 	/* Helper variables. */
-    //int i = 0;
+    //uint32_t i = 0;
 	
     /* Verify it exists */
     if (csm_obj == NULL || csm_obj->hdl == NULL)

--- a/csmi/src/ras/src/csmi_ras_msg_type_query.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_query.c
@@ -31,7 +31,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ras_msg_type_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ras_msg_type_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_query;
 
 void csmi_ras_msg_type_query_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/ras/src/csmi_ras_msg_type_update.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_update.c
@@ -31,7 +31,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_ras_msg_type_update_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_ras_msg_type_update_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_update;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_msg_type_update;
 
 void csm_ras_msg_type_update_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/ras/src/csmi_ras_msg_type_update.c
+++ b/csmi/src/ras/src/csmi_ras_msg_type_update.c
@@ -141,7 +141,7 @@ void csm_ras_msg_type_update_destroy(csm_api_object *csm_obj)
 	csmi_api_internal *csmi_hdl;
     API_PARAMETER_OUTPUT_TYPE *output = NULL;
 	/* Helper variables. */
-    //int i = 0;
+    //uint32_t i = 0;
     
 	/* Verify it exists */
     if (csm_obj == NULL || csm_obj->hdl == NULL)

--- a/csmi/src/ras/src/csmi_ras_subscribe.c
+++ b/csmi/src/ras/src/csmi_ras_subscribe.c
@@ -23,7 +23,7 @@
 
 #define API_PARAMETER_INPUT_TYPE csm_ras_subscribe_input_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_subscribe;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_subscribe;
 
 void csm_ras_subscribe_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/ras/src/csmi_ras_unsubscribe.c
+++ b/csmi/src/ras/src/csmi_ras_unsubscribe.c
@@ -23,7 +23,7 @@
 
 #define API_PARAMETER_INPUT_TYPE csm_ras_unsubscribe_input_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_ras_unsubscribe;
+static const csmi_cmd_t expected_cmd = CSM_CMD_ras_unsubscribe;
 
 void csm_ras_unsubscribe_destroy(csm_api_object *csm_obj);
 

--- a/csmi/src/ras/tests/test_csmi_ras_event_create.c
+++ b/csmi/src/ras/tests/test_csmi_ras_event_create.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
    strftime(ftime,80,"%Y-%m-%dT%H:%M:%S %z", info);
 
 
-  //int i;
+  //uint32_t i;
   //int nodeCount;
   //csm_api_object *csm_obj = NULL;
 

--- a/csmi/src/wm/cmd/allocation_create.c
+++ b/csmi/src/wm/cmd/allocation_create.c
@@ -107,7 +107,7 @@ static void help() {
 
 int main(int argc, char *argv[])
 {
-    int                i;
+    uint32_t             i;
     int                opt;
     int                indexptr = 0;
     int                return_value;

--- a/csmi/src/wm/cmd/allocation_query.c
+++ b/csmi/src/wm/cmd/allocation_query.c
@@ -79,7 +79,7 @@ static void help()
 int main(int argc, char *argv[])
 {
 	/*Helper Variables*/
-	int i;
+	uint32_t i;
 	int opt;
 	int indexptr = 0;
 	int return_value = 0;

--- a/csmi/src/wm/cmd/allocation_query_details.c
+++ b/csmi/src/wm/cmd/allocation_query_details.c
@@ -74,7 +74,7 @@ static void help()
 int main(int argc, char *argv[])
 {
 	/*Helper Variables*/
-	int i;
+	uint32_t i;
 	int opt;
 	int indexptr = 0;
 	int return_value = 0;

--- a/csmi/src/wm/cmd/allocation_resources_query.c
+++ b/csmi/src/wm/cmd/allocation_resources_query.c
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	
 	/*Set up data to call API*/

--- a/csmi/src/wm/cmd/allocation_step_query.c
+++ b/csmi/src/wm/cmd/allocation_step_query.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*For for loops*/
-	uint32_t i = 0;
+	int32_t i = 0;
 
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	

--- a/csmi/src/wm/cmd/allocation_step_query_active_all.c
+++ b/csmi/src/wm/cmd/allocation_step_query_active_all.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	int opt;
 	int parameterCounter = 0;
 	/*For for loops*/
-	uint32_t i = 0;
+	int32_t i = 0;
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	
 	/*Argument Variables*/

--- a/csmi/src/wm/cmd/allocation_step_query_details.c
+++ b/csmi/src/wm/cmd/allocation_step_query_details.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*For for loops*/
-	uint32_t i = 0;
+	int32_t i = 0;
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	
 	/*Set up data to call API*/
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
                 printf("  num_tasks:            %"PRId32"\n", step->num_tasks);
                 printf("  user_flags:           %s\n",        step->user_flags);
 	        	printf("  compute_nodes:\n");
-	        	uint32_t j = 0;
+	        	int32_t j = 0;
 	        	for(j = 0; j < step->num_nodes; j++){
 	        		printf("    - %s\n", step->compute_nodes[j]);
 	        	}

--- a/csmi/src/wm/cmd/node_resources_query.c
+++ b/csmi/src/wm/cmd/node_resources_query.c
@@ -111,7 +111,8 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
+    int32_t  k = 0; 
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	
 	/*Set up data to call API*/
@@ -164,8 +165,8 @@ int main(int argc, char *argv[])
 		csmutil_logging(error, "%s-%d:", __FILE__, __LINE__);
 		csmutil_logging(error, "  Encountered %i extra parameter(s). Expected none.", argc);
 		csmutil_logging(error, "  Extra args found:");
-		for(i = 0; i < argc; i++){
-			csmutil_logging(error, "    argv[%i]: %s", i, argv[i]);
+		for(k = 0; k < argc; k++){
+			csmutil_logging(error, "    argv[%k]: %s", k, argv[k]);
 		}
 		csmutil_logging(error, "  Run with '-h' for help and information.");
 		csm_free_struct_ptr(API_PARAMETER_INPUT_TYPE, input);
@@ -235,7 +236,7 @@ int main(int argc, char *argv[])
 				if(output->results[i]->ssds_count > 0)
 				{
 					printf("  ssds:\n");
-					int j = 0;
+					uint32_t j = 0;
 					for(j = 0; j < output->results[i]->ssds_count; j++)
 					{
 						printf("    - ssd_serial_number:  %s\n",        output->results[i]->ssds[j]->serial_number);

--- a/csmi/src/wm/cmd/node_resources_query_all.c
+++ b/csmi/src/wm/cmd/node_resources_query_all.c
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 	/* getopt_long stores the option index here. */
 	int indexptr = 0;
 	/*i var for 'for loops'*/
-	int i = 0;
+	uint32_t i = 0;
     char *arg_check = NULL; ///< Used in verifying the long arg values.
 	
 	/*Set up data to call API*/
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
 				if(output->results[i]->ssds_count > 0)
 				{
 					printf("  ssds:\n");
-					int j = 0;
+					uint32_t j = 0;
 					for(j = 0; j < output->results[i]->ssds_count; j++)
 					{
 						printf("    - ssd_serial_number:  %s\n",        output->results[i]->ssds[j]->serial_number);

--- a/csmi/src/wm/src/csmi_allocation_create.c
+++ b/csmi/src/wm/src/csmi_allocation_create.c
@@ -49,7 +49,7 @@
         }                                                               \
     }           
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_create;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_create;
 
 int csm_allocation_create(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_allocation_delete.c
+++ b/csmi/src/wm/src/csmi_allocation_delete.c
@@ -23,7 +23,7 @@
 #define API_PARAMETER_INPUT_TYPE  csm_allocation_delete_input_t
 #define API_PARAMETER_OUTPUT_TYPE 
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_delete;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_delete;
 
 int csm_allocation_delete(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_allocation_query.c
+++ b/csmi/src/wm/src/csmi_allocation_query.c
@@ -24,7 +24,7 @@
 #define API_PARAMETER_INPUT_TYPE    csm_allocation_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE   csm_allocation_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_query; ///< The expected command, used in verifying network communication.
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_query; ///< The expected command, used in verifying network communication.
 
 void csmi_allocation_query_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_allocation_query_active_all.c
+++ b/csmi/src/wm/src/csmi_allocation_query_active_all.c
@@ -28,7 +28,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_allocation_query_active_all_input_t 
 #define API_PARAMETER_OUTPUT_TYPE csm_allocation_query_active_all_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_query_active_all;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_query_active_all;
 
 void csmi_allocation_query_active_all_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_allocation_query_details.c
+++ b/csmi/src/wm/src/csmi_allocation_query_details.c
@@ -23,7 +23,7 @@
 #define API_PARAMETER_INPUT_TYPE   csm_allocation_query_details_input_t
 #define API_PARAMETER_OUTPUT_TYPE  csm_allocation_query_details_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_query_details;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_query_details;
 
 void csmi_allocation_query_details_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_allocation_resources_query.c
+++ b/csmi/src/wm/src/csmi_allocation_resources_query.c
@@ -36,7 +36,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_allocation_resources_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_allocation_resources_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_resources_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_resources_query;
 
 void csmi_allocation_resources_query_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_allocation_step_begin.c
+++ b/csmi/src/wm/src/csmi_allocation_step_begin.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_allocation_step_begin_input_t
 #define API_PARAMETER_OUTPUT_TYPE 
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_begin;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_begin;
 
 int csm_allocation_step_begin(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_allocation_step_begin.c
+++ b/csmi/src/wm/src/csmi_allocation_step_begin.c
@@ -53,7 +53,7 @@ int csm_allocation_step_begin(
     create_csm_api_object(handle, expected_cmd, NULL);
 
     // If the step was not supplied or the number of nodes was zero, return an error.	
-    if ( !input || input->num_nodes == 0 )
+    if ( !input || input->num_nodes <= 0 )
     {
         csmutil_logging(error, "An invalid step was provided (steps need nodes)");
 

--- a/csmi/src/wm/src/csmi_allocation_step_cgroup_create.c
+++ b/csmi/src/wm/src/csmi_allocation_step_cgroup_create.c
@@ -28,7 +28,7 @@
 #define API_PARAMETER_INPUT_TYPE    csm_allocation_step_cgroup_create_input_t
 #define API_PARAMETER_OUTPUT_TYPE  
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_cgroup_create;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_cgroup_create;
 
 int csm_allocation_step_cgroup_create(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_allocation_step_cgroup_delete.c
+++ b/csmi/src/wm/src/csmi_allocation_step_cgroup_delete.c
@@ -29,7 +29,7 @@
 #define API_PARAMETER_INPUT_TYPE    csm_allocation_step_cgroup_delete_input_t
 #define API_PARAMETER_OUTPUT_TYPE  
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_cgroup_delete;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_cgroup_delete;
 
 int csm_allocation_step_cgroup_delete(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_allocation_step_end.c
+++ b/csmi/src/wm/src/csmi_allocation_step_end.c
@@ -36,7 +36,7 @@
 #define API_PARAMETER_INPUT_TYPE  csm_allocation_step_end_input_t
 #define API_PARAMETER_OUTPUT_TYPE 
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_end;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_end;
 
 int csm_allocation_step_end(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_allocation_step_query.c
+++ b/csmi/src/wm/src/csmi_allocation_step_query.c
@@ -35,7 +35,7 @@
 #define API_PARAMETER_INPUT_TYPE  csm_allocation_step_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_allocation_step_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_query;
 
 void csmi_allocation_step_query_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_allocation_step_query_active_all.c
+++ b/csmi/src/wm/src/csmi_allocation_step_query_active_all.c
@@ -32,7 +32,7 @@
 #define API_PARAMETER_INPUT_TYPE  csm_allocation_step_query_active_all_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_allocation_step_query_active_all_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_query_active_all;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_query_active_all;
 
 void csmi_allocation_step_query_active_all_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_allocation_step_query_details.c
+++ b/csmi/src/wm/src/csmi_allocation_step_query_details.c
@@ -33,7 +33,7 @@
 #define API_PARAMETER_INPUT_TYPE  csm_allocation_step_query_details_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_allocation_step_query_details_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_query_details;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_step_query_details;
 
 void csmi_allocation_step_query_details_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_allocation_update_history.c
+++ b/csmi/src/wm/src/csmi_allocation_update_history.c
@@ -36,7 +36,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_allocation_update_history_input_t
 #define API_PARAMETER_OUTPUT_TYPE 
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_update_history;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_update_history;
 
 int csm_allocation_update_history(
 

--- a/csmi/src/wm/src/csmi_allocation_update_state.c
+++ b/csmi/src/wm/src/csmi_allocation_update_state.c
@@ -28,7 +28,7 @@
 #define API_PARAMETER_INPUT_TYPE    csm_allocation_update_state_input_t
 #define API_PARAMETER_OUTPUT_TYPE  
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_allocation_update_state;
+static const csmi_cmd_t expected_cmd = CSM_CMD_allocation_update_state;
 
 int csm_allocation_update_state(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_cgroup_login.c
+++ b/csmi/src/wm/src/csmi_cgroup_login.c
@@ -28,7 +28,7 @@
 #define API_PARAMETER_INPUT_TYPE    csm_cgroup_login_input_t
 #define API_PARAMETER_OUTPUT_TYPE  
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_cgroup_login;
+static const csmi_cmd_t expected_cmd = CSM_CMD_cgroup_login;
 
 int csm_cgroup_login(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_jsrun_cmd.c
+++ b/csmi/src/wm/src/csmi_jsrun_cmd.c
@@ -49,7 +49,7 @@
         }                                                               \
     }           
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_jsrun_cmd;
+static const csmi_cmd_t expected_cmd = CSM_CMD_jsrun_cmd;
 
 int csm_jsrun_cmd(
     csm_api_object **handle, 

--- a/csmi/src/wm/src/csmi_node_resources_query.c
+++ b/csmi/src/wm/src/csmi_node_resources_query.c
@@ -121,7 +121,7 @@ void csmi_node_resources_query_destroy(csm_api_object *handle)
 	csmi_api_internal *csmi_hdl;
     API_PARAMETER_OUTPUT_TYPE *output = NULL;
 	/* Helper variables. */
-    //int i = 0;
+    //uint32_t i = 0;
     
 	/* Verify it exists */
     if (handle == NULL || handle->hdl == NULL)

--- a/csmi/src/wm/src/csmi_node_resources_query.c
+++ b/csmi/src/wm/src/csmi_node_resources_query.c
@@ -34,7 +34,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_node_resources_query_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_resources_query_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_resources_query;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_resources_query;
 
 void csmi_node_resources_query_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/src/csmi_node_resources_query_all.c
+++ b/csmi/src/wm/src/csmi_node_resources_query_all.c
@@ -35,7 +35,7 @@
 #define API_PARAMETER_INPUT_TYPE csm_node_resources_query_all_input_t
 #define API_PARAMETER_OUTPUT_TYPE csm_node_resources_query_all_output_t
 
-const static csmi_cmd_t expected_cmd = CSM_CMD_node_resources_query_all;
+static const csmi_cmd_t expected_cmd = CSM_CMD_node_resources_query_all;
 
 void csmi_node_resources_query_all_destroy(csm_api_object *handle);
 

--- a/csmi/src/wm/tests/test_csmi_allocation_create.c
+++ b/csmi/src/wm/tests/test_csmi_allocation_create.c
@@ -24,7 +24,7 @@
 
 int csmi_client(int argc, char *argv[])
 {
-  int                i;
+  uint32_t               i;
   int                retval;
   csmi_allocation_t   allocation;
   char             **compute_nodes;

--- a/csmi/src/wm/tests/test_csmi_allocation_query.c
+++ b/csmi/src/wm/tests/test_csmi_allocation_query.c
@@ -36,7 +36,8 @@ static void usage(const char *argv0)
 
 int csmi_client(int argc, char *argv[])
 {
-  int                i;
+  uint32_t           i;
+  int32_t            j;
   int                ch;
   int                indexptr = 0;
   int                retval;
@@ -64,8 +65,8 @@ int csmi_client(int argc, char *argv[])
   if (argc != 2)
     usage(argv[0]);
 
-  for (i = optind; i < argc; i++) {
-    input.allocation_id = (uint64_t)atol(argv[i]);
+  for (j = optind; j < argc; j++) {
+    input.allocation_id = (uint64_t)atol(argv[j]);
   }
 
   retval = csm_allocation_query(&csm_obj, &input, &output);

--- a/csmi/src/wm/tests/test_csmi_allocation_query_active_all.c
+++ b/csmi/src/wm/tests/test_csmi_allocation_query_active_all.c
@@ -25,8 +25,8 @@
 int csmi_client(int argc, char *argv[])
 {
   int retval = 0;
-  int i;
-  int j;
+  uint32_t i;
+  uint32_t j;
   csm_api_object    *csm_obj = NULL;
   csm_allocation_query_active_all_input_t input;
   csm_allocation_query_active_all_output_t* output = NULL;

--- a/csmi/src/wm/tests/test_csmi_allocation_query_details.c
+++ b/csmi/src/wm/tests/test_csmi_allocation_query_details.c
@@ -36,7 +36,8 @@ static void usage(const char *argv0)
 
 int csmi_client(int argc, char *argv[])
 {
-  int                i;
+  uint32_t           i;
+  int32_t            j;
   int                ch;
   int                indexptr = 0;
   int                retval;
@@ -61,8 +62,8 @@ int csmi_client(int argc, char *argv[])
   if (argc != 2)
     usage(argv[0]);
 
-  for (i = optind; i < argc; i++) {
-    input.allocation_id = (uint64_t)atol(argv[i]);
+  for (j = optind; j < argc; j++) {
+    input.allocation_id = (uint64_t)atol(argv[j]);
   }
 
   retval = csm_allocation_query_details(&csm_obj, &input, &output);

--- a/csmi/src/wm/tests/test_csmi_allocation_update_state.c
+++ b/csmi/src/wm/tests/test_csmi_allocation_update_state.c
@@ -25,7 +25,7 @@
 int csmi_client(int argc, char *argv[])
 {
   int retval = 0;
-  int i;
+  uint32_t i;
   int j;
   uint64_t allocation_id= 3;
   csm_api_object    *csm_obj = NULL;

--- a/csmi/src/wm/tests/test_csmi_sample.c
+++ b/csmi/src/wm/tests/test_csmi_sample.c
@@ -142,7 +142,7 @@ int csmi_client(int argc, char *argv[])
     if ( !ret_val ) 
     {
         /// Output the contents of the query.
-        int i;
+        uint32_t i;
         csmi_allocation_t *allocation_query = alloc_query_out->allocation;
 
         printf("\nallocation_id: %" PRIu64 "\n", allocation_query->allocation_id);

--- a/csmi/templates/csmi_helpers/make_csmi_c_api.sh
+++ b/csmi/templates/csmi_helpers/make_csmi_c_api.sh
@@ -43,7 +43,7 @@ build_function()
     csmi_name=${1/csm_/csmi_}
     function_prototype=${2/;/}
     
-    function_string="const static csmi_cmd_t ExpectedCmd = CSM_CMD_${trimmed_name};\n\n"
+    function_string="static const csmi_cmd_t ExpectedCmd = CSM_CMD_${trimmed_name};\n\n"
     function_string+="/** @brief Destroys the csm_api object, releasing the handle pointed "
     function_string+="to by the object.\n \*\n \*"
     function_string+=" @param csm_obj An object containing a pointer to a handle for the "

--- a/csmnet/src/CPP/endpoint_heartbeat.h
+++ b/csmnet/src/CPP/endpoint_heartbeat.h
@@ -211,7 +211,7 @@ public:
   }
 
   // consider remote end to be dead if last successful recv was more than 2x_Interval seconds ago
-  const bool peerDead( TimeType & reference )
+  bool peerDead( TimeType & reference )
   {
     bool dead = (_EndOfUnsure < reference) && ( _Status == MISSING_RECV );
     if( dead )

--- a/fshipcld/include/NodeName.h
+++ b/fshipcld/include/NodeName.h
@@ -190,7 +190,8 @@ public:
   char isUnkFile() { return (_d_type == DT_UNKNOWN); }
   int isRoot() { return (_inodeForFuse == FUSE_ROOT_ID); }
 
-  const char *const accessNamePTR() {
+  // XXX Not sure why it was complaining about const char* const
+  const char * accessNamePTR() {
     if (_name_ptr)
       return _name_ptr;
     return _shortName;

--- a/scripts/setupBoost.cmake
+++ b/scripts/setupBoost.cmake
@@ -10,7 +10,7 @@ find_package(Boost ${BoostVersion} REQUIRED COMPONENTS ${BoostComponents})
 message("boost includes: ${Boost_INCLUDE_DIRS}")
 message("boost librarys: ${Boost_LIBRARY_DIRS}")
 
-include_directories(${Boost_INCLUDE_DIRS})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 #
 # Boost install steps:

--- a/transport/include/MemChunk.h
+++ b/transport/include/MemChunk.h
@@ -50,8 +50,8 @@ MemChunkBase(int pNumChunks, uint64_t pChunkSize){
 virtual memItemPtr getChunk()=0;
 virtual void putChunk(memItemPtr pMi)=0;
 virtual ~MemChunkBase(){};
-const uint64_t getChunkSize()const{return _chunkSize;}
-const int getNumChunks()const{return _numChunks;}
+uint64_t getChunkSize()const{return _chunkSize;}
+int getNumChunks()const{return _numChunks;}
 protected:
    uint64_t _chunkSize;
    int _numChunks;


### PR DESCRIPTION
This pull request fixes a number of warnings/errors caused by adding the `-Wextra` option to the build settings.

For the most part these changes are to whether a variable is signed or unsigned. I attempted to split the changes roughly by locations in the code and the nature of the changes.