### PR TITLE
Fixing data aggregator function parameters.

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.cc
@@ -202,7 +202,7 @@ bool GetGPFSUsage(int64_t &gpfs_read, int64_t &gpfs_write)
     return success;
 }
 
-bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t gpu_energy)
+bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t &gpu_energy)
 {
     // Generate the value map for the query.
     std::unordered_map<std::string, int64_t> valueMap = {

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/DataAggregators.h
@@ -61,7 +61,7 @@ bool GetGPFSUsage(int64_t &gpfs_read, int64_t &gpfs_write);
  * @return True  - The data was read successfully.
  * @return False - The data could not be read.
  */
-bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t gpu_energy );
+bool GetOCCAccounting(int64_t &energy, int64_t &power_cap_hit, int64_t &gpu_energy );
 
 /** @brief Retrieves the power capacity of the node using the OCC /sys/fs utility.
  * This function queries the OCC file to determine the power cap.


### PR DESCRIPTION
`gpu_energy` was not a reference type.