### PR TITLE
add missing csmenv option to csm_ctrl command

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csm_ctrl_cmd_handler.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_ctrl_cmd_handler.cc
@@ -65,6 +65,10 @@ void CSM_CTRL_CMD_HANDLER::Process( const csm::daemon::CoreEvent &aEvent,
   {
     SET_SEVERITY_LEVEL(csmapi, option.get_log_csmapi());
   }
+  if (option.get_log_csmenv() != utility::bluecoral_sevs::NUM_SEVERITIES)
+  {
+    SET_SEVERITY_LEVEL(csmenv, option.get_log_csmenv());
+  }
   
   // process the options which would require to generate the response.
   // The response is simply a string

--- a/csmd/src/daemon/src/csmi_request_handler/ctrl_cmd_option.h
+++ b/csmd/src/daemon/src/csmi_request_handler/ctrl_cmd_option.h
@@ -36,6 +36,7 @@ public:
     _log_csmd = utility::bluecoral_sevs::NUM_SEVERITIES;
     _log_csmras = utility::bluecoral_sevs::NUM_SEVERITIES;
     _log_csmapi = utility::bluecoral_sevs::NUM_SEVERITIES;
+    _log_csmenv = utility::bluecoral_sevs::NUM_SEVERITIES;
     _dump_perf_data = false;
     _dump_mem_usage = false;
     _agg_reset = false;
@@ -52,6 +53,7 @@ private:
     ar & _log_csmd;
     ar & _log_csmras;
     ar & _log_csmapi;
+    ar & _log_csmenv;
     ar & _dump_perf_data;
     ar & _dump_mem_usage;
     ar & _agg_reset;
@@ -87,6 +89,11 @@ public:
     _log_csmapi = i_level;
   }
   utility::bluecoral_sevs get_log_csmapi() { return _log_csmapi; }
+  void set_log_csmenv(utility::bluecoral_sevs i_level)
+  {
+    _log_csmenv = i_level;
+  }
+  utility::bluecoral_sevs get_log_csmenv() { return _log_csmenv; }
   
   void set_dump_perf_data() { _dump_perf_data = true;}
   bool get_dump_perf_data() { return _dump_perf_data;}
@@ -103,6 +110,7 @@ private:
   utility::bluecoral_sevs _log_csmd;
   utility::bluecoral_sevs _log_csmras;
   utility::bluecoral_sevs _log_csmapi;
+  utility::bluecoral_sevs _log_csmenv;
   bool _dump_perf_data;
   bool _dump_mem_usage;
   bool _agg_reset;

--- a/csmd/src/daemon/tests/csm_ctrl_cmd.cc
+++ b/csmd/src/daemon/tests/csm_ctrl_cmd.cc
@@ -88,6 +88,7 @@ int ParseCommandLineOptions( int argc, char **argv, CtrlCmdOption &o_cmd_option 
   std::string log_csmnet;
   std::string log_csmras;
   std::string log_csmapi;
+  std::string log_csmenv;
   
   po::options_description usage("Supported Command Line Options");
   usage.add_options()
@@ -112,6 +113,9 @@ int ParseCommandLineOptions( int argc, char **argv, CtrlCmdOption &o_cmd_option 
             "Specify the severity level ")
         ("log.csmapi",
             po::value<std::string>(&log_csmapi),
+            "Specify the severity level ")
+        ("log.csmenv",
+            po::value<std::string>(&log_csmenv),
             "Specify the severity level ")
 
         ("agg.reset",
@@ -199,6 +203,20 @@ int ParseCommandLineOptions( int argc, char **argv, CtrlCmdOption &o_cmd_option 
     }
   }
   
+  if( vm.count( "log.csmenv" ) )
+  {
+    if (str2severity.find(log_csmenv) != str2severity.end())
+    {
+      o_cmd_option.set_log_csmenv(str2severity[log_csmenv]);
+      count++;
+    }
+    else
+    {
+      std::cout << "Invalid severity: " << log_csmenv << std::endl;
+      return -1;
+    }
+  }
+
   if( vm.count( "dump_perf_data" ) )
   {
     o_cmd_option.set_dump_perf_data();


### PR DESCRIPTION
# Add missing csmenv option to csm_ctrl command

## Purpose
Enable log-level change to csmenv component

## Approach
extended the existing lists of vars and functions to cover csmenv

Future improvements should address this by attempting to generate code based on the log subcomponent definitions.

## How to Test
Go to a compute or aggregator, call the ctrl-cmd to change the csmenv log level
```
 csm_ctrl_cmd --log.csmenv debug
```
Then check the csmd logfile and confirm that csmenv::debug entries appear after e.g. an environmental bucket has been triggered (depends on bucket interval in configuration of compute daemon)
