### PR TITLE
Fixing the clang build INTMAX_MAX => INT_MAX

### DIFF
--- a/csmd/src/daemon/include/bds_info.h
+++ b/csmd/src/daemon/include/bds_info.h
@@ -59,7 +59,7 @@ public:
     // check if the port is valid
     errno = 0;
     int pn = strtoimax( port.c_str(), nullptr, 10 );
-    if(( errno == ERANGE ) || ( pn == INTMAX_MAX ) || ( pn <= 0 ) || ( pn > 65535 ))
+    if(( errno == ERANGE ) || ( pn == INT_MAX ) || ( pn <= 0 ) || ( pn > 65535 ))
       throw csm::daemon::Exception("Invalid port found while initializing BDS_info");
 
     _Port = port;


### PR DESCRIPTION
Looks like we we comparing the int64 constant instead of the int32 constant.
Issue #131