### PR TITLE
csm: change default netmgr polling loops to 10 on compute daemons

### DIFF
--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -1063,7 +1063,12 @@ void Configuration::CreateThreadPool()
       enabled = true;
     }
     else
-      _Tweaks._NetMgr_polling_loops = 1000;
+    {
+      if( _Role == CSM_DAEMON_ROLE_AGENT )
+        _Tweaks._NetMgr_polling_loops = 10;
+      else
+        _Tweaks._NetMgr_polling_loops = 1000;
+    }
 
     uint_val = GetValueInConfig( std::string("csm.tuning.dcgm_update_interval_s") );
     if( ! uint_val.empty() )


### PR DESCRIPTION
The jitter mitigation experiments suggest to set a default of 10 for the number of loops that the netmgr would stay alive looking for more potential work before going to sleep.

This pull request changes the default for compute nodes to 10 so that the default reflects the recommended value.

In order to test, one would have to perform the jitter tests because these numbers are not logged anywhere yet. Let me know if it's desired to add logging for these numbers/settings.