### PR TITLE
Update ras trace messages for consistency and easier debugging

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
@@ -93,7 +93,7 @@ void CSMIRasEventCreate::onRasPoolExit(RasEvent &rasEvent,
                                        const csm::daemon::CoreEvent &aEvent, 
                                        std::vector<csm::daemon::CoreEvent*>& postEventList)
 {
-    LOG(csmras, info) << "CSMIRasEventCreate::Process" << "onRasPoolExit = " << rasEvent.msg_id();
+    LOG(csmras, debug) << "CSMIRasEventCreate::Process" << "onRasPoolExit = " << rasEvent.msg_id();
 
     string suppressed = rasEvent.getValue(CSM_RAS_FKEY_SUPPRESSED);
     string ctxIdStr = rasEvent.getValue(CSM_RAS_FKEY_CTXID);       // get the remembered context id...
@@ -135,7 +135,7 @@ void CSMIRasEventCreate::onRasPoolExit(RasEvent &rasEvent,
      
     if (!db_write_resp_pending)
     {
-       LOG(csmras, debug) << "RAS EVENT COMPLETE   " << rasEvent.getLogString();
+       LOG(csmras, info) << "RAS EVENT COMPLETE   " << rasEvent.getLogString();
     }
 }
 
@@ -220,7 +220,7 @@ RasRc CSMIRasEventCreate::decodeRasEvent(csm::network::MessageAndAddress content
         strftime(time_stamp, 80, "%Y-%m-%d %H:%M:%S", info);    
         snprintf(time_stamp_with_usec, 80, "%s.%06lu", time_stamp, now_tv.tv_usec);
     
-        LOG(csmras, info) << "Optional parameter time_stamp is not set, setting to:" << time_stamp_with_usec;
+        LOG(csmras, debug) << "Optional parameter time_stamp is not set, setting to:" << time_stamp_with_usec;
         rasEvent.setValue(CSM_RAS_FKEY_TIME_STAMP, time_stamp_with_usec);
     }
     else
@@ -684,11 +684,11 @@ void CSMIRasEventCreate::Process( const csm::daemon::CoreEvent &aEvent,
                     }
                     else if (suppressed)
                     {
-                        LOG(csmras, debug) << "RAS EVENT SUPPRESSED " << rctx->_rasEvent->getLogString(); 
+                        LOG(csmras, info) << "RAS EVENT SUPPRESSED " << rctx->_rasEvent->getLogString() << " state:" << node_state; 
                     }
                     else
                     {
-                        LOG(csmras, debug) << "RAS EVENT DISABLED   " << rctx->_rasEvent->getLogString(); 
+                        LOG(csmras, info) << "RAS EVENT DISABLED   " << rctx->_rasEvent->getLogString(); 
                     }
                 }
 
@@ -733,7 +733,7 @@ void CSMIRasEventCreate::Process( const csm::daemon::CoreEvent &aEvent,
             else if (rctx->_state == CSMIRasEventCreateContext::WRITE_RAS_EVENT) 
             {
                 LOG(csmras, debug) << "RAS EVENT DB WR RESP " << rctx->_rasEvent->getLogString(); 
-                LOG(csmras, debug) << "RAS EVENT COMPLETE   " << rctx->_rasEvent->getLogString(); 
+                LOG(csmras, info) << "RAS EVENT COMPLETE   " << rctx->_rasEvent->getLogString(); 
             }
             else 
             {

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
@@ -695,7 +695,7 @@ void CSMIRasEventCreate::Process( const csm::daemon::CoreEvent &aEvent,
                 if (rasRc._rc != CSMI_SUCCESS) {
                     csm::daemon::NetworkEvent *ev = (csm::daemon::NetworkEvent *)reqEvent;
                     csm::network::MessageAndAddress c = ev->GetContent();
-                    LOG(csmras,error) << "CreateRasEvent error " << rec._msg_id << ": " << rasRc._errstr;
+                    LOG(csmras, error) << "RAS EVENT ERROR      " << rctx->_rasEvent->getLogString() << " errstr:" << rasRc._errstr; 
                     if (! c._Msg.GetInt() )
                         returnErrorMsg(c.GetAddr(), c._Msg, rasRc._rc, rasRc._errstr, postEventList);
 


### PR DESCRIPTION
This pull request contains minor modification to the CSM RAS trace messages to aid in determining how individual RAS events are processed, even when the csmras logging level is set to info. The goal is to provide two trace messages at the info level for every CSM RAS event received. The first message indicates that a new message has been received; the second message indicates what the final result of processing is.

Example traces for different results:
```
# Normal operation when a valid RAS event is being created and it is not disabled, suppressed, thresholded, etc:
2018-09-10 10:27:01.446219     csmras::info     | NEW RAS EVENT        ctx:15 ts:2018-09-10 10:27:01.445917 loc:c650f99p26 msg:csm.status.down
2018-09-10 10:27:01.480834     csmras::info     | RAS EVENT COMPLETE   ctx:15 ts:2018-09-10 10:27:01.445917 loc:c650f99p26 msg:csm.status.down

# A valid RAS event has been created, but recording of the event is suppressed due to the current state of the node:
2018-09-10 10:28:36.498916     csmras::info     | NEW RAS EVENT        ctx:16 ts:2018-09-10 10:28:36.498707 loc:c650f99p26 msg:csm.status.down
2018-09-10 10:28:36.500915     csmras::info     | RAS EVENT SUPPRESSED ctx:16 ts:2018-09-10 10:28:36.498707 loc:c650f99p26 msg:csm.status.down state:OUT_OF_SERVICE

2018-09-10 10:30:31.973510     csmras::info     | NEW RAS EVENT        ctx:18 ts:2018-09-10 10:30:31.973287 loc:c650f99p26 msg:csm.status.down
2018-09-10 10:30:31.975247     csmras::info     | RAS EVENT SUPPRESSED ctx:18 ts:2018-09-10 10:30:31.973287 loc:c650f99p26 msg:csm.status.down state:MAINTENANCE

# A valid RAS event has been created, but recording of the event is disabled due to the enabled/disabled setting in ras_msg_type policy table:
2018-09-10 10:31:44.657769     csmras::info     | NEW RAS EVENT        ctx:19 ts:2018-09-10 10:31:44.657580 loc:c650f99p26 msg:csm.status.down
2018-09-10 10:31:44.659966     csmras::info     | RAS EVENT DISABLED   ctx:19 ts:2018-09-10 10:31:44.657580 loc:c650f99p26 msg:csm.status.down

# An invalid RAS event has been requested or some other error has occurred:
2018-09-10 10:53:31.095877     csmras::info     | NEW RAS EVENT        ctx:15 ts:2018-09-10 10:53:31.095604 loc:c650f99p26 msg:csm.status.not_working
2018-09-10 10:53:31.097196     csmras::error    | RAS EVENT ERROR      ctx:15 ts:2018-09-10 10:53:31.095604 loc:c650f99p26 msg:csm.status.not_working errstr:RAS Event could not be created in database (invalid msg_id)
```

