### PR TITLE
LSF and NVMe fixes

### DIFF
--- a/bb/scripts/bbtools.pm
+++ b/bb/scripts/bbtools.pm
@@ -190,9 +190,15 @@ $::BBPATH="/tmp/bblv_$::JOBUSER\_$::JOBID";
 $::BBPATH = $ENV{"BBPATH"} if($ENV{"BBPATH"} ne "");
 $ENV{"BBPATH"} = $::BBPATH;
 $::BBALL = join(",",0..$#::HOSTLIST_ARRAY);
-$::TARGET_NODE0 = "--jobstepid=1 --hostlist=$::HOSTLIST --target=0";
-$::TARGET_ALL   = "--jobstepid=1 --hostlist=$::HOSTLIST --target=0-";
-$::TARGET_QUERY = "--jobstepid=0 --hostlist=$::HOSTLIST --target=0";
+
+$hl = "";
+if($controller !~ /csm/i)
+{
+    $hl = " --hostlist=$::HOSTLIST";
+}
+$::TARGET_NODE0 = "--jobstepid=1$hl --target=0";
+$::TARGET_ALL   = "--jobstepid=1$hl --target=0-";
+$::TARGET_QUERY = "--jobstepid=0$hl --target=0";
 
 if(exists $ENV{"BSCFS_MNT_PATH"})
 {
@@ -326,6 +332,7 @@ sub getBBENVDir
         $jsondata = `/bin/cat /etc/ibm/bb.cfg`;
 	    $json = decode_json($jsondata);
         $bbenvdir = $json->{"bb"}{"envdir"};
+        $controller = $json->{"bb"}{"cmd"}{"controller"};
     };
     
     if($bbenvdir eq "")

--- a/bb/scripts/epsub.bb
+++ b/bb/scripts/epsub.bb
@@ -47,6 +47,9 @@ sub bbfail
 
 sub openBBENV
 {
+    $maskvalue = umask() | 7;  # mask off world bits
+    umask($maskvalue);
+    
     my $bbenvfile = &getBBENVName();
     open(BBENV, ">". $bbenvfile) || bbfail "Unable to open BB_ENVFILE file ($bbenvfile).  $!";
     
@@ -56,6 +59,12 @@ sub openBBENV
     {
         bbfail "Permissions on $bbenvfile are too broad, the group and world fields should be zero.";
     }
+}
+
+# Check for job submission failure and abort
+if($ENV{"LSB_SUB_JOB_ID"} eq "-1")
+{
+    exit(0);
 }
 
 if(!-d &getBBENVDir())

--- a/bb/scripts/nvmet.json
+++ b/bb/scripts/nvmet.json
@@ -6,7 +6,7 @@
         "adrfam": "ipv4", 
         "traddr": "127.0.0.1", 
         "treq": "not specified", 
-        "trsvcid": "1023", 
+        "trsvcid": "4420", 
         "trtype": "rdma"
       }, 
       "portid": 1, 

--- a/flightlog/src/buildFlightRegistry.pl
+++ b/flightlog/src/buildFlightRegistry.pl
@@ -311,6 +311,7 @@ sub outputHeader
         select STDOUT;
         close($fp);
         ($csum) = `sum $file` =~ /(\d+)/;
+        $csum =~ s/^0*//;
         open($fp, ">>$file");
         select $fp;
     }


### PR DESCRIPTION
New option in bbactivate to setup LSF.

Fixes apply to burstbuffer and burstbuffer-lsf RPMs on launch/login nodes, and a switch of the NVMe port to match IANA designation.  

Build issue with flightlogs potentially have a leading zero in the checksum calculation.  
