### PR TITLE
csm_allocation_update_state private check bug fix

### DIFF
--- a/csmconf/csm_api.acl
+++ b/csmconf/csm_api.acl
@@ -6,6 +6,7 @@
   "private":
   ["csm_allocation_query_details",
    "csm_allocation_delete",
+   "csm_allocation_update_state",
    "csm_bb_cmd",
    "csm_jsrun_cmd",
    "csm_allocation_step_query_details"],

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationUpdateState.h
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationUpdateState.h
@@ -26,6 +26,17 @@ class CSMIAllocationUpdateState : public CSMIStatefulDB
 public:
     CSMIAllocationUpdateState(csm::daemon::HandlerOptions& options) ;
 
+	virtual bool CompareDataForPrivateCheck(
+        const std::vector<csm::db::DBTuple *>& tuples,
+        const csm::network::Message &msg,
+        csm::daemon::EventContextHandlerState_sptr ctx) final;
+	
+	virtual bool RetrieveDataForPrivateCheck(
+        const std::string& arguments, 
+        const uint32_t len, 
+        csm::db::DBReqContent **dbPayload,
+        csm::daemon::EventContextHandlerState_sptr ctx ) final;
+
     virtual bool CreatePayload(
         const std::string& arguments,
         const uint32_t len,


### PR DESCRIPTION
Non root users were unable to update the state of their allocations from `running` to `staging-out`, this is due to the private check functions being unimplemented. 

This pull request re-implements the private check and adds `csm_allocation_update_state` to the list of private APIs by default in the acl file.

@pdlun92 We're going to need a new test case to check, I'll make an issue with details.