### PR TITLE
Increased rpm version to 1.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (ibm)
 
 set(BUILDID_RELEASE    1)
 set(BUILDID_CUMULFIXID 1)
-set(BUILDID_EFIXID     1)
+set(BUILDID_EFIXID     2)
 
 execute_process(
   COMMAND git rev-list --count HEAD


### PR DESCRIPTION
The CAST 1.1.1 branch was created yesterday. @fpizzano and I would like to bump the version associated with the master branch to 1.1.2 as a place holder for the next official release. When the next official release plan finalizes, we will revisit whether 1.1.2 is appropriate.