### PR TITLE
non-blocking connection review

### DIFF
--- a/csmnet/src/CPP/multi_endpoint.cc
+++ b/csmnet/src/CPP/multi_endpoint.cc
@@ -433,8 +433,6 @@ csm::network::MultiEndpoint::RecvFrom( csm::network::MessageAndAddress &aMsgAddr
     AddCtrlEvent( csm::network::NET_CTL_DISCONNECT, ep->GetRemoteAddr() );
     DeleteEndpoint( ep, "Recv:HUP" );
     rc = 0;
-    // warum schmeiß ich hier eine exception????
-    //throw csm::network::ExceptionEndpointDown( "Endpoint disconnected", ENOTCONN );
   }
   else // process any non-error activity
   {
@@ -474,11 +472,17 @@ csm::network::MultiEndpoint::RecvFrom( csm::network::MessageAndAddress &aMsgAddr
       catch ( csm::network::Exception &e )
       {
         if( aMsgAddr.GetAddr() == nullptr )
+        {
+          _Epoll.AckEvent();
           throw csm::network::Exception("BUG: RecvFrom is supposed to return the address of the down endpoint.");
+        }
 
         // permission errors will be handled by ReliableMsg and won't cause the endpoint to disconnect
         if( e.GetErrno() == EPERM )
+        {
+          _Epoll.AckEvent();
           throw;
+        }
 
         if(( aMsgAddr.GetAddr()->GetAddrType() != csm::network::CSM_NETWORK_TYPE_LOCAL ) && ( e.GetErrno() != 0 ))
         { LOG( csmnet, info ) << "Disconnect addr=:" << aMsgAddr.GetAddr()->Dump() << " :" << e.what();  }
@@ -857,7 +861,9 @@ csm::network::Endpoint * csm::network::EpollWrapper::NextActiveEP( const bool aB
     _ActiveEvents = epoll_wait( _CtrlSock, _EpollEvents, CSM_MULTENDPOINT_MAX_EVENTS, timeout );
     _CurrentEvent = 0;
     _CompletedEvent = 0;
-    if( _ActiveEvents <= 0 )
+    if( _ActiveEvents < 0 )
+      throw csm::network::ExceptionFatal("Epoll error during epoll_wait():", errno );
+    if( _ActiveEvents == 0 )
       ret = nullptr;
     else
       LOG(csmnet, debug) << "sock=" << _CtrlSock << " New EPOLL events: " << _ActiveEvents;


### PR DESCRIPTION
# non-blocking connection review

## Purpose
Reviewed the handling of non-blocking connect() for SSL and non-SSL connections between daemons. Potentially has an impact on issue #128 because there were some incorrect socket settings that got fixed.

#### Open Questions and Pre-Merge TODOs
Needs thorough testing especially with error cases where either the network or the peer daemon is not functioning properly. 

## How to Test
- regular function needs to be preserved
- in case a remote daemon is not responsive (stopped via signal, net cable pulled, firewall up), connection timeouts should be short to reduce the time the network thread waits for the timeout.
- especially important for compute daemons with 2 aggregators where one aggregator is unresponsive
- SSL connection becomes non-blocking with this PR which makes it useful to include SSL error cases too.