### PR TITLE
bb:Honor a return code value from bbProxy in sendTransferCompleteForF…

### DIFF
--- a/bb/src/BBTagInfo2.cc
+++ b/bb/src/BBTagInfo2.cc
@@ -669,7 +669,7 @@ void BBTagInfo2::sendTransferCompleteForFileMsg(const string& pConnectionName, c
 
         try
         {
-            rc = sendMsgAndWaitForNonDataReply(pConnectionName, l_Complete);
+            rc = sendMsgAndWaitForReturnCode(pConnectionName, l_Complete);
         }
         catch(exception& e)
         {

--- a/bb/src/connections.h
+++ b/bb/src/connections.h
@@ -50,7 +50,7 @@ typedef enum CONNECTION_SUSPEND_OPTION CONNECTION_SUSPEND_OPTION;
 class ResponseDescriptor
 {
   public:
-    
+
     volatile txp::Msg* reply;
     char attr[sizeof(txp::Attr_uint64)];
     std::string connName;
@@ -87,7 +87,7 @@ extern int sendMessage(const std::string& name, txp::Msg* msg);
 extern int sendMessage(const std::string& name, txp::Msg* msg, ResponseDescriptor& reply, bool addUidGid=0);
 extern int sendMessage2bbserver(const std::string& name, txp::Msg* msg, ResponseDescriptor& reply);
 bool const MUSTADDUIDGID=true;
-extern int sendMsgAndWaitForNonDataReply(const std::string& pConnectionName, txp::Msg* &pMsg);
+extern int sendMsgAndWaitForReturnCode(const std::string& pConnectionName, txp::Msg* &pMsg);
 
 typedef void(MessageHandlerFunc_t)(txp::Id id, const std::string& pConnectionName, txp::Msg* msg);
 extern int registerMessageHandler(int32_t id, MessageHandlerFunc_t* func);

--- a/transport/scripts/txpConfig.py
+++ b/transport/scripts/txpConfig.py
@@ -65,6 +65,7 @@ ATTRIBUTE_NAMES_TO_ADD = ('bbjob_objectversion',                # __u32
                           'option',                             # __u32
                           'performoperation',                   # __u32
                           'rate',                               # __u64
+                          'returncode',                         # __s32
                           'serializeversion',                   # __u32
                           'sizetransferred',                    # __u64
                           'sourcefile',                         # char*


### PR DESCRIPTION
…ileMsg().  Allows for the transfer definition to be marked as failed if the close related activitiy is not properly completed on the compute node.


# Pull Request Title

## Purpose
_Describe the problem or feature in addition to a link to the issues._

## Approach
_How does this change address the problem?_

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.
- [ ] Assign both @pdlun92 and @williammorrison2 to review (So they can check regression)
- [ ] Assign 1 developer to sanity check the code. (Working on automatically doing this via `./github/CODEOWNERS.md`)
- [ ] Replace suggested text in this template with real PR information. 
- [ ] Appropriatly label
- [ ] Assign a milestone. 

## How to Test

1. Think about what you want to test.
2. Test it.

## Screenshots

