### PR TITLE
Cgroup improvement, added additional task migration

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastResponder.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastResponder.h
@@ -27,7 +27,7 @@
 #include "CSMIMcast.h"
 #include "CSMIMcastPrototypes.h"
 
-#define ERR_MSG_DIVIDE "---- End Remote Errors ----"
+#define ERR_MSG_DIVIDE " | "
 #define STATE_NAME "McastResponder:"
 #include "../csmi_network_message_state.h"
 

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
@@ -61,7 +61,7 @@
 #define KB_TO_B(kB) kB * 1024
 
 /// Enables a check for development enviroment.
-//#define VM_DEVELOPMENT 0
+#define VM_DEVELOPMENT 1
 
 namespace csm {
 namespace daemon {
@@ -266,11 +266,11 @@ void CGroup::SetupCGroups(int64_t cores)
             controller < csm_enum_max(csmi_cgroup_controller_t);
             ++controller )
         {
-            CreateCGroup(csmi_cgroup_controller_t_strs[controller], CGroup::SYSTEM_CGROUP);
+            std::string cg = CreateCGroup(csmi_cgroup_controller_t_strs[controller], CGroup::SYSTEM_CGROUP);
             MigrateTasks( 
                 std::string(CGroup::CONTROLLER_DIR)
                     .append(csmi_cgroup_controller_t_strs[controller]).append("/"), 
-                sysCpuset );
+                cg );
         }
 
         // TODO Compute System CGroup limit.
@@ -934,6 +934,7 @@ uint64_t CGroup::MigrateTasks(
     const std::string& targetGroup ) const
 {
     LOG( csmapi, trace ) << _LOG_PREFIX "MigrateTasks Enter";
+    LOG( csmapi, debug) << sourceGroup << "  " <<  targetGroup;
 
     // Build the tasks strings.
     std::string sourceTasks(sourceGroup);

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
@@ -61,7 +61,7 @@
 #define KB_TO_B(kB) kB * 1024
 
 /// Enables a check for development enviroment.
-#define VM_DEVELOPMENT 1
+//#define VM_DEVELOPMENT 1
 
 namespace csm {
 namespace daemon {

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
@@ -255,18 +255,23 @@ void CGroup::SetupCGroups(int64_t cores)
     {
         const std::string sysCpuset = CreateCGroup( CGroup::CPUSET, CGroup::SYSTEM_CGROUP );
 
+        WriteToParameter(        CPUS, sysCpuset,  sysCores.c_str(),  sysCores.size() );
+        WriteToParameter( MEM_MIGRATE, sysCpuset, &ENABLE_CONTROLLER, sizeof(ENABLE_CONTROLLER));
+ 
+        CopyParameter( MEMS, CGroup::CPUSET_DIR, sysCpuset );
+        MigrateTasks( CGroup::CPUSET_DIR, sysCpuset );
+
+        // Migrate the tasks.
         for( uint32_t controller = CG_CPUSET + 1;
             controller < csm_enum_max(csmi_cgroup_controller_t);
             ++controller )
         {
             CreateCGroup(csmi_cgroup_controller_t_strs[controller], CGroup::SYSTEM_CGROUP);
+            MigrateTasks( 
+                std::string(CGroup::CONTROLLER_DIR)
+                    .append(csmi_cgroup_controller_t_strs[controller]).append("/"), 
+                sysCpuset );
         }
-
-        WriteToParameter(        CPUS, sysCpuset,  sysCores.c_str(),  sysCores.size() );
-        WriteToParameter( MEM_MIGRATE, sysCpuset, &ENABLE_CONTROLLER, sizeof(ENABLE_CONTROLLER));
-
-        CopyParameter( MEMS, CGroup::CPUSET_DIR, sysCpuset );
-        MigrateTasks( CGroup::CPUSET_DIR, sysCpuset );
 
         // TODO Compute System CGroup limit.
     }


### PR DESCRIPTION
Implemented a new feature which migrates tasks to the non cpuset system cgroup when the allocation is created. The following cgroups should all have the same number of pids in the `tasks` file after the allocation is created:

* `/sys/fs/cgroup/cpuset/csm_system`
* `/sys/fs/cgroup/memory/csm_system`
* `/sys/fs/cgroup/devices/csm_system`
* `/sys/fs/cgroup/cpuacct/csm_system`


Cgroup tests should be modified to check this in the near future.
