### PR TITLE
Increased rpm version to 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (ibm)
 
 set(BUILDID_RELEASE    1)
 set(BUILDID_CUMULFIXID 1)
-set(BUILDID_EFIXID     0)
+set(BUILDID_EFIXID     1)
 
 execute_process(
   COMMAND git rev-list --count HEAD


### PR DESCRIPTION
I can merge once the change is approved by @fpizzano and @tgooding. 

The changes CSM is planning for the next release are consistent with incrementing the EFIXID portion of the rpm version (1.1.0 -> 1.1.1). Is this also an appropriate version increase from the perspective of the burst buffer team?