### PR TITLE
enable ctrl-cmd to reset primary/secondary connection status according to config

### DIFF
--- a/csmd/src/daemon/include/connection_handling.h
+++ b/csmd/src/daemon/include/connection_handling.h
@@ -241,9 +241,9 @@ protected:
   int SecondaryUp();
   virtual int CreatePrimary();
   void QueueFailoverMsg( csm::network::Address_sptr addr );
+  void QueueResetMsg( csm::network::Address_sptr addr );
   int UpTransitionAndFailover( const csm::network::Address_sptr i_Addr,
                                const bool i_Failover );
-
 private:
   int CreateSecondary();
 

--- a/csmd/src/daemon/include/connection_handling.h
+++ b/csmd/src/daemon/include/connection_handling.h
@@ -230,6 +230,9 @@ public:
   virtual int ProcessSystemEvent( const csm::daemon::SystemContent::SIGNAL_TYPE i_Signal,
                                   const csm::network::Address_sptr i_Addr,
                                   const uint64_t i_MsgIdCandidate = 0 );
+
+  void ResetPrimary();
+
 protected:
   virtual int CheckConnectivityNoLock();
   virtual int PrimaryDown();

--- a/csmd/src/daemon/include/csm_daemon_network_manager.h
+++ b/csmd/src/daemon/include/csm_daemon_network_manager.h
@@ -134,6 +134,7 @@ public:
   }
   inline csm::daemon::VirtualNetworkChannel_sptr GetNetMgrChannel() const { return _NetMgrChannel; }
   inline csm::daemon::RetryBackOff *GetRetryBackoff() { return _IdleLoopRetry; }
+  inline csm::daemon::ConnectionHandling *GetConnectionHandling() const { return _ConnMgr; }
 
   bool ProcessNetCtlEvents();
   bool EndpointMaintenance();

--- a/csmd/src/daemon/include/csm_daemon_state.h
+++ b/csmd/src/daemon/include/csm_daemon_state.h
@@ -337,7 +337,6 @@ public:
   {
     return _Aggregators[ 1 ];
   }
-  void ResetPrimary();
   void SetPrimaryAggregator( const csm::network::Address_sptr primary );
 
   virtual void AddEP( const csm::network::Address_sptr addr,

--- a/csmd/src/daemon/include/csm_event_sink.h
+++ b/csmd/src/daemon/include/csm_event_sink.h
@@ -38,5 +38,6 @@ public:
 #include "src/csm_event_sinks/csm_sink_db.h"
 #include "src/csm_event_sinks/csm_sink_network.h"
 #include "src/csm_event_sinks/csm_sink_timer.h"
+#include "src/csm_event_sinks/csm_sink_system.h"
 
 #endif /* CSM_DAEMON_SRC_CSM_EVENT_SINK_H_ */

--- a/csmd/src/daemon/include/csm_system_event.h
+++ b/csmd/src/daemon/include/csm_system_event.h
@@ -39,6 +39,7 @@ public:
     RETRY_CONNECT,
     RESTARTED,
     FAILOVER,
+    RESET_AGG,
     FATAL,
     JOB_START,
     JOB_END,
@@ -86,9 +87,10 @@ operator<<( stream &out, const SystemContent::SIGNAL_TYPE &aType )
   {
     case SystemContent::CONNECTED:    out << "CONNECTED";    break;
     case SystemContent::DISCONNECTED: out << "DISCONNECTED"; break;
-    case SystemContent::FAILOVER: out << "FAILOVER"; break;
-    case SystemContent::RESTARTED: out << "RESTARTED"; break;
     case SystemContent::RETRY_CONNECT: out << "RETRY_CONNECT"; break;
+    case SystemContent::RESTARTED: out << "RESTARTED"; break;
+    case SystemContent::FAILOVER: out << "FAILOVER"; break;
+    case SystemContent::RESET_AGG: out << "RESET_AGG"; break;
     case SystemContent::FATAL: out << "FATAL"; break;
     case SystemContent::JOB_START: out << "JOB_START"; break;
     case SystemContent::JOB_END: out << "JOB_END"; break;

--- a/csmd/src/daemon/src/connection_handling.cc
+++ b/csmd/src/daemon/src/connection_handling.cc
@@ -995,3 +995,22 @@ void csm::daemon::ConnectionHandling_compute::QueueFailoverMsg( csm::network::Ad
                     std::string( CSM_FAILOVER_MSG ));
   _EndpointList.SendTo( evData );
 }
+
+
+void csm::daemon::ConnectionHandling_compute::QueueResetMsg( csm::network::Address_sptr addr )
+{
+  if( addr == nullptr )
+    throw csm::daemon::Exception( "Trying reset msg to nullptr address." );
+
+  CSMLOG( csmd, debug ) << "Creating RESET message for Aggregator: " << addr->Dump() << " to signal secondary address.";
+  csm::network::MessageAndAddress evData;
+  evData.SetAddr( addr );
+  evData._Msg.Init( CSM_CMD_CONNECTION_CTRL,
+                    CSM_HEADER_INT_BIT,
+                    CSM_PRIORITY_DEFAULT,
+                    _MsgIdCandidate,
+                    0x0, 0x0,
+                    geteuid(), getegid(),
+                    std::string( CSM_RESET_MSG ));
+  _EndpointList.SendTo( evData );
+}

--- a/csmd/src/daemon/src/connection_handling.cc
+++ b/csmd/src/daemon/src/connection_handling.cc
@@ -957,6 +957,27 @@ csm::daemon::ConnectionHandling_compute::CheckConnectivityNoLock()
   return rc;
 }
 
+void csm::daemon::ConnectionHandling_compute::ResetPrimary()
+{
+  if( _SingleAggregator )
+    return;
+
+  if( _Connected == CONN_HDL_MASK_BOTH )
+  {
+    csm::network::Address_sptr addr = _DaemonState->GetActiveAddress();
+    if( addr->MakeKey() == _ScndKey )
+    {
+      CSMLOG( csmd, debug ) << "ResetPrimary() Resetting Primary agg to configured: " << _Primary->_Addr->Dump();
+      QueueResetMsg( _Secondary->_Addr );
+      QueueFailoverMsg( _Primary->_Addr );
+      _ComputeDaemonState->SetPrimaryAggregator( _Primary->_Addr );
+    }
+    else
+      CSMLOG( csmd, debug ) << "ResetPrimary() no action necessary. Primary agg already matches configured: " << _Primary->_Addr->Dump();
+  }
+}
+
+
 void csm::daemon::ConnectionHandling_compute::QueueFailoverMsg( csm::network::Address_sptr addr )
 {
   if( addr == nullptr )

--- a/csmd/src/daemon/src/csm_daemon_core.cc
+++ b/csmd/src/daemon/src/csm_daemon_core.cc
@@ -111,6 +111,9 @@ csm::daemon::CoreGeneric::InitInfrastructure(const csm::daemon::EventManagerNetw
   else
     throw csm::daemon::Exception("BUG: no timer-mgr defined. Cannot continue.");
 
+  csm::daemon::EventSink* systemSink = new csm::daemon::EventSinkSystem( _netMgr->GetConnectionHandling() );
+  _EventSinks.Add( csm::daemon::EVENT_TYPE_SYSTEM, systemSink );
+
   //csm::daemon::EventSourceEnvironmental* envSource = new csm::daemon::EventSourceEnvironmental();
   //AddEventSource(envSource, "ENVIRONMENTAL");
   // make sure to remove from source set and delete in destructor

--- a/csmd/src/daemon/src/csm_daemon_network_manager.cc
+++ b/csmd/src/daemon/src/csm_daemon_network_manager.cc
@@ -409,6 +409,16 @@ bool csm::daemon::EventManagerNetwork::ProcessNetCtlEvents()
             break;
         }
         break;
+      case csm::network::NET_CTL_RESET:  // compute tells us that it switched to a different primary aggregator
+        switch( _Config->GetRole() )
+        {
+          case CSM_DAEMON_ROLE_AGGREGATOR:
+            _DaemonState->SetConnectionTypeEP( info_itr->_Address, csm::daemon::ConnectionType::SECONDARY );
+            break;
+          default:
+            break;
+        }
+        break;
       case csm::network::NET_CTL_TIMEOUT:
       {
         csm::daemon::MessageContextContainer_sptr msgCtx = _MessageControl.FindMsgAndCtx( info_itr->_MsgId, true );

--- a/csmd/src/daemon/src/csm_daemon_network_manager.cc
+++ b/csmd/src/daemon/src/csm_daemon_network_manager.cc
@@ -416,6 +416,7 @@ bool csm::daemon::EventManagerNetwork::ProcessNetCtlEvents()
             _DaemonState->SetConnectionTypeEP( info_itr->_Address, csm::daemon::ConnectionType::SECONDARY );
             break;
           default:
+            CSMLOG( csmd, info ) << "NET_CTL_RESET event at non-aggregator daemon. Ignoring...";
             break;
         }
         break;

--- a/csmd/src/daemon/src/csm_daemon_state.cc
+++ b/csmd/src/daemon/src/csm_daemon_state.cc
@@ -771,7 +771,7 @@ void csm::daemon::DaemonStateAgent::SetPrimaryAggregator( const csm::network::Ad
   std::lock_guard<std::mutex> guard( _map_lock );
 
   if( primary == nullptr )
-    throw csm::daemon::Exception("BUG: SetPrimaryAggregator attemped with nullptr.");
+    throw csm::daemon::Exception("BUG: SetPrimaryAggregator attempted with nullptr.");
 
   CSMLOG( csmd, debug ) << "SetPrimaryAggregator(): current status: primary=" << ( _Aggregators[ 0 ] != nullptr ? _Aggregators[ 0 ]->Dump() : "NULL" )
       << " secondary=" << ( _Aggregators[ 1 ] != nullptr ? _Aggregators[ 1 ]->Dump() : "NULL" );

--- a/csmd/src/daemon/src/csm_daemon_state.cc
+++ b/csmd/src/daemon/src/csm_daemon_state.cc
@@ -760,12 +760,6 @@ void csm::daemon::DaemonStateAgent::InitActiveAddresses( )
   }
 }
 
-void csm::daemon::DaemonStateAgent::ResetPrimary()
-{
-  csm::daemon::Configuration *config = csm::daemon::Configuration::Instance();
-  SetPrimaryAggregator( config->GetConfiguredAggregatorAddress() );
-}
-
 void csm::daemon::DaemonStateAgent::SetPrimaryAggregator( const csm::network::Address_sptr primary )
 {
   std::lock_guard<std::mutex> guard( _map_lock );

--- a/csmd/src/daemon/src/csm_event_sinks/csm_sink_system.h
+++ b/csmd/src/daemon/src/csm_event_sinks/csm_sink_system.h
@@ -1,0 +1,81 @@
+/*================================================================================
+
+    csmd/src/daemon/src/csm_event_sinks/csm_sink_system.h
+
+  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+
+================================================================================*/
+
+#ifndef CSMD_SRC_DAEMON_SRC_CSM_EVENT_SINKS_CSM_SINK_SYSTEM_H_
+#define CSMD_SRC_DAEMON_SRC_CSM_EVENT_SINKS_CSM_SINK_SYSTEM_H_
+
+#include <queue>
+#include <mutex>
+
+#include "include/csm_system_event.h"
+#include "include/csm_event_sink.h"
+#include "include/connection_handling.h"
+
+#include "logging.h"
+
+namespace csm {
+namespace daemon {
+
+class EventSinkSystem: public csm::daemon::EventSink
+{
+
+public:
+  EventSinkSystem( csm::daemon::ConnectionHandling *aConnHdlg )
+  : _ConnHandling( aConnHdlg )
+  { }
+  
+  virtual ~EventSinkSystem()
+  { }
+  
+  virtual int PostEvent( const csm::daemon::CoreEvent &aEvent )
+  {
+    //LOG(csmd, info) << "EventSinkTimer: PostEvent...";
+    const SystemEvent *event = dynamic_cast<const SystemEvent *>( &aEvent );
+    if( event == nullptr )
+      return 0;
+
+    csm::daemon::SystemContent sysdata = event->GetContent();
+
+    LOG(csmd, trace ) << "EventSinkSystem: Processing event " << sysdata.GetSignalType();
+    
+    switch( sysdata.GetSignalType() )
+    {
+      case csm::daemon::SystemContent::RESET_AGG:
+      {
+        csm::daemon::ConnectionHandling_compute *comp_ch = dynamic_cast<csm::daemon::ConnectionHandling_compute*>( _ConnHandling );
+        if( comp_ch != nullptr )
+          comp_ch->ResetPrimary();
+        break;
+      }
+      default:
+        break;
+    }
+
+    return 0;
+  }
+
+  virtual csm::daemon::CoreEvent* FetchEvent()
+  {
+    return nullptr;
+  }
+
+private:
+  csm::daemon::ConnectionHandling *_ConnHandling;
+};
+
+}  // namespace daemon
+} // namespace csm
+
+#endif /* CSMD_SRC_DAEMON_SRC_CSM_EVENT_SINKS_CSM_SINK_SYSTEM_H_ */

--- a/csmd/src/daemon/src/csmi_request_handler/csm_ctrl_cmd_handler.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_ctrl_cmd_handler.cc
@@ -80,6 +80,23 @@ void CSM_CTRL_CMD_HANDLER::Process( const csm::daemon::CoreEvent &aEvent,
     reply_payload.append( GetDaemonState()->DumpMapSize() );
   }
 
+  if( option.get_agg_reset() )
+  {
+    LOG( csmd, info ) << "Resetting Primary aggregator on user request.";
+    if( _handlerOptions.GetRole() != CSM_DAEMON_ROLE_AGENT )
+      reply_payload.append("Primary aggregator reset only applicable to compute daemons.\n");
+    else
+    {
+      csm::daemon::DaemonStateAgent *dsa = dynamic_cast<csm::daemon::DaemonStateAgent*>( _handlerOptions.GetDaemonState() );
+      if( dsa != nullptr )
+      {
+        csm::daemon::SystemContent content(csm::daemon::SystemContent::RESET_AGG);
+        postEventList.push_back( new csm::daemon::SystemEvent( content, csm::daemon::EVENT_TYPE_SYSTEM, nullptr ) );
+        reply_payload.append("Successfully created trigger for daemon to reset primary aggregator. Please check the daemon log.\n");
+      }
+    }
+  }
+
   msg.SetData(reply_payload );
   msg.SetResp();
   msg.CheckSumUpdate();

--- a/csmd/src/daemon/src/csmi_request_handler/ctrl_cmd_option.h
+++ b/csmd/src/daemon/src/csmi_request_handler/ctrl_cmd_option.h
@@ -38,6 +38,7 @@ public:
     _log_csmapi = utility::bluecoral_sevs::NUM_SEVERITIES;
     _dump_perf_data = false;
     _dump_mem_usage = false;
+    _agg_reset = false;
   }
   
 private:
@@ -53,6 +54,7 @@ private:
     ar & _log_csmapi;
     ar & _dump_perf_data;
     ar & _dump_mem_usage;
+    ar & _agg_reset;
   }
   
 public:
@@ -92,6 +94,9 @@ public:
   void set_dump_mem_usage() { _dump_mem_usage = true;}
   bool get_dump_mem_usage() { return _dump_mem_usage;}
  
+  void set_agg_reset() { _agg_reset = true; }
+  bool get_agg_reset() const { return _agg_reset; }
+
 private:
   utility::bluecoral_sevs _log_csmdb;
   utility::bluecoral_sevs _log_csmnet;
@@ -100,6 +105,7 @@ private:
   utility::bluecoral_sevs _log_csmapi;
   bool _dump_perf_data;
   bool _dump_mem_usage;
+  bool _agg_reset;
 
 };
 

--- a/csmd/src/daemon/tests/csm_ctrl_cmd.cc
+++ b/csmd/src/daemon/tests/csm_ctrl_cmd.cc
@@ -113,6 +113,9 @@ int ParseCommandLineOptions( int argc, char **argv, CtrlCmdOption &o_cmd_option 
         ("log.csmapi",
             po::value<std::string>(&log_csmapi),
             "Specify the severity level ")
+
+        ("agg.reset",
+            "Cause a compute daemon to reset the current primary connection to the configured aggregator. ")
     ;
 
   po::variables_map vm;
@@ -207,7 +210,13 @@ int ParseCommandLineOptions( int argc, char **argv, CtrlCmdOption &o_cmd_option 
     o_cmd_option.set_dump_mem_usage();
     count++;
   }
-    
+
+  if( vm.count( "agg.reset"))
+  {
+    o_cmd_option.set_agg_reset();
+    count++;
+  }
+
   return count;
 
 }

--- a/csmnet/include/csm_network_header.h
+++ b/csmnet/include/csm_network_header.h
@@ -69,6 +69,13 @@
 #define CSM_FAILOVER_MSG "FAIL0VER"
 
 
+/** @def CSM_RESET_MSG
+ * @brief String to be sent between compute and aggregator to
+ *  signal a reset of primary connection to secondary
+ */
+#define CSM_RESET_MSG "R3S3T"
+
+
 /** @def CSM_RESTART_MSG
  * @brief String to be sent between compute and aggregator to
  * signal a restarted or "fresh from disconnect" state

--- a/csmnet/src/CPP/network_ctrl_path.h
+++ b/csmnet/src/CPP/network_ctrl_path.h
@@ -33,6 +33,7 @@ typedef enum
   NET_CTL_DISCONNECT,
   NET_CTL_FAILOVER,
   NET_CTL_RESTARTED,
+  NET_CTL_RESET,
   NET_CTL_FATAL,
   NET_CTL_OTHER,
   NET_CTL_MAX
@@ -50,6 +51,7 @@ operator<<( stream &out, const csm::network::NetworkCtrlEventType &aType )
     case NET_CTL_DISCONNECT: out << "NET_CTL_DISCONNECT"; break;
     case NET_CTL_FAILOVER:   out << "NET_CTL_FAILOVER";   break;
     case NET_CTL_RESTARTED:  out << "NET_CTL_RESTARTED";  break;
+    case NET_CTL_RESET:      out << "NET_CTL_RESET";      break;
     case NET_CTL_FATAL:      out << "NET_CTL_FATAL";      break;
     case NET_CTL_OTHER:      out << "NET_CTL_OTHER";      break;
     default:                 out << "ERROR: !!!OUT-OF-RANGE!!!";

--- a/csmnet/src/CPP/reliable_msg.cc
+++ b/csmnet/src/CPP/reliable_msg.cc
@@ -213,6 +213,11 @@ retry:
           LOG( csmnet, debug ) << "Received ControlMsg from " << aMsgAddr.GetAddr()->Dump() << " to RESTART";
           AddCtrlEvent( csm::network::NET_CTL_RESTARTED, aMsgAddr.GetAddr() );
         }
+        if( 0 == aMsgAddr._Msg.GetData().compare( CSM_RESET_MSG ) )
+        {
+          LOG( csmnet, debug ) << "Received ControlMsg from " << aMsgAddr.GetAddr()->Dump() << " to RESET connection status.";
+          AddCtrlEvent( csm::network::NET_CTL_RESET, aMsgAddr.GetAddr() );
+        }
         ret = 0; // don't expose this message, the network event is enough
         break;
       }


### PR DESCRIPTION
This adds a new feature/option to csm_ctrl_cmd:
```
csm_ctrl_cmd --agg.reset
```
This requests a compute daemon to reset it's primary/secondary connections in case the primary/secondary had changed because of aggregator fails/restarts etc.

A few details for whoever is interested:
* new internal ctrl msg between compute and agg to tell a primary agg to reset connection status to secondary - was required because both aggregators stay up and therefore this is not possible to be processed like a failover
* added a system event (RESET_AGG) to allow API handlers to trigger system events (extension of former JOB_START/STOP event handling); this makes it easier to process additional system events in the future
* existing ctrl-cmd extended to trigger the RESET_AGG system event; note: as with the existing ctrl-cmd this needs to be called on the same node as the compute daemon that is to be reset.


For testing, I'll create an issue that describes how to test.

(Apologies for mixing in an extra commit that fixes a typo in one of the files that has additional changes. I could have buried it within the other commits, but I prefer to keep things contained. ;-) )