### PR TITLE
Overhaul of CSM FVT for hcdiag: First pass for basic bucket 

### DIFF
--- a/csmtest/buckets/basic/hcdiag.sh
+++ b/csmtest/buckets/basic/hcdiag.sh
@@ -27,7 +27,15 @@ fi
 
 # Local Variables
 LOG=${LOG_PATH}/buckets/basic/hcdiag.log
+TEMP_LOG=${LOG_PATH}/buckets/basic/hcdiag.log
 HC_DIAG_PATH=/opt/ibm/csm/hcdiag
+
+if [ -f "${BASH_SOURCE%/*}/../../include/functions.sh" ]
+then
+        . "${BASH_SOURCE%/*}/../../include/functions.sh"
+else
+        echo "Could not find functions file expected at /../../include/functions.sh, exitting."
+fi
 
 echo "------------------------------------------------------------" >> ${LOG}
 echo "                 Starting hcdiag Bucket" >> ${LOG}
@@ -35,137 +43,111 @@ echo "------------------------------------------------------------" >> ${LOG}
 date >> ${LOG}
 echo "------------------------------------------------------------" >> ${LOG}
 
-echo "CALLING hcdiag test ppping..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test ppping --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_ppping.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\nppping FAILED"
-fi
+# Test Case 1: ppping
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test ppping --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 1: ppping"
 
-echo "CALLING hcdiag test test_memsize..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test test_memsize --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_test_memsize.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\ntest_memsize FAILED"
-fi
+# Test Case 2: chk-cpu
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 2: chk-cpu"
 
-echo "CALLING hcdiag test test_simple..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test test_simple --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_test_simple.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\ntest_simple FAILED"
-fi
+# Test Case 3: chk-cpu-count
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu-count --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 3: chk-cpu-count"
 
-echo "CALLING hcdiag hxecache..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test hxecache --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_hxecache.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\nhxecache FAILED"
-fi
+# Test Case 4: chk-csm-health
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-csm-health --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 4: chk-csm-health"
 
-echo "CALLING hcdiag hxecpu..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test hxecpu --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_hxecpu.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\nhxecpu FAILED"
-fi
+# Test Case 5: chk-free-memory
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-free-memory --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 5: chk-free-memory"
 
-echo "CALLING hcdiag hxefpu64..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test hxefpu64 --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_hxefpu64.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\nhxefpu64 FAILED"
-fi
+# Test Case 6: chk-led
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-led --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 2: chk-cpu"
 
-echo "CALLING hcdiag hxemem64..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test hxemem64 --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_hxemem64.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\nhxemem64 FAILED"
-fi
+# Test Case 7: chk-boot-time
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-boot-time --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 7: chk-boot-time"
 
-echo "CALLING hcdiag daxpy..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test daxpy --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_daxpy.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\ndaxpy FAILED"
-fi
+# Test Case 8: chk-noping
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-noping --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 8: chk-noping"
 
-echo "CALLING hcdiag dcgm_diag..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test dcgm-diag --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_dcgm_diag.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\ndcgm_diag FAILED"
-fi
+# Test Case 9: chk-sys-firmware
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-sys-firmware --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 9: chk-sys-firmware"
 
-echo "CALLING hcdiag dgemm..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test dgemm --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_dgemm.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\ndgemm FAILED"
-fi
+# Test Case 10: rpower
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test rpower --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 10: rpower"
 
-echo "CALLING hcdiag jlink..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test jlink --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_jlink.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\njlink FAILED"
-fi
+# Test Case 11: rvitals
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test rvitals --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 11: rvitals"
 
-echo "CALLING hcdiag nvvs..." >> ${LOG}
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test nvvs --target ${COMPUTE_NODES} > ${LOG_PATH}/test/hcdiag_nvvs.log 2>&1
-RC=$?
-if [ ${RC} -eq 0 ]
-then
-        echo "PASS" >> ${LOG}
-else
-        echo "FAILED" >> ${LOG}
-        FLAGS+="\nnvvs FAILED"
-fi
+# Test Case 12: fieldiag
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test fieldiag --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 12: fieldiag"
+
+# Test Case 13: chk-memory
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-memory --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 13: chk-memory"
+
+# Test Case 14: chk-cpu
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-aslr --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 14: chk-aslr"
+
+# Test Case 15: chk-load-average
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-average --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 2: chk-load-average"
+
+# Test Case 16: chk-load-cpu
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-cpu --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 16: chk-load-cpu"
+
+# Test Case 17: chk-load-mem
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-mem --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 17: chk-load-mem"
+
+# Test Case 18: chk-nfs-mount
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-nfs-mount --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 18: chk-nfs-mount"
+
+# Test Case 19: chk-os
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-os --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 19: chk-os"
+
+# Test Case 20: chk-power
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-power --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 20: chk-power"
+
+# Test Case 21: chk-process
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-process --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 21: chk-process"
+
+# Test Case 22: chk-smt
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-smt --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 22: chk-smt"
+
+# Test Case 23: chk-sw-level
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-sw-level --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 23: chk-sw-level"
+
+# Test Case 24: chk-temp
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-temp --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 24: chk-temp"
+
+# Test Case 25: chk-zombies
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-zombies --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 25: chk-zombies"
+
+# Test Case 26: test-simple
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test test-simple --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 26: test-simple"
+
+rm -f ${TEMP_LOG}
 
 echo "------------------------------------------------------------" >> ${LOG}
 echo "                hcdiag Bucket COMPLETED" >> ${LOG}

--- a/csmtest/buckets/basic/hcdiag.sh
+++ b/csmtest/buckets/basic/hcdiag.sh
@@ -27,7 +27,8 @@ fi
 
 # Local Variables
 LOG=${LOG_PATH}/buckets/basic/hcdiag.log
-TEMP_LOG=${LOG_PATH}/buckets/basic/hcdiag.log
+TEMP_LOG=${LOG_PATH}/buckets/basic/hcdiag_temp.log
+FLAG_LOG=${LOG_PATH}/buckets/basic/hcdiag_flags.log
 HC_DIAG_PATH=/opt/ibm/csm/hcdiag
 
 if [ -f "${BASH_SOURCE%/*}/../../include/functions.sh" ]
@@ -43,17 +44,23 @@ echo "------------------------------------------------------------" >> ${LOG}
 date >> ${LOG}
 echo "------------------------------------------------------------" >> ${LOG}
 
+# Copy included test.properties over to active test.properties
+echo "y" | cp ${FVT_PATH}/include/hcdiag/test.properties ${HC_DIAG_PATH}/etc/
+
 # Test Case 1: ppping
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test ppping --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
 check_return_flag $? "Test Case 1: ppping"
 
-# Test Case 2: chk-cpu
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 2: chk-cpu"
+# Get run id from temp log
+run_id=`grep "run id" ${TEMP_LOG} | awk -F' ' '{print $6}' | awk -F',' '{print $1}'`
 
-# Test Case 3: chk-cpu-count
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu-count --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 3: chk-cpu-count"
+# Test Case 2: csm_diag_run_query
+${CSM_PATH}/csm_diag_run_query -r ${run_id} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 2: csm_diag_run_query"
+
+# Test Case 3: csm_diag_run_query_details
+${CSM_PATH}/csm_diag_run_query_details -r ${run_id} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 3: csm_diag_run_query_details"
 
 # Test Case 4: chk-csm-health
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-csm-health --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
@@ -65,7 +72,7 @@ check_return_flag $? "Test Case 5: chk-free-memory"
 
 # Test Case 6: chk-led
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-led --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 2: chk-cpu"
+check_return_flag $? "Test Case 6: chk-led"
 
 # Test Case 7: chk-boot-time
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-boot-time --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
@@ -75,84 +82,53 @@ check_return_flag $? "Test Case 7: chk-boot-time"
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-noping --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
 check_return_flag $? "Test Case 8: chk-noping"
 
-# Test Case 9: chk-sys-firmware
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-sys-firmware --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 9: chk-sys-firmware"
-
-# Test Case 10: rpower
+# Test Case 9: rpower
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test rpower --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 10: rpower"
+check_return_flag $? "Test Case 9: rpower"
 
-# Test Case 11: rvitals
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test rvitals --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 11: rvitals"
-
-# Test Case 12: fieldiag
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test fieldiag --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 12: fieldiag"
-
-# Test Case 13: chk-memory
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-memory --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 13: chk-memory"
-
-# Test Case 14: chk-cpu
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-aslr --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 14: chk-aslr"
-
-# Test Case 15: chk-load-average
+# Test Case 10: chk-load-average
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-average --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 2: chk-load-average"
+check_return_flag $? "Test Case 10: chk-load-average"
 
-# Test Case 16: chk-load-cpu
+# Test Case 11: chk-load-cpu
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-cpu --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 16: chk-load-cpu"
+check_return_flag $? "Test Case 11: chk-load-cpu"
 
-# Test Case 17: chk-load-mem
+# Test Case 12: chk-load-mem
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-mem --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 17: chk-load-mem"
+check_return_flag $? "Test Case 12: chk-load-mem"
 
-# Test Case 18: chk-nfs-mount
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-nfs-mount --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 18: chk-nfs-mount"
-
-# Test Case 19: chk-os
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-os --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 19: chk-os"
-
-# Test Case 20: chk-power
+# Test Case 13: chk-power
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-power --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 20: chk-power"
+check_return_flag $? "Test Case 13: chk-power"
 
-# Test Case 21: chk-process
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-process --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 21: chk-process"
-
-# Test Case 22: chk-smt
+# Test Case 14: chk-smt
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-smt --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 22: chk-smt"
+check_return_flag $? "Test Case 14: chk-smt"
 
-# Test Case 23: chk-sw-level
-${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-sw-level --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 23: chk-sw-level"
-
-# Test Case 24: chk-temp
+# Test Case 15: chk-temp
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-temp --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 24: chk-temp"
+check_return_flag $? "Test Case 15: chk-temp"
 
-# Test Case 25: chk-zombies
+# Test Case 16: chk-zombies
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-zombies --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 25: chk-zombies"
+check_return_flag $? "Test Case 16: chk-zombies"
 
-# Test Case 26: test-simple
+# Test Case 17: test-simple
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test test-simple --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 26: test-simple"
+check_return_flag $? "Test Case 17: test-simple"
+
+# Test Case 18: chk-process
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-process --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 18: chk-process"
+
+# Test Case 19: chk-nfs-mount
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-nfs-mount --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 19: chk-nfs-mount"
 
 rm -f ${TEMP_LOG}
 
 echo "------------------------------------------------------------" >> ${LOG}
 echo "                hcdiag Bucket COMPLETED" >> ${LOG}
-echo "------------------------------------------------------------" >> ${LOG}
-echo "Additional Flags:" >> ${LOG}
-echo -e "${FLAGS}" >> ${LOG}
 echo "------------------------------------------------------------" >> ${LOG}
 exit 0

--- a/csmtest/include/hcdiag/test.properties
+++ b/csmtest/include/hcdiag/test.properties
@@ -19,7 +19,7 @@
 description = check if the node aslr is enable/disabled
 executable  = /opt/ibm/csm/hcdiag/tests/chk-aslr/chk-aslr.sh
 timeout     = 10
-
+args        = 2
 
 ## chk-boot-time
 [tests.chk-boot-time]

--- a/csmtest/include/hcdiag/test.properties
+++ b/csmtest/include/hcdiag/test.properties
@@ -1,0 +1,768 @@
+# -*- coding: utf-8 -*-                   # remove when Python 3
+#================================================================================
+#   
+#    hcdiag/src/framework/test.properties
+# 
+#  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+# 
+#===============================================================================*/
+
+
+[tests.chk-aslr]
+description = check if the node aslr is enable/disabled
+executable  = /opt/ibm/csm/hcdiag/tests/chk-aslr/chk-aslr.sh
+timeout     = 10
+
+
+## chk-boot-time
+[tests.chk-boot-time]
+description = check if the nodes were boot succesfully 
+executable  = /opt/ibm/csm/hcdiag/tests/chk-boot-time/chk-boot-time.sh
+targetType  = Management
+xcat_cmd    = yes
+timeout     = 10
+#args        = -v
+
+## chk-cpu
+[tests.chk-cpu]
+description = Check number of cpus, cpu frequence, cores present=cores online on the node
+executable  = /opt/ibm/csm/hcdiag/tests/chk-cpu/chk-cpu.sh
+timeout     = 10
+
+
+## chk-cpu-count
+[tests.chk-cpu-count]
+description = check number of cpus on the node
+executable  = /opt/ibm/csm/hcdiag/tests/chk-cpu-count/chk-cpu-count.sh
+timeout     = 10
+
+[tests.chk-idle-state]
+description = check node idle state configuration
+executable  = /opt/ibm/csm/hcdiag/tests/chk-idle-state/chk-idle-state.sh
+timeout     = 10
+
+## chk-csm-health from CSM infrastructure
+[tests.chk-csm-health]
+description = csm infrastructure health check
+executable  = /opt/ibm/csm/hcdiag/tests/chk-csm-health/chk-csm-health.sh
+timeout     = 100
+targetType  = Management
+
+# default threshold is 10% of the available memory
+[tests.chk-free-memory]
+description = check if the amount of free memory is above the threshold.
+executable  = /opt/ibm/csm/hcdiag/tests/chk-free-memory/chk-free-memory.sh
+timeout     = 10
+#args = 10
+
+
+## uses the clustconf.yaml as input for gpfs filesystem/mount point
+## and check it with what is on the machine
+[tests.chk-gpfs-mount]
+description = check gpfs filesystem/mount point
+executable  = /opt/ibm/csm/hcdiag/tests/chk-gpfs-mount/chk-gpfs-mount.sh
+timeout     = 10
+
+[tests.chk-gpu-ats]
+description = check if the gpu ats is enable/disabled
+executable  = /opt/ibm/csm/hcdiag/tests/chk-gpu-ats/chk-gpu-ats.sh
+args        = 1
+timeout     = 10
+
+[tests.chk-hca-attributes]
+description = check hca board version and firmware
+executable  = /opt/ibm/csm/hcdiag/tests/chk-hca-attributes/chk-hca-attributes.sh
+timeout     = 10
+
+[tests.chk-ib-node]
+description = check node ib bandwidth
+executable  = /opt/ibm/csm/hcdiag/tests/chk-ib-node/chk-ib-node.sh
+timeout     = 50
+#args       = 21250
+
+[tests.chk-ib-pcispeed]
+description = check ib adapters vendor, speed and width
+executable  = /opt/ibm/csm/hcdiag/tests/chk-ib-pcispeed/chk-ib-pcispeed.sh
+timeout     = 10
+#args       = 16GT/s x8 Mellanox
+
+## dheck if there is a kworker process consuming more than N% of the cpu.
+[tests.chk-kworker]
+description = check kworker process consuming more than N% of the cpu
+executable  = /opt/ibm/csm/hcdiag/tests/chk-kworker/chk-kworker.sh
+#args        = 20.0
+
+[tests.chk-led]
+description = check for fault led in the node range 
+executable  = /opt/ibm/csm/hcdiag/tests/chk-led/chk-led.sh
+targetType  = Management
+timeout     = 10
+
+[tests.chk-load-average]
+description = check if the node load average is below the threshold
+executable  = /opt/ibm/csm/hcdiag/tests/chk-load/chk-load.sh
+args        = average 40 
+timeout     = 10
+
+[tests.chk-load-cpu]
+description = check if the node cpu load is bellow the threshold
+executable  = /opt/ibm/csm/hcdiag/tests/chk-load/chk-load.sh
+# args: [cpu] [threshold] [number_of_process]
+#args        = cpu 90 1
+timeout     = 10
+
+[tests.chk-load-mem]
+description = check if the node memory load is bellow the threshold
+executable  = /opt/ibm/csm/hcdiag/tests/chk-load/chk-load.sh
+# args: mem [threshold] [number_of_process]
+args        =  mem 90 1 
+timeout     = 10
+
+[tests.chk-memory]
+description = check if the node total memory, number of banks and bank size
+executable  = /opt/ibm/csm/hcdiag/tests/chk-memory/chk-memory.sh
+timeout     = 10
+
+## Check if the Mellanox adapters are configured correctly.
+[tests.chk-mlnx-pci]
+description = check mellanox pci configuration 
+executable  = /opt/ibm/csm/hcdiag/tests/chk-mlnx-pci/chk-mlnx-pci.sh
+timeout     = 10
+
+## Check Mellanox adapters link errors.
+[tests.chk-mlxlink-pci]
+description = check mellanox link errors 
+executable  = /opt/ibm/csm/hcdiag/tests/chk-mlxlink-pci/chk-mlxlink-pci.sh
+#args       = 100
+timeout     = 10
+
+## chk-nfs-mount
+[tests.chk-nfs-mount]
+description = check if the filesystem is mounted corretly
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nfs-mount/chk-nfs-mount.sh
+timeout     = 10
+args        = /ugadmin
+
+## chk-noping
+[tests.chk-noping]
+description = check if the nodes that are booted are pinging
+executable  = /opt/ibm/csm/hcdiag/tests/chk-noping/chk-noping.sh
+targetType  = Management
+xcat_cmd    = yes
+timeout     = 100
+#args        = -v
+
+[tests.chk-nvidia-clocks]
+description = check nvidia clocks
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nvidia-clocks/chk-nvidia-clocks.sh
+timeout     = 10
+
+
+[tests.chk-nvidia-smi]
+description = check possible stuck nvidia-smi
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nvidia-smi/chk-nvidia-smi.sh
+timeout     = 10
+
+[tests.chk-nvlink-speed]
+description = check nvlink speed
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nvlink-speed/chk-nvlink-speed.sh
+timeout     = 10
+
+[tests.chk-nvidia-vbios]
+description = check nvidia vbios
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nvidia-vbios/chk-nvidia-vbios.sh
+timeout     = 10
+
+[tests.chk-nvlink-speed]
+description = check nvilink speed using nvidia-smi command
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nvlink-speed/chk-nvlink-speed.sh
+timeout     = 10
+
+# we assume by default that nvme device will be mounted /nvme mount point
+# if not, pass the mount point as argument
+[tests.chk-nvme-mount]
+description = check if nvme device is mounted
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nvme-mount/chk-nvme-mount.sh
+timeout     = 10
+#args        = /nvme
+
+[tests.chk-nvme]
+description = check nvme device vendor and firmware
+executable  = /opt/ibm/csm/hcdiag/tests/chk-nvme/chk-nvme.sh
+timeout     = 10
+
+[tests.chk-os]
+description = check node operating system and kernel version
+executable  = /opt/ibm/csm/hcdiag/tests/chk-os/chk-os.sh
+timeout     = 10
+
+[tests.chk-power]
+description = check current power capping/shifting values on node
+executable  = /opt/ibm/csm/hcdiag/tests/chk-power/chk-power.sh
+timeout     = 10
+
+# default list of process : csmd nvidia-persistenced nv-hostengine opal-prd automount
+[tests.chk-process]
+description = check if a list of process are running on the node
+executable  = /opt/ibm/csm/hcdiag/tests/chk-process/chk-process.sh
+timeout     = 10
+args = csmd 
+
+[tests.chk-smt]
+description = check the node smt
+executable  = /opt/ibm/csm/hcdiag/tests/chk-smt/chk-smt.sh
+args        = 4
+timeout     = 10
+
+[tests.chk-sw-level]
+description = check the node software stack levels
+executable  = /opt/ibm/csm/hcdiag/tests/chk-sw-level/chk-sw-level.sh
+timeout     = 10
+
+[tests.chk-sys-firmware-local]
+description = check firmware levels on the node
+executable  = /opt/ibm/csm/hcdiag/tests/chk-sys-firmware-local/chk-sys-firmware-local.sh
+timeout     = 10
+
+[tests.chk-sys-firmware]
+description = check machine firmware levels
+executable  = /opt/ibm/csm/hcdiag/tests/chk-sys-firmware/chk-sys-firmware.sh
+timeout     = 10
+targetType  = Management
+
+[tests.chk-temp]
+description = Check the temperature sensors on a node
+executable  = /opt/ibm/csm/hcdiag/tests/chk-temp/chk-temp.sh
+timeout     = 10
+
+[tests.chk-zombies]
+description = check possible stuck zombie tasks
+executable  = /opt/ibm/csm/hcdiag/tests/chk-zombies/chk-zombies.sh
+timeout     = 10
+
+[tests.compdiag]
+description = comprehensive fabric diagnostic test
+executable  = /opt/ibm/csm/hcdiag/tests/compdiag/compdiag.sh
+group       = ib
+timeout     = 600
+
+## IBM spectrum mpi package daxpy
+[tests.daxpy]
+description = measure aggregate memory bandwidth in MB/s.
+executable  = /opt/ibm/csm/hcdiag/tests/daxpy/daxpy.sh
+group       = memory
+timeout     = 100
+targetType  = Compute    
+
+[tests.daxpy-per-socket]
+description = measure aggregate memory bandwidth in MB/s, per socket.
+executable  = /opt/ibm/csm/hcdiag/tests/daxpy/daxpy.sh
+group       = memory
+timeout     = 100
+args        = 2
+targetType  = Compute    
+
+# NVIDIA datacenter. Argment for dcgmi diag is level, possible values:
+# 1 - Quick System Validation (~ seconds)  
+# 2 - Extended System Validation (~ 2 minutes)  
+# 3 - System HW Diagnostics ( ~ 15 minutes)        
+[tests.dcgm-diag]
+description = NVIDIA DCGM diagnostic test
+group       = gpu
+timeout     = 900
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/dcgm-diag/dcgm-diag.sh
+args        = 3
+
+[tests.dcgm-diag-double]
+description = NVIDIA DCGM double precision diagnostic test
+group       = gpu
+timeout     = 9000
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/dcgm-diag/dcgm-diag.sh
+# args: <which diag> <stats_path> <debug_path>
+## Note debug_path+<hostname_s>/dcgm.debug has 30 characters limitation
+args        = 5 /tmp /tmp
+
+[tests.dcgm-diag-single]
+description = NVIDIA DCGM single precision diagnostic test
+group       = gpu
+timeout     = 9000
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/dcgm-diag/dcgm-diag.sh
+# args: <which diag> <stats_path> <debug_path>
+## Note debug_path+<hostname_s>/dcgm.debug has 30 characters limitation
+args        = 4 /tmp /tmp
+
+# NVIDIA datacenter. Argument for dcgmi health is the list of what to watch.
+# Default is all.
+# Possible values:
+# a - all watches
+# p - PCIe watches 
+# m - memory watches 
+# i - infoROM watches
+# t - thermal and power watches 
+# n - NVLink watches 
+[tests.dcgm-health]
+description = NVIDIA DCGM health check
+group       = gpu
+timeout     = 100
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/dcgm-health/dcgm-health.sh
+#args        = a
+
+##  IBM spectrum mpi package dgemm
+[tests.dgemm]
+description = measure CPU performance. 
+executable  = /opt/ibm/csm/hcdiag/tests/dgemm/dgemm.sh
+group       = cpu
+timeout     = 600
+targetType  = Compute
+
+##  IBM spectrum mpi package dgemm-gpu
+[tests.dgemm-gpu]
+description  = measure GPU performance.
+executable  = /opt/ibm/csm/hcdiag/tests/dgemm-gpu/dgemm-gpu.sh
+group        = gpu
+timeout      = 2000
+targetType   = Compute
+#args        = 1
+
+# strong recomend to run on the node, just invoking this script
+# NOTE: NVIDIA distributes the fieldiag binary and the source code for the
+#       kernel module. The files should be copied to /opt/ibm/csm/hcdiag/tests/fieldiag 
+#       or the path should be updated in the fieldiag.sh script.
+[tests.fieldiag]
+description = NVIDIA hardware diagnostic
+executable  = /opt/ibm/csm/hcdiag/tests/fieldiag/fieldiag.sh
+group       = gpu
+timeout     = 25000
+
+# NOTE: Distributed by GPFS
+[tests.gpfsperf]
+description = GPFS benchmark to measure the performance of the filesystem
+executable  = /opt/ibm/csm/hcdiag/tests/gpfsperf/gpfsperf.sh
+group       = Filesystem
+#             <gpfs_fs>   [blocksize]  [directory]
+args        = /gpfs/gpfs0   1M  /gpfs/gpfs0/diagadmin 
+timeout     = 25000
+
+# checks gpu memory bw, gpu dgemm flops, nvlink transfer speeds 
+# NOTE: the source code for the gpu-health binary is distributed as samples
+# arguments:
+#  nvlink transfer to devices in the same socket speed: default 65 GB/sec  
+#  gpu memory bandwidth: defaul 800 GB/sec
+#  gpu dgemm: deault is 7 TFlops
+[tests.gpu-health]
+description = checks gpu memory bw, gpu dgemm flops, nvlink transfer speeds 
+executable  = /opt/ibm/csm/hcdiag/tests/gpu-health/gpu-health.sh
+group       = gpu
+#args        = 40 800 6.7
+args        = 65 800 6.7
+timeout     = 10000
+
+[tests.gpudirect]
+description = Exercise GPUDirect RDMA and p2p data movement
+executable  = /opt/ibm/csm/hcdiag/tests/gpudirect/gpudirect.sh
+targetType  = Management
+group       = ib
+timeout     = 150
+
+[tests.hcatest]
+description = Verify operating hca with verbs latency test
+executable  = /opt/ibm/csm/hcdiag/tests/hcatest/hcatest.sh
+targetType  = Management
+group       = ib
+timeout     = 150
+
+# IBM HTX package.  htx tests arguments:
+# cycles: duration of the run, in cycles
+# pass  : 1|2, indicating pass1 or pass2 (not all the tests have pass2)
+# debug : 0|1, print debug info or not. Default is 0
+
+
+# arguments for hxecache is <cycles> [debug]
+[tests.hxecache]
+description = HTX L1/L2/L3 caches stress test
+group       = memory
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxecache/hxecache.sh 
+args        = 10 
+
+# arguments for hxecpu is  <cycles> <level> [debug] 
+[tests.hxecpu]
+description = HTX processor core cpu test
+group       = cpu
+timeout     = 800
+targetType  = Compute
+executable = /opt/ibm/csm/hcdiag/tests/hxecpu/hxecpu.sh
+args        = 10 1 
+
+# arguments for hxecpu_pass2 is  <cycles> <level> [debug] 
+[tests.hxecpu_pass2]
+description = HTX processor core cpu test pass2
+group       = cpu
+timeout     = 800
+targetType  = Compute
+executable = /opt/ibm/csm/hcdiag/tests/hxecpu/hxecpu.sh
+args        = 10 2 
+
+# arguments for hxediag is  <eth|ib> <duration> [args]
+
+[tests.hxediag_eth]
+description = HTX test for Ethernet adapters
+group       = io
+timeout     = 800
+targetType  = Compute
+executable = /opt/ibm/csm/hcdiag/tests/hxediag/hxediag.sh
+args        = eth 10 
+
+# arguments for hxediag is  <eth|ib> <duration> [args]
+[tests.hxediag_ib]
+description = HTX test for IB adapters
+group       = io
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxediag/hxediag.sh
+args        = ib 10 
+
+# arguments for hxeewm is <cycles> [debug]
+[tests.hxeewm_pass2]
+description = HTX thermal test
+group       = processor
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxeewm/hxeewm.sh
+args        = 10 1 
+
+
+# arguments for hxefabricbus  <cycles> [debug] 
+[tests.hxefabricbus_pass2]
+description = HTX processor fabric bus test 
+group       = processor
+timeout     = 800
+targetType  = Compute
+executable = /opt/ibm/csm/hcdiag/tests/hxefabricbus/hxefabricbus.sh
+args        = 10  
+
+# arguments for hxefpu64 is <cycles> <level> [debug]
+[tests.hxefpu64]
+description = HTX VSU (Vector Scalar Unit) test
+group       = processor
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxefpu64/hxefpu64.sh
+args        = 10 1 
+
+# arguments for hxefpu64_pass2 is <cycles> <level> [debug]
+[tests.hxefpu64_pass2]
+description = HTX VSU (Vector Scalar Unit) test pass2
+group       = processor
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxefpu64/hxefpu64.sh
+args        = 10 2 
+
+# arguments for hxemem64 is  <cycles> <level> [debug]
+[tests.hxemem64]
+description = HTX memory subsystem test
+group       = memory
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxemem64/hxemem64.sh
+args        = 2 1 
+
+# arguments for hxemem64_pass2 is <cycles> <level> [debug]
+[tests.hxemem64_pass2]
+description = HTX memory subsystem test
+group       = memory
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxemem64/hxemem64.sh
+args        = 2 2
+
+# arguments for hxenvidia is <cycles> [debug]
+[tests.hxenvidia]
+description = HTX gpu test
+group       = gpu
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxenvidia/hxenvidia.sh
+args        = 10 1
+
+# arguments for hxenvidia is <cycles> [debug]
+[tests.hxenvidia_pass2]
+description = HTX gpu test
+group       = gpu
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxenvidia/hxenvidia.sh
+args        = 10 2
+
+# arguments for hxerng is <cycles> [debug]
+[tests.hxerng_pass2]
+description = HTX random number generator engine test
+group       = core
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxerng/hxerng.sh
+args        = 10 
+
+# arguments for hxesctu is <cycles> [debug]
+[tests.hxesctu_pass2]
+description = HTX processor cache coherency test
+group       = memory
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxesctu/hxesctu.sh
+args        = 10  
+
+# arguments for hxestorage is <module> <duration> <pass> 
+# disk
+[tests.hxestorage_sd]
+description = HTX storage subsystem test
+group       = storage
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxestorage/hxestorage.sh
+args        = sd 10 1  
+
+[tests.hxestorage_sd_pass2]
+description = HTX storage subsystem test
+group       = storage
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxestorage/hxestorage.sh
+args        = sd 10 2  
+
+# nvme
+[tests.hxestorage_nvme]
+description = HTX storage subsystem test
+group       = storage
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxestorage/hxestorage.sh
+args        = nvme 10 1  
+
+[tests.hxestorage_nvme_pass2]
+description = HTX storage subsystem test
+group       = storage
+timeout     = 800
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/hxestorage/hxestorage.sh
+args        = nvme 10 2  
+
+[tests.ibcredit]
+description = Checks for credit loops
+executable  = /opt/ibm/csm/hcdiag/tests/ibcredit/ibcredit.sh
+group       = ib
+timeout     = 10
+
+[tests.ibverbs]
+description = Verify verbs point to point communication between nodes
+executable  = /opt/ibm/csm/hcdiag/tests/ibverbs/ibverbs.sh
+targetType  = Management
+group       = ib
+timeout     = 150
+
+[tests.ipoib]
+description = Shows the state, MTU, and mode of IPoIB devices on a node
+executable  = /opt/ibm/csm/hcdiag/tests/ipoib/ipoib.sh
+timeout     = 10
+
+[tests.mmhealth]
+description = Verify status of the gpfs in the node 
+executable  = /opt/ibm/csm/hcdiag/tests/mmhealth/mmhealth.sh
+timeout     = 10
+
+[tests.lnklwls]
+description = Verify link width and speed
+executable  = /opt/ibm/csm/hcdiag/tests/lnklwls/lnklwls.sh
+group       = ib
+timeout     = 10
+
+[tests.lnkqual]
+description = Check for marginal link error
+executable  = /opt/ibm/csm/hcdiag/tests/lnkqual/lnkqual.sh
+group       = ib
+timeout     = 10
+
+##  IBM spectrum mpi package jlink
+[tests.jlink]
+description = JLINK measures the bandwidth between nodes, and to discover bad or low-performing links.
+executable  = /opt/ibm/csm/hcdiag/tests/jlink/jlink.sh
+group       = ib
+timeout     = 50
+targetType  = Compute
+clustertest = yes
+          
+[tests.nsdperf]
+description = network performance test
+group       = performance
+timeout     = 300
+targetType  = Management
+executable  = /opt/ibm/csm/hcdiag/tests/nsdperf/nsdperf.sh
+
+# NVIDIA nvvs. Argument for nvvs is the same as dcgm-diag arguments
+[tests.nvvs]
+description = NVVS (NVIDIA Validation Suite).
+group       = gpu
+timeout     = 300
+#timeout     = 100
+targetType  = Compute
+executable  = /opt/ibm/csm/hcdiag/tests/nvvs/nvvs.sh
+args        = 3
+
+## Invokes p2pBandwidthLatencyTest, from cuda samples
+[tests.p2pBandwidthLatencyTest]
+description = NVIDIA GPU bandwidth test
+executable  = /opt/ibm/csm/hcdiag/tests/p2pBandwidthLatencyTest/p2pBandwidthLatencyTest.sh
+timeout     = 200
+group       = gpu
+
+## Invokes /opt/xcat/bin/ppping
+[tests.ppping]
+description = parallel ping from nodes to other nodes in the cluster
+executable  = /opt/ibm/csm/hcdiag/tests/ppping/ppping.sh
+targetType  = Management
+timeout     = 200
+group       = ib
+args        = -i ib0,ib1
+
+[tests.rpower]
+description = check rpower status
+executable  = /opt/ibm/csm/hcdiag/tests/rpower/rpower.sh
+timeout     = 100
+targetType  = Management
+xcat_cmd    = yes
+#args        = -v
+
+[tests.rvitals]
+description = check if rvitals match the spec 
+executable  = /opt/ibm/csm/hcdiag/tests/rvitals/rvitals.sh
+timeout     = 300
+targetType  = Management
+xcat_cmd    = yes
+#args        = -v
+
+[tests.swhealth]
+description = Run switch health check report
+executable  = /opt/ibm/csm/hcdiag/tests/swhealth/swhealth.sh
+timeout     = 60
+
+## very simple hello test
+[tests.test-simple]
+description = simple hello test
+executable  = /opt/ibm/csm/hcdiag/tests/test-simple/test-simple.sh
+timeout     = 1
+
+[bucket.performance]
+description = A default set of tests designed to provide comprehensive performance test.
+tests       = dgemm, daxpy, jlink
+
+[bucket.ib]    
+description = A default set of tests to provide comprehensive Infiniband test.
+tests       = jlink, ppping
+
+[bucket.gpu]    
+description = A default set of tests to provide comprehensive GPU test.
+tests       = dcgm-diag
+
+
+[bucket.htx_pass1]    
+description = A bucket including all htx pass1 tests
+tests       = hxecache,hxecpu,hxefpu64,hxemem64,hxenvidia,hxediag_ib, hxediag_eth,hxestorage_sd,hxestorage_nvme
+
+[bucket.htx_pass2]    
+description = A bucket including all htx pass2 tests
+tests       = hxeewm_pass2,hxecpu_pass2,hxefpu64_pass2,hxemem64_pass2,hxenvidia_pass2,hxerng_pass2,hxesctu_pass2,hxefabricbus_pass2,hxestorage_sd_pass2,hxestorage_nvme_pass2
+
+#############
+# executed as xcat post-boot
+[bucket.boot_node_health]
+description=A set of tests to be executed as post-boot
+tests=chk-cpu,chk-memory,chk-mlnx-pci,chk-nvlink-speed,gpu-health
+
+##############
+# 1 min
+[bucket.node_health]
+description = A default set of tests designed to provide comprehensive node_health.
+tests=chk-load-cpu,chk-load-mem,chk-smt,chk-gpfs-mount,chk-nfs-mount,chk-process,chk-power,chk-free-memory,chk-cpu,chk-gpu-ats,chk-aslr,chk-sw-level,chk-idle-state
+#tests=chk-load-cpu,chk-load-mem,chk-smt,chk-gpfs-mount,chk-nfs-mount,chk-process,chk-power,chk-zombies,chk-free-memory,chk-cpu,chk-gpu-ats,chk-aslr,chk-sw-level
+
+##############
+# 1 min
+# this is the same bucket as node_health but w/o chk-load_cpu,chk-load-mem,chk-free-memor
+[bucket.node_health_shared]
+description = A default set of tests designed to provide comprehensive node_health.
+tests=chk-smt,chk-gpfs-mount,chk-nfs-mount,chk-process,chk-power,chk-cpu,chk-gpu-ats,chk-aslr,chk-sw-level,chk-idle-state
+
+##############
+# 15 min
+[bucket.short]
+description=A set of 15 minutes test, non intrusive
+tests=chk-hca-attributes,chk-ib-pcispeed,chk-load-average,chk-mlnx-pci,chk-nvidia-smi,chk-nvidia-vbios,chk-os,chk-sys-firmware-local,chk-nvme,chk-nvlink-speed
+
+##############
+# 30 min
+[bucket.medium]
+description=A set of 30 minutes test, non intrusive
+tests=daxpy,dgemm,dgemm-gpu,nvvs,dcgm-diag,gpu-health,p2pBandwidthLatencyTest,mmhealth
+
+##############
+# 60 min
+[bucket.long]
+description=A set of 60 minutes test
+tests      = hxecache,hxecpu,hxefpu64,hxemem64,hxenvidia,hxediag_ib,hxediag_eth,hxestorage_sd,hxestorage_nvme
+
+
+##################################################################
+#  This set of buckets defined to run without root privilege
+################################################################## 
+# 1 min
+# this is the same bucket as node_health but w/o chk-load_cpu,chk-load-mem,chk-free-memor
+[bucket.node_health_noroot]
+description = A default set of tests designed to provide comprehensive node_health.
+tests=chk-load-cpu,chk-load-mem,chk-smt,chk-gpfs-mount,chk-nfs-mount,chk-process,chk-power,chk-free-memory,chk-gpu-ats,chk-aslr,chk-sw-level,chk-idle-state
+
+##############
+# 15 min
+[bucket.short_noroot]
+description=A set of 15 minutes test, non intrusive, no root
+tests=chk-hca-attributes,chk-load-average,chk-nvidia-smi,chk-nvidia-vbios,chk-os,chk-sys-firmware-local
+
+##############
+# 30 min
+[bucket.medium_noroot]
+description=A set of 30 minutes test, no root
+tests=daxpy,dgemm,dgemm-gpu,nvvs,dcgm-diag,gpu-health,p2pBandwidthLatencyTest
+
+##############
+# 1+15+30 min
+[bucket.all_noroot]
+description=A set of all wsc tests with no root
+tests=chk-load-cpu,chk-load-mem,chk-smt,chk-gpfs-mount,chk-nfs-mount,chk-process,chk-power,chk-free-memory,chk-gpu-ats,chk-aslr,chk-sw-level,chk-idle-state,chk-hca-attributes,chk-load-average,chk-nvidia-smi,chk-nvidia-vbios,chk-os,chk-sys-firmware-local,daxpy,dgemm,dgemm-gpu,nvvs,dcgm-diag,gpu-health,p2pBandwidthLatencyTest
+
+##################################################################
+#  This set of buckets defined to run in 15 minutes Utilities node
+################################################################## 
+##############
+# 15 min
+[bucket.infrastructure_short]
+description=A set of 15 minutes test, non intrusive
+tests=chk-hca-attributes,chk-ib-pcispeed,chk-mlnx-pci,chk-os,chk-sys-firmware-local,chk-nvme,chk-led,chk-memory,chk-nfs-mount,chk-gpfs-mount,chk-power,chk-cpu
+
+#############
+# 15 min
+[bucket.mgmt_short]
+description=A set of 15 minutes test, non intrusive for the management node
+tests=chk-noping,chk-sys-firmware,chk-led
+


### PR DESCRIPTION
This is a first pass of "basic" (hardware/software-package independent) hcdiag tests to be included in CSM regression.  

List is as follows
```
ppping
chk-csm-health
chk-free-memory
chk-led
chk-boot-time
chk-noping
rpower
chk-load-average
chk-load-cpu
chk-load-mem
chk-power
chk-smt
chk-temp
chk-zombies
test-simple
chk-process
chk-nfs-mount
```
If that looks like an acceptable list for a first pass we can get this pull request merged in upon approval.  I have included a list of additional tests to add in an email to the reviewers.  
