### PR TITLE
CSM FVT regression test cases for hcdiag that require clustconf.yaml

### DIFF
--- a/csmtest/buckets/basic/hcdiag.sh
+++ b/csmtest/buckets/basic/hcdiag.sh
@@ -44,8 +44,11 @@ echo "------------------------------------------------------------" >> ${LOG}
 date >> ${LOG}
 echo "------------------------------------------------------------" >> ${LOG}
 
-# Copy included test.properties over to active test.properties
+# Copy included test.properties and clustconf.yaml over to active test.properties
 echo "y" | cp ${FVT_PATH}/include/hcdiag/test.properties ${HC_DIAG_PATH}/etc/
+xdcp ${COMPUTE_NODE} ${FVT_PATH}/include/hcdiag/test,properties ${HC_DIAG_PATH}/etc/
+echo "y" | cp ${FVT_PATH}/include/hcdiag/clustconf.yaml ${HC_DIAG_PATH}/etc/
+xdcp ${COMPUTE_NODES} ${FVT_PATH}/include/hcdiag/clustconf.yaml ${HC_DIAG_PATH}/etc/
 
 # Test Case 1: ppping
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test ppping --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
@@ -125,6 +128,34 @@ check_return_flag $? "Test Case 18: chk-process"
 # Test Case 19: chk-nfs-mount
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-nfs-mount --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
 check_return_flag $? "Test Case 19: chk-nfs-mount"
+
+# Test Case 20: chk-cpu
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 20: chk-cpu"
+
+# Test Case 21: chk-cpu-count
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu-count --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 21: chk-cpu-count"
+
+# Test Case 22: chk-sys-firmware
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-sys-firmware --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 22: chk-sys-firmware"
+
+# Test Case 23: chk-memory
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-memory --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 23: chk-memory"
+
+# Test Case 24: chk-aslr
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-aslr --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 24: chk-aslr"
+
+# Test Case 25: chk-os
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-os --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 25: chk-os"
+
+# Test Case 26: chk-temp
+${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-temp --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 26: chk-temp"
 
 rm -f ${TEMP_LOG}
 

--- a/csmtest/buckets/basic/hcdiag.sh
+++ b/csmtest/buckets/basic/hcdiag.sh
@@ -46,7 +46,7 @@ echo "------------------------------------------------------------" >> ${LOG}
 
 # Copy included test.properties and clustconf.yaml over to active test.properties
 echo "y" | cp ${FVT_PATH}/include/hcdiag/test.properties ${HC_DIAG_PATH}/etc/
-xdcp ${COMPUTE_NODE} ${FVT_PATH}/include/hcdiag/test,properties ${HC_DIAG_PATH}/etc/
+xdcp ${COMPUTE_NODES} ${FVT_PATH}/include/hcdiag/test.properties ${HC_DIAG_PATH}/etc/
 echo "y" | cp ${FVT_PATH}/include/hcdiag/clustconf.yaml ${HC_DIAG_PATH}/etc/
 xdcp ${COMPUTE_NODES} ${FVT_PATH}/include/hcdiag/clustconf.yaml ${HC_DIAG_PATH}/etc/
 
@@ -65,97 +65,101 @@ check_return_exit $? 0 "Test Case 2: csm_diag_run_query"
 ${CSM_PATH}/csm_diag_run_query_details -r ${run_id} > ${TEMP_LOG} 2>&1
 check_return_exit $? 0 "Test Case 3: csm_diag_run_query_details"
 
-# Test Case 4: chk-csm-health
+# Test Case 4: hcdiag_query.py
+${HC_DIAG_PATH}/bin/hcdiag_query.py -r ${run_id} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 4: hcdiag_query.py"
+
+# Test Case 5: chk-csm-health
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-csm-health --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 4: chk-csm-health"
+check_return_flag $? "Test Case 5: chk-csm-health"
 
-# Test Case 5: chk-free-memory
+# Test Case 6: chk-free-memory
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-free-memory --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 5: chk-free-memory"
+check_return_flag $? "Test Case 6: chk-free-memory"
 
-# Test Case 6: chk-led
+# Test Case 7: chk-led
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-led --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 6: chk-led"
+check_return_flag $? "Test Case 7: chk-led"
 
-# Test Case 7: chk-boot-time
+# Test Case 8: chk-boot-time
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-boot-time --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 7: chk-boot-time"
+check_return_flag $? "Test Case 8: chk-boot-time"
 
-# Test Case 8: chk-noping
+# Test Case 9: chk-noping
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-noping --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 8: chk-noping"
+check_return_flag $? "Test Case 9: chk-noping"
 
-# Test Case 9: rpower
+# Test Case 10: rpower
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test rpower --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 9: rpower"
+check_return_flag $? "Test Case 10: rpower"
 
-# Test Case 10: chk-load-average
+# Test Case 11: chk-load-average
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-average --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 10: chk-load-average"
+check_return_flag $? "Test Case 11: chk-load-average"
 
-# Test Case 11: chk-load-cpu
+# Test Case 12: chk-load-cpu
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-cpu --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 11: chk-load-cpu"
+check_return_flag $? "Test Case 12: chk-load-cpu"
 
-# Test Case 12: chk-load-mem
+# Test Case 13: chk-load-mem
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-load-mem --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 12: chk-load-mem"
+check_return_flag $? "Test Case 13: chk-load-mem"
 
-# Test Case 13: chk-power
+# Test Case 14: chk-power
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-power --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 13: chk-power"
+check_return_flag $? "Test Case 14: chk-power"
 
-# Test Case 14: chk-smt
+# Test Case 15: chk-smt
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-smt --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 14: chk-smt"
+check_return_flag $? "Test Case 15: chk-smt"
 
-# Test Case 15: chk-temp
+# Test Case 16: chk-temp
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-temp --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 15: chk-temp"
+check_return_flag $? "Test Case 16: chk-temp"
 
-# Test Case 16: chk-zombies
+# Test Case 17: chk-zombies
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-zombies --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 16: chk-zombies"
+check_return_flag $? "Test Case 17: chk-zombies"
 
-# Test Case 17: test-simple
+# Test Case 18: test-simple
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test test-simple --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 17: test-simple"
+check_return_flag $? "Test Case 18: test-simple"
 
-# Test Case 18: chk-process
+# Test Case 19: chk-process
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-process --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 18: chk-process"
+check_return_flag $? "Test Case 19: chk-process"
 
-# Test Case 19: chk-nfs-mount
+# Test Case 20: chk-nfs-mount
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-nfs-mount --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 19: chk-nfs-mount"
+check_return_flag $? "Test Case 20: chk-nfs-mount"
 
-# Test Case 20: chk-cpu
+# Test Case 21: chk-cpu
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 20: chk-cpu"
+check_return_flag $? "Test Case 21: chk-cpu"
 
-# Test Case 21: chk-cpu-count
+# Test Case 22: chk-cpu-count
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-cpu-count --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 21: chk-cpu-count"
+check_return_flag $? "Test Case 22: chk-cpu-count"
 
-# Test Case 22: chk-sys-firmware
+# Test Case 23: chk-sys-firmware
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-sys-firmware --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 22: chk-sys-firmware"
+check_return_flag $? "Test Case 23: chk-sys-firmware"
 
-# Test Case 23: chk-memory
+# Test Case 24: chk-memory
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-memory --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 23: chk-memory"
+check_return_flag $? "Test Case 24: chk-memory"
 
-# Test Case 24: chk-aslr
+# Test Case 25: chk-aslr
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-aslr --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 24: chk-aslr"
+check_return_flag $? "Test Case 25: chk-aslr"
 
-# Test Case 25: chk-os
+# Test Case 26: chk-os
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-os --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 25: chk-os"
+check_return_flag $? "Test Case 26: chk-os"
 
-# Test Case 26: chk-temp
+# Test Case 27: chk-temp
 ${HC_DIAG_PATH}/bin/hcdiag_run.py --test chk-temp --target ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_flag $? "Test Case 26: chk-temp"
+check_return_flag $? "Test Case 27: chk-temp"
 
 rm -f ${TEMP_LOG}
 

--- a/csmtest/include/hcdiag/clustconf.yaml
+++ b/csmtest/include/hcdiag/clustconf.yaml
@@ -1,0 +1,349 @@
+#================================================================================
+#
+#    hcdiag/src/tests/common/CMakeLists.txt
+#
+#  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+# node specific information, make it work like a 
+# bash case statement.
+# note very little of this information is actually used yet.
+# so this is a placeholder for when we get all the tests to pick it up
+node_info:
+  - case: c699mgt00
+    rvitals: habenaro
+    ncpus: 176
+    memory: 
+      total: 572
+      banks: 16
+      bank_size:  32
+    clock:   
+      max: 3.50
+      min: 2.0
+    firmware: 
+      name: "unknown version"
+      versions:
+        - 'BMC Firmware: 2.16'
+        - 'System Firmware Product Version: IBM-habanero-ibm-OP8_v1.8_1.1'
+        - 'System Firmware Product Additional Info: hostboot-bc98d0b-74f74b1'
+        - 'System Firmware Product Additional Info: occ-0362706-opdirty-60bbdf1'
+        - 'System Firmware Product Additional Info: skiboot-5.1.16'
+        - 'System Firmware Product Additional Info: hostboot-binaries-43d5a59'
+        - 'System Firmware Product Additional Info: habanero-xml-a71550e-9ba0a35'
+        - 'System Firmware Product Additional Info: capp-ucode-105cb8f-opdirty'
+
+
+    ib:
+      slot_rx: "00(03|33):01:00.(0|1)"
+      board_id: "IBM2150110033"
+      firmware: "12.22.4020"
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.5 (Maipo)"
+    kernel:
+      release: "4.14.0-49.8.1.el7a.ppc64le"
+
+    software:
+        - ibm-csm: 1.2.0-727
+        - gpfs.base: 5.0.1
+        - lm_sensors: 3.4.0-4.20160601gitf9185e5
+        - datacenter: 1.4.2-1
+        - cuda: 9-2-9.2.148-1 
+        - ibm_smpi: 10.02.00.05dev0
+
+  - case: c699mgt0.*
+    rvitals: boston
+    firmware: 
+      name: "unknown version"
+      versions:
+        - 'TBD'
+
+  - case: (c699launch01)
+    rvitals: wspoon_dd2
+    ncpus: 176
+    memory: 
+      total: 572
+      banks: 16
+      bank_size:  32
+    clock:   
+      max: 3.50
+      min: 2.0
+    firmware:
+      name: 1742FxRev11
+      versions:
+        - 'BMC Firmware Product:   ibm-v2.0-0-r46-0-gbed584c (Active)*'
+        - 'HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.185 (Active)*'
+        - 'HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126'
+        - 'HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4'
+        - 'HOST Firmware Product: -- additional info: hostboot-8c017b7-pa10387d'
+        - 'HOST Firmware Product: -- additional info: hostboot-binaries-37be536'
+        - 'HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-pd73059d'
+        - 'HOST Firmware Product: -- additional info: machine-xml-94a137f'
+        - 'HOST Firmware Product: -- additional info: occ-f796766'
+        - 'HOST Firmware Product: -- additional info: op-build-v2.0.5-305-g9caa6d0'
+        - 'HOST Firmware Product: -- additional info: petitboot-v1.7.1-p22c6f3f'
+        - 'HOST Firmware Product: -- additional info: sbe-1b143b5'
+        - 'HOST Firmware Product: -- additional info: skiboot-v6.0.6'
+
+    gpu:
+      pciids:
+        - '0004:04:00.0'
+        - '0004:05:00.0'
+        - '0035:03:00.0'
+        - '0035:04:00.0'
+      device: "Tesla V100-SXM2-16GB"
+      vbios: "88.00.13.00.02"
+      clocks_applications_gr: 1530
+      clocks_applications_mem: 877
+      persistence_mode: Enabled
+      link_speed : 25
+    ib:
+      slot_rx: "00(03|33):01:00.(0|1)"
+      board_id: "IBM0000000002"
+      firmware: "16.22.8038"
+    nvme:
+      vendor: "Samsung"
+      firmware_rev: "MN12MN12"
+    temp:
+      celsius_high: "35.0"
+      celsius_low: "14.0"
+
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.5 (Maipo)"
+    kernel:
+      release: "4.14.0-49.10.1.el7a.ppc64le"
+    ufm:
+      ip_address: "10.7.0.41"
+      user: "admin"
+      password: "123456"
+
+    software:
+        - ibm-csm: 1.2.0-727
+        - gpfs.base: 5.0.1
+        - lm_sensors: 3.4.0-4.20160601gitf9185e5
+        - datacenter: 1.4.2-1
+        - cuda: 9-2-9.2.148-1 
+        - ibm_smpi: 10.02.00.05dev0
+
+  - case: (c699login\d+|c699wrk\d+)
+    rvitals: wspoon_dd2
+    ncpus: 176
+    memory: 
+      total: 572
+      banks: 16
+      bank_size:  32
+    clock:   
+      max: 3.50
+      min: 2.0
+    firmware:
+      name: 1742FxRev11
+      versions:
+        - 'BMC Firmware Product:   ibm-v2.0-0-r46-0-gbed584c (Active)*'
+        - 'HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.185 (Active)*'
+        - 'HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126'
+        - 'HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4'
+        - 'HOST Firmware Product: -- additional info: hostboot-8c017b7-pa10387d'
+        - 'HOST Firmware Product: -- additional info: hostboot-binaries-37be536'
+        - 'HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-pd73059d'
+        - 'HOST Firmware Product: -- additional info: machine-xml-94a137f'
+        - 'HOST Firmware Product: -- additional info: occ-f796766'
+        - 'HOST Firmware Product: -- additional info: op-build-v2.0.5-305-g9caa6d0'
+        - 'HOST Firmware Product: -- additional info: petitboot-v1.7.1-p22c6f3f'
+        - 'HOST Firmware Product: -- additional info: sbe-1b143b5'
+        - 'HOST Firmware Product: -- additional info: skiboot-v6.0.6'
+
+    gpu:
+      pciids:
+        - '0004:04:00.0'
+        - '0004:05:00.0'
+        - '0035:03:00.0'
+        - '0035:04:00.0'
+      device: "Tesla V100-SXM2-16GB"
+      vbios: "88.00.13.00.02"
+      clocks_applications_gr: 1530
+      clocks_applications_mem: 877
+      persistence_mode: Enabled
+      link_speed : 25
+    ib:
+      slot_rx: "00(03|33):01:00.(0|1)"
+      board_id: "IBM0000000002"
+      firmware: "16.22.8038"
+
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.5 (Maipo)"
+    kernel:
+      release: "4.14.0-49.10.1.el7a.ppc64le"
+    ufm:
+      ip_address: "10.7.0.41"
+      user: "admin"
+      password: "123456"
+
+    software:
+        - ibm-csm: 1.2.0-727
+        - gpfs.base: 5.0.1
+        - lm_sensors: 3.4.0-4.20160601gitf9185e5
+        - datacenter: 1.4.2-1
+        - cuda: 9-2-9.2.148-1 
+        - ibm_smpi: 10.02.00.05dev0
+    nvme:
+      vendor: "Samsung"
+      firmware_rev: "MN12MN12"
+    temp:
+      celsius_high: "35.0"
+      celsius_low: "14.0"
+
+#
+# 6 gpus
+#
+  - case: (c699c0([0-5]+[0-9]))
+    rvitals: wspoon_dd2
+    ncpus: 176
+    memory: 
+      total: 606
+      banks: 16
+      bank_size:  32
+    clock: 
+      max: 3.50
+      min: 2.0
+    firmware:
+      name: 1742FxRev11
+      versions:
+        - 'BMC Firmware Product:   ibm-v2.0-0-r46-0-gbed584c (Active)*'
+        - 'HOST Firmware Product:   IBM-witherspoon-ibm-OP9_v1.19_1.185 (Active)*'
+        - 'HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126'
+        - 'HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4'
+        - 'HOST Firmware Product: -- additional info: hostboot-8c017b7-pa10387d'
+        - 'HOST Firmware Product: -- additional info: hostboot-binaries-37be536'
+        - 'HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-pd73059d'
+        - 'HOST Firmware Product: -- additional info: machine-xml-94a137f'
+        - 'HOST Firmware Product: -- additional info: occ-f796766'
+        - 'HOST Firmware Product: -- additional info: op-build-v2.0.5-305-g9caa6d0'
+        - 'HOST Firmware Product: -- additional info: petitboot-v1.7.1-p22c6f3f'
+        - 'HOST Firmware Product: -- additional info: sbe-1b143b5'
+        - 'HOST Firmware Product: -- additional info: skiboot-v6.0.6'
+
+    gpu:
+      pciids:
+        - '0004:04:00.0'
+        - '0004:05:00.0'
+        - '0004:06:00.0'
+        - '0035:03:00.0'
+        - '0035:04:00.0'
+        - '0035:05:00.0'
+      device: "Tesla V100-SXM2-16GB"
+      vbios: "88.00.13.00.02"
+      clocks_applications_gr: 1530
+      clocks_applications_mem: 877
+      persistence_mode: Enabled
+      link_speed : 25
+    ib:
+      slot_rx: "00(03|33):01:00.(0|1)"
+      board_id: "IBM0000000002"
+      firmware: "16.22.8038"
+
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.5 (Maipo)"
+    kernel:
+      release: "4.14.0-49.10.1.el7a.ppc64le"
+    ufm:
+      ip_address: "10.7.0.41"
+      user: "admin"
+      password: "123456"
+
+
+    software:
+        - ibm-csm: 1.2.0-727
+        - gpfs.base: 5.0.1
+        - lm_sensors: 3.4.0-4.20160601gitf9185e5
+        - datacenter: 1.4.2-1
+        - cuda: 9-2-9.2.148-1 
+        - ibm_smpi: 10.02.00.05dev0
+    nvme:
+      vendor: "Samsung"
+      firmware_rev: "MN12MN12"
+    temp:
+      celsius_high: "35.0"
+      celsius_low: "14.0"
+
+  - case: c650f03p[07,09,11]
+    ncpus: 160
+    clock:   
+      max: 4.50
+      min: 2.0
+    firmware: 
+      name: "unknown version"
+      versions:
+        - 'BMC Firmware: 2.13'
+        - 'System Firmware Product Version: IBM-garrison-ibm-OP8_v1.10_2.1' 
+        - 'System Firmware Product Additional Info: op-build-0d23629'
+        - 'System Firmware Product Additional Info: buildroot-81b8d98'
+        - 'System Firmware Product Additional Info: skiboot-68b4d66-e0e8c0b'
+        - 'System Firmware Product Additional Info: hostboot-2cae1c6-1c89d8d'
+        - 'System Firmware Product Additional Info: linux-4.4.15-openpower1-c22576f'
+        - 'System Firmware Product Additional Info: petitboot-v1.2.1-e799385'
+        - 'System Firmware Product Additional Info: garrison-xml-a207cab'
+        - 'System Firmware Product Additional Info: occ-69fb587'
+        - 'System Firmware Product Additional Info: host'
+    memory: 
+      total: 251
+      banks: 0
+      bank_size:  0
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.3 (Maipo)"
+    kernel:
+      release: "3.10.0-514.el7.ppc64le"
+    software:
+        - ibm-csm: 1.3.0-769 
+    temp:
+      celsius_high: "100.0"
+      celsius_low: "14.0"
+#
+# gpfs mounts expected on all nodes.
+gpfs_mounts: 
+  - {mount: '/gpfs/wscgpfs01',  match: 'wscgpfs01' }
+  - {mount: '/gpfs/wscgpfs02',  match: 'wscgpfs02' }
+
+
+rvitals:
+  habenaro:
+    - {id: 'nada', match: 0 }
+  boston:
+    - {id: 'nada', match: 0 }
+  wspoon_dd2: 
+    - {id: 'Ambient', regex: (\S+), range: [10,40] }
+    # note this is an error, remove when correct in https://github.ibm.com/DCS-research/R92-cluster/issues/1710
+    - {id: 'Fan1 \d',  regex: (\S+), range: [0,24000] }
+    - {id: 'Fan[0-3] \d',  regex: (\S+), range: [2500,14000] }
+    - {id: 'P\d Vcs Temp',  regex: (\S+), range: [15,80]}
+    - {id: 'P\d Vdd Temp',  regex: (\S+), range: [15,80]}
+    - {id: 'P\d Vddr Temp',  regex: (\S+), range: [15,80]}
+    - {id: 'P\d Vdn Temp',  regex: (\S+), range: [15,80]}
+    - {id: 'Ambient', regex: (\S+), range: [10,40] }
+    - {id: 'DIMM\d+ Temp', regex: (\S+), range: [15,75,N/A]}
+    - {id: 'P\d Core6 Temp',    regex: (\S+), range: [0,90,N/A]}
+    - {id: 'P\d Core7 Temp',    regex: (\S+), range: [0,90,N/A]}
+
+    - {id: 'P\d Core\d Temp',    regex: (\S+), range: [10,90,N/A]}
+    - {id: 'P\d GPU Power',  regex: (\S+), range: [10,1800,N/A] }
+    - {id: 'P\d Io Power',  regex: (\S+), range: [10,500,N/A] }
+    - {id: 'P\d Mem Power',  regex: (\S+), range: [10,500,N/A] }
+    - {id: 'P\d Power',  regex: (\S+), range: [1,1800,N/A] }
+    - {id: 'Ps\d Input Power',  regex: (\S+), range: [10,1800,N/A] }
+    # Yesenia: Jordan keuseman says that the power supply will support until 300 Vac
+    - {id: 'Ps\d Input Voltage',  regex: (\S+), range: [200,300,N/A] }
+    - {id: 'Ps1 Output Current',  regex: (\S+), range: [0,100,N/A] }
+    - {id: 'Ps\d Output Voltage',  regex: (\S+), range: [10,400,0] }
+
+    - {id: 'Ps\d Output Current',  regex: (\S+), range: [10,100,N/A] }
+    - {id: 'Ps\d Output Voltage',  regex: (\S+), range: [300,400,N/A] }
+    - {id: 'Storage A Power',  regex: (\S+), range: [10,500,N/A] }
+    - {id: 'Storage B Power',  regex: (\S+), range: [10,500,N/A] }
+    - {id: 'Total Power',  regex: (\S+), range: [10,2000,N/A] }
+

--- a/csmtest/tools/complete_fvt.sh
+++ b/csmtest/tools/complete_fvt.sh
@@ -77,8 +77,8 @@ ${FVT_PATH}/buckets/error_injection/messaging.sh
 check_return $?
 #${FVT_PATH}/buckets/timing/allocation.sh
 #check_return $?
-#${FVT_PATH}/buckets/basic/hcdiag.sh
-#check_return $?
+${FVT_PATH}/buckets/basic/hcdiag.sh
+check_return $?
 ${FVT_PATH}/buckets/basic/csm_ctrl_cmd.sh
 check_return $?
 ${FVT_PATH}/tools/dual_aggregator/shutdown_daemons.sh


### PR DESCRIPTION
Added a static clustconf.yaml to be distributed for hcdiag regression. Also added the test cases that are dependent on that file to basic hcdiag bucket.

Added in this commit:
```
chk-cpu
chk-cpu-count
chk-sys-firmware
chk-memory
chk-aslr            
chk-os
chk-temp
```
Once approved I will merge to master