### PR TITLE
csm: fix client-to-daemon large message protocol

### DIFF
--- a/csmd/src/daemon/src/csm_daemon_network_manager.cc
+++ b/csmd/src/daemon/src/csm_daemon_network_manager.cc
@@ -577,7 +577,15 @@ bool csm::daemon::EventManagerNetwork::EndpointSendActivity()
   }
   if( ! data_sptr->_Msg.Validate() )
   {
-    CSMLOG(csmd, error) << "BUG: Found invalid outbound message! Returning send error to handler.";
+    if( data_sptr->_Msg.GetDataLen() >= CSM_PAYLOAD_LIMIT )
+    {
+      CSMLOG(csmd, warning) << "Outbound message is too long (limit=" << CSM_PAYLOAD_LIMIT-1
+        << ") Returning send error to handler.";
+    }
+    else
+    {
+      CSMLOG(csmd, error) << "BUG: Corrupted or invalid outbound message! Returning send error to handler.";
+    }
     QueueInboundErrorEvent( data_sptr, msgContext, "Send: Invalid Message", EBADMSG );
     return true;
   }

--- a/csmi/src/common/src/csmi_common_utils.c
+++ b/csmi/src/common/src/csmi_common_utils.c
@@ -12,12 +12,12 @@
     restricted by GSA ADP Schedule Contract with IBM Corp.
 
 ================================================================================*/
-#include "csmi/src/common/include/csmi_common_utils.h"
-#include "csmi/src/common/include/csmi_serialization.h"
-#include "csmi/src/common/include/csmi_api_internal.h"
 #include "csmutil/include/csmutil_logging.h"
 #include "csmnet/src/C/csm_network_internal_api_c.h"
 #include "csmi/include/csm_api_common.h"
+#include "csmi/src/common/include/csmi_common_utils.h"
+#include "csmi/src/common/include/csmi_serialization.h"
+#include "csmi/src/common/include/csmi_api_internal.h"
 
 #include <assert.h>
 #include <pthread.h>

--- a/csmnet/src/C/csm_network_internal_api_c.h
+++ b/csmnet/src/C/csm_network_internal_api_c.h
@@ -16,6 +16,9 @@
 #ifndef __CSM_NETWORK_INTERNAL_API_C_H__
 #define __CSM_NETWORK_INTERNAL_API_C_H__
 
+#include "csm_network_header.h"
+#include "csm_network_msg_c.h"
+
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -26,9 +29,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/time.h>
-
-#include "csm_network_header.h"
-#include "csm_network_msg_c.h"
 
 #ifndef DGRAM_PAYLOAD_MAX
 #define DGRAM_PAYLOAD_MAX ( 65535 )

--- a/csmnet/src/CPP/endpoint_buffer.h
+++ b/csmnet/src/CPP/endpoint_buffer.h
@@ -95,10 +95,12 @@ public:
       throw csm::network::ExceptionProtocol("Buffer State protocol failure: Buffer overflow.");
     else
     {
-      LOG( csmnet, trace ) << "Updating buffer. recvd=" << i_Skip;
       _DataLen += i_Skip;
       _BufferTail += i_Skip;
       _BufferState = Transition();
+      LOG( csmnet, trace ) << "Updating buffer. recvd=" << i_Skip
+          << " data=" << _DataLen
+          << " new state=" << _BufferState;
     }
   }
 
@@ -111,6 +113,7 @@ protected:
     _BufferHead = _BufferBase;
     _BufferTail = _BufferBase;
     _BufferState = BUFFER_EMPTY;
+    LOG( csmnet, trace ) << "Reset buffer.";
   }
 
   inline EndpointBufferStates Transition() const
@@ -166,6 +169,7 @@ protected:
         if( ProcessedData() == _DataLen )
           Reset();
         _BufferState = Transition();
+        LOG( csmnet, trace ) << "Updating buffer. new state=" << _BufferState;
         break;
       }
       case BUFFER_MSG_INVALID:


### PR DESCRIPTION
We noticed that the large-msg protocol for messages from clients to daemon was not functioning as expected. It caused the daemon to receive several invalid messages and the client to get disconnected.
This PR fixes the protocol.

@fpizzano This might be a candidate for a hotfix since it might cause trouble for anything that tries to send CSM API requests larger than 128k.

Will open an issue to add a regression test.