### PR TITLE
extended CSM version info including git commit and date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ execute_process(
   OUTPUT_VARIABLE GITCOMMITIDSHORT
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+execute_process(
+  COMMAND git log -1 --format=%cd
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE tmp_COMMITDATE
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
 
 message("GIT commit: ${tmp_GITCOMMITID}")
@@ -46,8 +52,10 @@ message("Build time: ${tmp_BUILDTIME}")
 if(tmp_GITCOMMITID STREQUAL "")
    message("GIT commit could not be determined.  Using current build time as commit ID")
    set(GITCOMMITID ${tmp_BUILDTIME})
+   set(GITCOMMITDATE ${tmp_BUILDTIME})
 else()
    set(GITCOMMITID ${tmp_GITCOMMITID})
+   set(GITCOMMITDATE ${tmp_COMMITDATE})
 endif()
 
 

--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -105,8 +105,9 @@ Configuration::Configuration( int argc, char **argv, const RunMode *runmode )
     // shall not continue. The code for now will come here only when csm.role is not valid
   }
 
-  CSMLOGp( csmd, info, "CSMD" ) << _Role << "; Build: " << std::string( CSM_VERSION, strnlen( CSM_VERSION, 10 ) )
-    << "; Config file: " << _CfgFile;
+  CSMLOGp( csmd, info, "CSMD" ) << _Role << "; Version: " << std::string( CSM_VERSION, strnlen( CSM_VERSION, 10 ) )
+    << "; Build: " << std::string( CSM_COMMIT, strnlen( CSM_COMMIT, 10 ))
+    << "; Date: " << std::string( CSM_DATE) << "; Config file: " << _CfgFile;
 
   #define RETRIES 5
   #define WAIT 30

--- a/csmutil/include/CMakeLists.txt
+++ b/csmutil/include/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(csm_buildversion csm_buildversion.cc)
 
 add_custom_command(TARGET csm_buildversion
 	POST_BUILD
-    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/csm_buildversion ${CMAKE_CURRENT_SOURCE_DIR}/csm_version.h ${VERSION}
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/csm_buildversion ${CMAKE_CURRENT_SOURCE_DIR}/csm_version.h ${VERSION} ${GITCOMMITID} ${GITCOMMITDATE}
     COMMENT "Generating csm_version"
 )
 

--- a/csmutil/include/csm_buildversion.cc
+++ b/csmutil/include/csm_buildversion.cc
@@ -21,6 +21,8 @@ int main(int argc, char** argv)
 {
     FILE* fd;
     char *version;    
+    char *commit;
+    char *date;
 
     if(argc > 2)
     {
@@ -28,6 +30,18 @@ int main(int argc, char** argv)
     }
     else version = strdup("unknown");
     
+    if( argc > 3 )
+    {
+      commit = argv[3];
+    }
+    else commit = strdup("unknown");
+
+    if( argc > 4 )
+    {
+      date = argv[4];
+    }
+    else date = strdup("no date");
+
     std::string fn = argv[1];
     fn += ".tmp";
     
@@ -48,7 +62,9 @@ int main(int argc, char** argv)
     fprintf(fd, "|    U.S. Government Users Restricted Rights:  Use, duplication or disclosure\n");
     fprintf(fd, "|    restricted by GSA ADP Schedule Contract with IBM Corp.\n");
     fprintf(fd, "*******************************************************************************/\n\n");
-    fprintf(fd, "#define CSM_VERSION \"%s\"", version);
+    fprintf(fd, "#define CSM_VERSION \"%s\"\n\n", version);
+    fprintf(fd, "#define CSM_COMMIT \"%s\"\n\n", commit);
+    fprintf(fd, "#define CSM_DATE \"%s\"\n\n", date);
     fclose(fd);
     
     std::string rsynccmd = std::string("rsync -c ") + fn + " " + std::string(argv[1]);


### PR DESCRIPTION
This extends the current first log line of the daemon to include version, commitID, and commit date to have more detailed info for users, testing, and developers.

I added @tgooding to review especially commit c272ba4 because I extended the top-level CMakeLists.txt to establish the commit date (using the committer date because that will reflect the exact date of the actual commit that's built).

