### PR TITLE
The multicast message creator now sorts the node list before pushing …

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.cc
@@ -70,7 +70,7 @@ bool CSMIHandlerState::PushDBReq(
     
 bool CSMIHandlerState::PushMCAST( 
     csm::network::Message message,
-    const std::vector<std::string>& targets,
+    std::vector<std::string>& targets,
     csm::daemon::EventContextHandlerState_sptr ctx,
     std::vector<csm::daemon::CoreEvent*>& postEventList,
     uint64_t targetState,
@@ -82,6 +82,10 @@ bool CSMIHandlerState::PushMCAST(
         ctx->SetErrorMessage("Multicast had no targets!");
         return false;
     }
+
+    // Sort the targets.
+    std::sort(targets.begin(), targets.end());
+
     // Set up the message count trackers.
     ctx->SetExpectedNumResponses(targets.size());
     ctx->SetReceivedNumResponses(0);

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.h
@@ -198,6 +198,7 @@ protected:
     
     /** @brief Pushes a multicast(MCAST) message to the event list.
      *
+     * @param targets Sorts the targets for multicast.
      * @param payload
      * @param payloadLen
      * @param ctx
@@ -206,12 +207,13 @@ protected:
      * @param errorOnFail If error handling for a failure is state specific, set to false. 
      *  Otherwise, an error will be pushed to the event list. Defaults to true.
      *
+     *
      * @return True  If successful.
      * @return False If failed.
      */
     bool PushMCAST(
         csm::network::Message message,
-        const std::vector<std::string>& targets,
+        std::vector<std::string>& targets,
         csm::daemon::EventContextHandlerState_sptr ctx,
         std::vector<csm::daemon::CoreEvent*>& postEventList,
         uint64_t targetState = UINT64_MAX,


### PR DESCRIPTION
…the message.

This is to facilitate some MTC optimization. Added a sort to the `PushMCAST` function.