### PR TITLE
Cgroup Debug/Error Logging

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
@@ -255,11 +255,12 @@ private:
      * @note SIGKILL is used in killing the tasks.
      *
      * @param[in] controlGroup The control group to kill the tasks in.
+     * @param[in] printPids If set this function will print the pids as an error log.
      * @return The total number of tasks that the kill function was run against.
      *
      * @throw CSMHandlerException If the tasks could not be killed.
      */
-    uint64_t KillTasks( const std::string& controlGroup ) const;
+    uint64_t KillTasks( const std::string& controlGroup, bool printPids = false ) const;
 
     /** @brief Copies the contents of a parameter from one group to another.
      *


### PR DESCRIPTION
Modified the error logging for cgroups. Now in the event of a failure a list of the pids that can't be killed will be logged to the error utility. 

Moved a warning error message down to debug to reduce confusion.