### PR TITLE
hostname and command configuration improvements

### DIFF
--- a/csmconf/csm_aggregator.cfg
+++ b/csmconf/csm_aggregator.cfg
@@ -11,7 +11,7 @@
             "format"                    :   "[AGG]%TimeStamp% %SubComponent%::%Severity% | %Message%",
             "consoleLog"                :   false,
             "fileLog"                   :   "/var/log/ibm/csm/csm_aggregator.log",
-            "__rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 1000000000 bytes is ~1GB",
+            "#rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 1000000000 bytes is ~1GB",
             "rotationSize"              :   1000000000,
             "default_sev"               :   "warning",
             "csmdb"                     :   "info",
@@ -27,8 +27,8 @@
             "heartbeat_interval" : 15,
             "local_client_listen" :
             {
-                "__socket_comment_1"  : "Use /run/csmd.sock by default.",
-                "__socket_comment_2"  : "Use /run/csmd_agg.sock when running a Master and Aggregator daemon in the same node.",
+                "#socket_comment_1"  : "Use /run/csmd.sock by default.",
+                "#socket_comment_2"  : "Use /run/csmd_agg.sock when running a Master and Aggregator daemon in the same node.",
                 "socket"              : "/run/csmd.sock",
                 "permissions"         : 777,
                 "group"               : ""

--- a/csmconf/csm_api.cfg
+++ b/csmconf/csm_api.cfg
@@ -1,4 +1,5 @@
 {
+   "#comment_1" : "This will be ignored",
    "csm_allocation_create" : 120,
    "csm_allocation_delete" : 120,
    "csm_allocation_update_state" : 120,

--- a/csmconf/csm_compute.cfg
+++ b/csmconf/csm_compute.cfg
@@ -12,7 +12,7 @@
             "consoleLog"                :   false,
             "sysLog"                    :   true,
             "fileLog"                   :   "/var/log/ibm/csm/csm_compute.log",
-            "__rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 100000000 bytes is ~100MB",
+            "#rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 100000000 bytes is ~100MB",
             "rotationSize"              :   100000000,
             "default_sev"               :   "warning",
             "csmdb"                     :   "info",

--- a/csmconf/csm_master.cfg
+++ b/csmconf/csm_master.cfg
@@ -12,7 +12,7 @@
             "consoleLog"                :   false,
             "sysLog"                    :   true,
             "fileLog"                   :   "/var/log/ibm/csm/csm_master.log",
-            "__rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 1000000000 bytes is ~1GB",
+            "#rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 1000000000 bytes is ~1GB",
             "rotationSize"              :   1000000000,
             "default_sev"               :   "warning",
             "csmdb"                     :   "info",

--- a/csmconf/csm_utility.cfg
+++ b/csmconf/csm_utility.cfg
@@ -12,7 +12,7 @@
             "consoleLog"                :   false,
             "sysLog"                    :   true,
             "fileLog"                   :   "/var/log/ibm/csm/csm_utility.log",
-            "__rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 100000000 bytes is ~100MB",
+            "#rotationSize_comment_1"  :   "Maximum size (in bytes) of the log file, 100000000 bytes is ~100MB",
             "rotationSize"              :   100000000,
             "default_sev"               :   "warning",
             "csmdb"                     :   "info",

--- a/csmd/include/csm_daemon_config.h
+++ b/csmd/include/csm_daemon_config.h
@@ -74,7 +74,7 @@ enum HostNameConfigState_t
 {
   HOST_CONFIG_NONE,
   HOST_CONFIG_VALID,
-  HOST_CONFIG_EMPTY
+  HOST_CONFIG_INVALID
 };
 
 class Configuration

--- a/csmd/include/csm_daemon_config.h
+++ b/csmd/include/csm_daemon_config.h
@@ -53,6 +53,8 @@
 #define ENVIRONMENTAL_GRANULARITY_DEFAULT "00:00:01"
 #define ENVIRONMENTAL_GRANULARITY_MINIMUM "00:00:00.50"
 
+#define CONFIGURATION_HOSTNAME_NONE ("NONE")
+
 namespace pt = boost::property_tree;
 namespace po = boost::program_options;
 
@@ -67,6 +69,13 @@ namespace csm {
 namespace daemon {
 
 typedef std::pair<unsigned, csm::db::DBConnInfo> DBDefinitionInfo;
+
+enum HostNameConfigState_t
+{
+  HOST_CONFIG_NONE,
+  HOST_CONFIG_VALID,
+  HOST_CONFIG_EMPTY
+};
 
 class Configuration
 {
@@ -202,6 +211,7 @@ private:
 
   // retrieve hostname from xCAT
   void SetHostname();
+  HostNameConfigState_t HostNameValidate( std::string host_val );
   
   std::string GetUnixServerSocket() const ;
   mode_t GetLocalSocketPermissions() const;

--- a/csmd/src/daemon/include/csm_api_acl.h
+++ b/csmd/src/daemon/include/csm_api_acl.h
@@ -169,6 +169,10 @@ private:
           BOOST_FOREACH(pt::ptree::value_type &api_list, list.second)
           {
             std::string api = api_list.second.data();
+
+            if( api.find("#") != std::string::npos )
+              continue;
+
             boost::algorithm::to_lower(api);
             if (!api.empty())
             {

--- a/csmd/src/daemon/include/csm_api_config.h
+++ b/csmd/src/daemon/include/csm_api_config.h
@@ -70,6 +70,10 @@ private:
       BOOST_FOREACH(pt::ptree::value_type &list, auth_tree)
       {
         std::string key = list.first.data();
+
+        if( key.find("#") != std::string::npos )
+          continue;
+
         boost::algorithm::to_lower(key);
 
         csmi_cmd_t cmd = csmi_cmd_get( key.c_str() );

--- a/csmd/src/daemon/src/csm_bds_manager.cc
+++ b/csmd/src/daemon/src/csm_bds_manager.cc
@@ -90,7 +90,8 @@ csm::daemon::EventManagerBDS::EventManagerBDS( const csm::daemon::BDS_Info &i_BD
   _Thread = new boost::thread( BDSManagerMain, this );
   _IdleRetryBackOff.SetThread( _Thread );
 
-  Connect();
+  if( BDSActive() )
+    Connect();
   Unfreeze();
 
 }
@@ -102,11 +103,12 @@ csm::daemon::EventManagerBDS::Connect()
   memset( &hints, 0, sizeof( struct addrinfo ) );
   hints.ai_family = AF_INET;
   hints.ai_socktype = SOCK_STREAM;
+  int tmp_errno = 0;
 
-  if( getaddrinfo( _BDS_Info.GetHostname().c_str(), _BDS_Info.GetPort().c_str(), &hints, &clist ) != 0 )
+  if( (tmp_errno = getaddrinfo( _BDS_Info.GetHostname().c_str(), _BDS_Info.GetPort().c_str(), &hints, &clist )) != 0 )
   {
     CSMLOG( csmd, warning ) << "Unable to collect address info for " << _BDS_Info.GetHostname() << ":" << _BDS_Info.GetPort()
-        << " error: " << strerror( errno );
+        << " error: " << gai_strerror( tmp_errno );
     return false;
   }
 


### PR DESCRIPTION
This pull request contains a small set of adjustments to handle configured host names and introduce 'NONE' as an option to ignore a host name setting (currently for secondary aggregator or BDS).

For example, a 'clean' single-aggregator config would look like this:
```
            "aggregatorB" :  {
                "host": "NONE",
                ...
```
It also enables to use comments in csm_api.cfg: any command that contains a # will be ignored. See example:

```
{
   "# comment" : "more comment",
   "also com#ment" : "possible but not recommended",
   "csm_allocation_create" : 500,
   "csm_allocation_delete" : 60,
   ...
```

We might want test cases that cover the 3 cases:
* valid entry to enable the config
* invalid entry that causes a warning
* NONE option to explicitly disable