### PR TITLE
Feature/bds access

### DIFF
--- a/csmd/src/daemon/src/csm_bds_manager.cc
+++ b/csmd/src/daemon/src/csm_bds_manager.cc
@@ -148,7 +148,26 @@ csm::daemon::EventManagerBDS::Connect()
 bool
 csm::daemon::EventManagerBDS::CheckConnectivity()
 {
-  return (_Socket > 0 );
+  bool alive = (_Socket > 0 );
+  if( ! alive )
+  {
+    CSMLOG( csmd, debug ) << "Connection to BDS is down.";
+    return alive;
+  }
+
+  char buf[ 8 ];
+  errno = 0;
+  ssize_t rc = recv( _Socket, buf, 1, MSG_DONTWAIT );
+  int terrno = errno;
+  alive = (( rc > 0 ) || ( terrno == EAGAIN ));
+  if( ! alive )
+  {
+    CSMLOG( csmd, warning ) << "Connection to BDS failed: rc=" << rc << ":"<< terrno;
+    close( _Socket );
+    _Socket = 0;
+  }
+
+  return alive;
 }
 
 bool
@@ -159,7 +178,7 @@ csm::daemon::EventManagerBDS::SendData( const std::string data )
   ssize_t remain = data.length();
   while(( rc >= 0 ) && ( rc < remain ))
   {
-    rc = write( _Socket, data.c_str() + done, remain );
+    rc = send( _Socket, data.c_str() + done, remain, 0 );
     if( rc > 0 )
     {
       remain -= rc;

--- a/csmd/src/daemon/src/csm_bds_manager.cc
+++ b/csmd/src/daemon/src/csm_bds_manager.cc
@@ -69,7 +69,7 @@ void BDSManagerMain( csm::daemon::EventManagerBDS *aMgr )
       }
       else
       {
-        CSMLOG( csmd, info ) << "Error sending to BDS: " << content;
+        CSMLOG( csmd, warning ) << "Failed sending to BDS: " << content.substr(0, 50 ) << ( content.length() > 49 ? "..." : "" );
       }
     }
   }


### PR DESCRIPTION
This fixes a critical problem with the BDS connection. Without this fix, if the connection fails, the bdsmgr component of csmd will not reconnect and will not even detect the failed connection properly in all cases.
This also updates the bds log msg in case the sending of data fails.
