### PR TITLE
added support for node range

### DIFF
--- a/csmi/src/inv/cmd/node_attributes_query.c
+++ b/csmi/src/inv/cmd/node_attributes_query.c
@@ -60,6 +60,7 @@ void help(){
 	puts("    -----------------|------------------|--------------");
 	puts("    -c, --comment    | \"csm.reserved.%\" | (STRING) Filter results by the comment field in the CSM database. This field will query by 'LIKE' so '%' are accepted. API will ignore NULL values.");
 	puts("    -n, --node_names | \"node01,node02\"  | (STRING) This is a csv field of node names to query. Filter results to only include records that have a matching node names. The node name is a unique identification for a node.");
+	puts("                     |                  | Valid formats: \"node01\", \"node01,node02\", or \"node[01-09]\"");
 	puts("    -s, --state      | \"IN_SERVICE\"     | (CSM_NODE_STATE) Filter results by the state field in the CSM database. API will ignore NULL values.");
 	puts("                     |                  | Valid values: \"undefined\", \"DISCOVERED\", \"IN_SERVICE\", \"OUT_OF_SERVICE\", \"ADMIN_RESERVED\", or \"SOFT_FAILURE\" ");
 	puts("    -t, --type       | \"compute\"        | (STRING) Filter results by the type field in the CSM database. API will ignore NULL values.");
@@ -152,8 +153,16 @@ int main(int argc, char *argv[])
 			case 'n':
             {
                 csm_optarg_test( "-n, --node_names", optarg, USAGE );
-				csm_parse_csv( optarg, input->node_names, input->node_names_count,
-                            char*, csm_str_to_char, NULL, "-n, --node_names", USAGE );
+				
+				int return_node_range = 0;	
+				
+				return_node_range = CORAL_stringTools_nodeRangeParser(optarg, &(input->node_names_count), &(input->node_names));
+				
+				if(return_node_range != 0)
+				{
+					//No range was found
+					csm_parse_csv( optarg, input->node_names, input->node_names_count, char*, csm_str_to_char, NULL, "-n, --node_names", USAGE );
+				}
 				
 				/* Increment optionalParameterCounter so later we can check if arguments were correctly set before calling API. */
 				optionalParameterCounter++;

--- a/csmi/src/inv/cmd/node_attributes_update.c
+++ b/csmi/src/inv/cmd/node_attributes_update.c
@@ -57,6 +57,7 @@ void help(){
 	puts("    Argument         | Example value   | Description  ");                                                 
 	puts("    -----------------|-----------------|--------------");
 	puts("    -n, --node_names | \"node01,node02\" | (STRING) This is a csv field of valid node names. Identifies which nodes will be updated.");
+	puts("                     |                 | Valid formats: \"node01\", \"node01,node02\", or \"node[01-09]\"");
 	puts("                     |                 | ");
 	puts("  OPTIONAL:");
 	puts("    csm_node_attributes_update can have 8 optional arguments");
@@ -146,8 +147,17 @@ int main(int argc, char *argv[])
 			case 'n':
 			{
                 csm_optarg_test( "-n, --node_names", optarg, USAGE )
-                csm_parse_csv( optarg, input->node_names, input->node_names_count, char*,
-                            csm_str_to_char, NULL, "-n, --node_names", USAGE )
+				
+				int return_node_range = 0;	
+				
+				return_node_range = CORAL_stringTools_nodeRangeParser(optarg, &(input->node_names_count), &(input->node_names));
+				
+				if(return_node_range != 0)
+				{
+					//No range was found
+					csm_parse_csv( optarg, input->node_names, input->node_names_count, char*, csm_str_to_char, NULL, "-n, --node_names", USAGE )
+				}
+				
 				/* Increment requiredParameterCounter so later we can check if arguments were correctly set before calling API. */
 				requiredParameterCounter++;
 				break;

--- a/utilities/include/string_tools.h
+++ b/utilities/include/string_tools.h
@@ -24,7 +24,9 @@ extern "C" {
 #endif
 
 //C includes
+#include <inttypes.h>
 #include <string.h>
+#include <stdint.h>
 
 /*
 * Author: Nick Buonarota
@@ -60,6 +62,23 @@ int CORAL_stringTools_seperatedValuesCount(char* myString, char delimiter, int* 
 *   4 ERROR: myString is NULL. Can not parse NULL string.
 */
 int CORAL_stringTools_nodeCount_xCATSyntax(char* myString, int* dataCount);
+
+/*
+* Author: Nick Buonarota
+* Last Edited: August 27, 2018
+* Summary: This function takes in a string and counts the number of 'nodes' based on a xCAT node range syntax of '[00-XY]'.
+* Parameters:
+*   char*     myString:     The string to compare.
+*   uint32_t* stringCount:  A pointer to an int. When this function finishes, this will contain
+*                           the number of 'seperated values' found in 'myString'.
+*   char***   stringArray:  A pointer to an array of strings. When this function finishes, this will contain
+*                           an array of 'seperated values' found in 'myString' with 'stringCount' elements. 
+*
+* Returns: int 
+*   0 Success
+*   1 ERROR: Generic error. Default.
+*/
+int CORAL_stringTools_nodeRangeParser(char* myString, uint32_t* stringCount, char*** stringArray);
 
 /*
 * Author: Nick Buonarota

--- a/utilities/src/string_tools.c
+++ b/utilities/src/string_tools.c
@@ -251,6 +251,201 @@ int CORAL_stringTools_nodeCount_xCATSyntax(char* myString, int* dataCount)
 
 /*
 * Author: Nick Buonarota
+* Last Edited: August 27, 2018
+* Summary: This function takes in a string and counts the number of 'nodes' based on a xCAT node range syntax of '[00-XY]'.
+* Parameters:
+*   char*     myString:     The string to compare.
+*   uint32_t* stringCount:  A pointer to an int. When this function finishes, this will contain
+*                           the number of 'seperated values' found in 'myString'.
+*   char***   stringArray:  A pointer to an array of strings. When this function finishes, this will contain
+*                           an array of 'seperated values' found in 'myString' with 'stringCount' elements. 
+*
+* Returns: int 
+*   0 Success
+*   1 ERROR: Generic error. Default.
+*   2 ERROR: noderange not present. generic
+*   3 ERROR: noderange not properly formatted. node range digits don't match. ie: 003 VS 05 ie: node[005-98]
+*   4 ERROR: noderange not properly formatted. node range is negative. ie: 100 VS 001 ie: node[100-001]
+*   5 ERROR: noderange not present. opening bracket '[' was not found
+*   6 ERROR: noderange not present. mid range dash '-' was not found
+*   7 ERROR: noderange not present. ending bracket ']' was not found
+*/
+int CORAL_stringTools_nodeRangeParser(char* myString, uint32_t* stringCount, char*** stringArray)
+{
+
+	// Function Variables 
+	// pointer location of the opening '[' bracket for the node range 
+	char* bracket_pointer = NULL;
+	
+	//search for the opening bracket 
+	bracket_pointer = strchr(myString,'[');
+
+	if(bracket_pointer == NULL)
+	{
+		//No range was found
+		//fprintf(stderr, "ERROR: opening bracket '[' was not found.\n");
+		//fprintf(stderr, "ERROR: determined noderange not present.\n");
+		return 5;
+	}else{
+		//range was found
+
+		// === Function Variables ===
+		// number of reserved characters before the opening bracket. aka, base node name 
+		int reserved_chars = 0;
+		//number of digits in the node range
+		int range_digits = 0;
+		//number of digits in the node range before '-', used to compare for a quality check
+		int range_digits_begin = 0;
+		//number of digits in the node range after '-', used to compare for a quality check
+		int range_digits_end = 0;
+		//used to later construct the full node name incrementally 
+		int range_counter = 0;
+		char range_counter_buffer[512];
+		// a reused string that will contain a full node name. 
+		char* base_node_name = NULL;
+		// ===========================
+		
+		//record the number of characters in the string before the '['
+		//aka, the base node name
+		reserved_chars = bracket_pointer-myString;
+
+		//find the dash
+		char* dash_pointer = NULL;
+		dash_pointer = strchr(myString,'-');
+
+		if(dash_pointer == NULL)
+		{
+			//No range was found
+			//fprintf(stderr, "ERROR: mid range dash '-' was not found.\n");
+			//fprintf(stderr, "ERROR: determined noderange not present.\n");
+			return 6;
+		}else
+		{
+			//good - found more format
+
+			//calculate the range digits
+			range_digits = (dash_pointer-myString+1) - (bracket_pointer-myString+1) -1;
+			range_digits_begin = range_digits;
+		}
+		
+		//find the end bracket
+		//only needed for testing quality. 
+		char* end_bracket_pointer = NULL;
+		end_bracket_pointer = strchr(myString,']');
+		
+		if(end_bracket_pointer == NULL)
+		{
+			//No range was found
+			//fprintf(stderr, "ERROR: ending bracket ']' was not found.\n");
+			//fprintf(stderr, "ERROR: determined noderange not present.\n");
+			return 7;
+		}
+		
+		//calculate the range digits
+		range_digits = (end_bracket_pointer-myString+1) - (dash_pointer-myString+1) -1;
+		range_digits_end = range_digits;
+		
+		//Quality check to make sure there is no mismatch between the opening range and closing range 
+		if(range_digits_begin != range_digits_end)
+		{
+			//illegal format detected. 
+			//fprintf(stderr, "ERROR: node range digits don't match.\n");
+			//fprintf(stderr, "ERROR: range_digits_begin: %i\n", range_digits_begin);
+			//fprintf(stderr, "ERROR: range_digits_end: %i\n", range_digits_end);
+			//fprintf(stderr, "ERROR: determined noderange was not properly formatted.\n");
+			return 3;
+		}
+
+		char* first_node_digit = NULL;
+
+		first_node_digit = (char*)calloc(range_digits+1,sizeof(char));
+		//memcpy the stuff out of myString
+		memcpy(first_node_digit, bracket_pointer+1, range_digits);
+
+		//grab the first node digit. save to int. 
+		//use this later to find total number of nodes
+		int first_node_digit_int = 0;
+		first_node_digit_int = atoi(first_node_digit);
+
+		//find end of range
+		char* last_node_digit = NULL;
+		last_node_digit = (char*)calloc(range_digits+1,sizeof(char));
+		//memcpy the stuff out of myString
+		memcpy(last_node_digit, dash_pointer+1, range_digits);
+
+		//grab the last node digit. save to int. use this later to find total number of nodes
+		int last_node_digit_int = 0;
+		last_node_digit_int = atoi(last_node_digit);
+
+		int totalNumberOfNodesInNodeRange = 0;
+		totalNumberOfNodesInNodeRange = last_node_digit_int - first_node_digit_int + 1;
+		
+		//make sure the begining of the node range is smaller than the end. 
+		if(totalNumberOfNodesInNodeRange < 0)
+		{
+			//illegal format detected. 
+			//fprintf(stderr, "ERROR: node range is negative: %i\n", totalNumberOfNodesInNodeRange);
+			//fprintf(stderr, "ERROR: determined noderange was not properly formatted.\n");
+			return 4;
+		}
+
+		//now that you know the total number of nodes in the range
+		//set the num nodes
+		*stringCount = totalNumberOfNodesInNodeRange;
+		//allocate the array
+		//so we can start filling up the node names
+		*stringArray = (char**)calloc(*stringCount, sizeof(char*));
+
+		//grab the base node name for the range
+		base_node_name = (char*)calloc(reserved_chars+1, sizeof(char));
+
+		memcpy(base_node_name, myString, reserved_chars);
+
+		//fill up all the node names in the range
+
+		//set up the first range counter
+		range_counter = first_node_digit_int;
+
+		char* full_node_name = NULL;
+
+		int i = 0;
+		for(i = 0; i < *stringCount; i++)
+		{
+			//reserve a node name with enough space for characters
+			// the reserved chars from above, plus the range digits, plus one for null terminated char
+			// example: c123f01p[01-10]
+			// reserved chars: c123f01p = 8
+			// range_digits: 01 = 2
+			// total space for malloc = 11
+			full_node_name = (char*)calloc(reserved_chars+range_digits+1,sizeof(char));
+
+			//memcpy the base node name
+			memcpy(full_node_name, base_node_name, reserved_chars);
+
+			//temp var for help
+			sprintf(range_counter_buffer, "%0*d", range_digits, range_counter);
+
+			//memcpy the node digits
+			memcpy(full_node_name + reserved_chars, range_counter_buffer, range_digits);
+
+			(*stringArray)[i] = strdup(full_node_name);
+
+			range_counter++;
+			free(full_node_name);
+		}
+	}
+	
+	//ToDo: What about a case where the node range has text? 
+	//Example: node[001-f45]
+	//it currently returns as node range is negative, improperly formatted.
+	//prevents an error, but could be more specific 
+	
+	return 0;
+}
+
+
+/*
+* Author: Nick Buonarota
 * Last Edited: July 11, 2018
 * Summary: This function takes in a string and compares it to CSM KEYWORDS.
 * Parameters:


### PR DESCRIPTION
# Added Support for node range

## Purpose
- working on https://github.com/NickyDaB/CAST/issues/15
- working on https://github.com/IBM/CAST/issues/222
- to give cmd line wrappers for CSM APIs support for a node range syntax like `node[01-09]`

## Approach
- not exactly a full solution to the core issue, but I did some work on this feature a few weeks ago in the R&D branch when I was looking into the issue with allocation query active all.
- I cleaned up some of that functionality into a function call.
- probably easy to use in multiple APIs.
- node attributes update and query is an example of using new function tool

#### Open Questions and Pre-Merge TODOs
- [ ] @pdlun92 please add a test case for this new feature
- Open Question: I'm not sure if we should bundle in `-n` like I did here, or expand out into a seperate flag like `-N, --node_range` if we do the second, then I can print out details of why the tool failed. but if we stick to the `-n` then I can't get specific because there may not be a node range on purpose ie: `-n "node01"` but keeping everything in `-n` seems more straight forward for a user. @whowutwut agrees to keep it as `-n`. look at `~/utilities/src/string_tools.c"` for more info

## How to Test

1. test the new feature. 
2. the tool itself can return multiple error codes that can be checked by a caller to report details. 
3. cmd line interfaces for `node_attributes_query` and `node_attributes_update` are the only two apis that use this tool at the moment. 

## Screenshots

```
[root@c650f03p41 bin]# ./csm_cluster_query_state 
---
# node_name  | collection_time            | update_time                | state      | type    | num_allocs - allocs - states - shared
#            +                            +                            +            +         +  
# c650f03p41 | 2018-08-27 13:59:30.917032 | 2018-08-27 13:58:32.653634 | DISCOVERED | utility |  0
# n01        | 1999-01-27 01:00:00        | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 1 - running - f
# n02        | 2016-01-27 02:00:00        | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 1 - running - f
# n03        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 1 - running - f
# n04        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 2 - running - f
# n05        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 2 - running - f
# n06        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 2 - running - f
# n07        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 3 - running - f
# n08        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 3 - running - f
# n09        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  1 - 3 - running - f
# n10        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n30        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n31        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n32        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n33        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n34        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n35        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
...
```


```
./csm_node_attributes_update -n n[01-09] -s "IN_SERVICE"
```

```
[root@c650f03p41 bin]# ./csm_cluster_query_state 
---
# node_name  | collection_time            | update_time                | state      | type    | num_allocs - allocs - states - shared
#            +                            +                            +            +         +  
# c650f03p41 | 2018-08-27 13:59:30.917032 | 2018-08-27 13:58:32.653634 | DISCOVERED | utility |  0
# n01        | 1999-01-27 01:00:00        | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 1 - running - f
# n02        | 2016-01-27 02:00:00        | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 1 - running - f
# n03        | 2018-08-27 13:58:03.465555 | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 1 - running - f
# n04        | 2018-08-27 13:58:03.465555 | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 2 - running - f
# n05        | 2018-08-27 13:58:03.465555 | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 2 - running - f
# n06        | 2018-08-27 13:58:03.465555 | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 2 - running - f
# n07        | 2018-08-27 13:58:03.465555 | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 3 - running - f
# n08        | 2018-08-27 13:58:03.465555 | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 3 - running - f
# n09        | 2018-08-27 13:58:03.465555 | 2018-08-27 16:55:20.115871 | IN_SERVICE | compute |  1 - 3 - running - f
# n10        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n30        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n31        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n32        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n33        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n34        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
# n35        | 2018-08-27 13:58:03.465555 | 2018-08-27 13:58:03.465555 | DISCOVERED | compute |  0
...

```
