### PR TITLE
extensions and improvements to logging of multicast and inventory

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csmi_agg_mtc_handler.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_agg_mtc_handler.cc
@@ -38,9 +38,8 @@ void CSMI_AGG_MTC_HANDLER::Process( const csm::daemon::CoreEvent &aEvent, std::v
       if( reqEvent != nullptr )
       {
         csm::network::MessageAndAddress msgAddr = reqEvent->GetContent();
-        CSMLOG( mtccomp, warning ) << "Request timeout detected. cmd="
-          << csm::network::cmd_to_string( msgAddr._Msg.GetCommandType() )
-          << " msgId=" << msgAddr._Msg.GetMessageID();
+        CSMLOG( mtccomp, warning ) << "[" << msgAddr._Msg.GetReservedID() << "] "
+          << csm::network::cmd_to_string( msgAddr._Msg.GetCommandType() ) << ": Request timeout detected ";
         postEventList.push_back( CreateErrorEvent(ETIMEDOUT, "Request timeout detected.", msgAddr ));
         return;
       }
@@ -88,7 +87,9 @@ void CSMI_AGG_MTC_HANDLER::Process( const csm::daemon::CoreEvent &aEvent, std::v
         postEventList.push_back( CreateNetworkEvent( inMsg, _AbstractMaster ) );
 
         const int timeout = csm_get_client_timeout( inMsg.GetCommandType() ) - 1000;
-        CSMLOG( mtccomp, debug ) << "Setting timeout to " << timeout << " milliseconds.";
+        CSMLOG( mtccomp, debug ) << "[" << inMsg.GetReservedID() << "] "
+            << csm::network::cmd_to_string( inMsg.GetCommandType() )
+            << "Setting timeout to " << timeout << " milliseconds.";
 
         postEventList.push_back( CreateTimerEvent(timeout, context, 1 ) );
         context->SetAuxiliaryId( 1 );
@@ -172,8 +173,10 @@ void CSMI_AGG_MTC_HANDLER::Process( const csm::daemon::CoreEvent &aEvent, std::v
         if( responses > 0 )
         {
           const int timeout = csm_get_agg_timeout( inMsg.GetCommandType());
-          CSMLOG( mtccomp, info ) << "Expecting " << responses <<
-            " responses. Setting timeout to " << timeout << " milliseconds.";
+          CSMLOG( mtccomp, info ) << "[" << inMsg.GetReservedID() << "] "
+              << csm::network::cmd_to_string( inMsg.GetCommandType() )
+              << " Expecting " << responses
+              << " responses. Setting timeout to " << timeout << " milliseconds.";
 
           postEventList.push_back( CreateTimerEvent(timeout, context, responses-1 ) );
           context->SetAuxiliaryId( responses );

--- a/csmd/src/inv/src/inv_aggregator_handler.cc
+++ b/csmd/src/inv/src/inv_aggregator_handler.cc
@@ -152,7 +152,7 @@ void INV_AGGREGATOR_HANDLER::CheckReplyFromMaster(const csm::daemon::CoreEvent &
   }
   else
   {
-    LOG(csmd, info) << "INV_AGGREGATOR_HANDLER::CheckReplyFromMaster(): Got a reply from Master";
+    LOG(csmd, debug) << "INV_AGGREGATOR_HANDLER::CheckReplyFromMaster(): Got a reply from Master";
   }
 
   return;
@@ -239,7 +239,7 @@ void INV_AGGREGATOR_HANDLER::Process( const csm::daemon::CoreEvent &aEvent, std:
           SendInventory( nInfo->_LastInventory,
                          CreateContext((void *)this, 0),
                          postEventList);
-          LOG(csmd, info) << "INV_AGGREGATOR_HANDLER: Sending a new node inventory to Master";
+          LOG(csmd, info) << "INV_AGGREGATOR_HANDLER: Sending a new node inventory (" << nInfo->_NodeID << ") to Master";
         }
         else
         {
@@ -305,7 +305,7 @@ void INV_AGGREGATOR_HANDLER::Process( const csm::daemon::CoreEvent &aEvent, std:
             SendInventory( content._Msg,
                            CreateContext((void *)this, 0),
                            postEventList);
-            LOG(csmd, info) << "INV_AGGREGATOR_HANDLER: Sending a new node inventory to Master";
+            LOG(csmd, info) << "INV_AGGREGATOR_HANDLER: Sending a new node inventory (" << nInfo->_NodeID << ") to Master";
           }
           else
             nInfo->EnableSendInventory();


### PR DESCRIPTION
 * adds the requestID and csm command type to the MTC handler msgs to improve tracking of requests traveling through the csm infrastructure.
 * moves a log line of the inventory handler from info to debug level because this unlikely has any informational value.
 * adds node name to the inventory msg logging