### PR TITLE
Added support for CSM processor socket inventory collection

### DIFF
--- a/csmd/src/inv/include/inv_processor_inventory.h
+++ b/csmd/src/inv/include/inv_processor_inventory.h
@@ -1,0 +1,26 @@
+/*================================================================================
+   
+    csmd/src/inv/include/inv_processor_inventory.h
+
+  © Copyright IBM Corporation 2018. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+ 
+================================================================================*/
+#ifndef __INV_PROCESSOR_INVENTORY_H
+#define __INV_PROCESSOR_INVENTORY_H
+
+#include <stdint.h>       // Provides int32_t
+
+#include "csmi/src/inv/include/inv_types.h"
+
+// Returns true if successful, false if an error occurred 
+// If successful, processor_count will contain the number of entries populated in the processor_inventory array
+bool GetProcessorInventory(csm_processor_inventory_t processor_inventory[CSM_PROCESSOR_MAX_DEVICES], uint32_t& processor_count);
+
+#endif

--- a/csmd/src/inv/src/CMakeLists.txt
+++ b/csmd/src/inv/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CSM_INVENTORY_SRC
   ${CSMD_INV_SRC_DIR}/inv_dimm_inventory.cc
   ${CSMD_INV_SRC_DIR}/inv_gpu_inventory.cc
   ${CSMD_INV_SRC_DIR}/inv_hca_inventory.cc
+  ${CSMD_INV_SRC_DIR}/inv_processor_inventory.cc
   ${CSMD_INV_SRC_DIR}/inv_ssd_inventory.cc
   ${CSMD_INV_SRC_DIR}/inv_agent_handler.cc
   ${CSMD_INV_SRC_DIR}/inv_aggregator_handler.cc

--- a/csmd/src/inv/src/inv_full_inventory.cc
+++ b/csmd/src/inv/src/inv_full_inventory.cc
@@ -18,6 +18,7 @@
 #include "inv_gpu_inventory.h"
 #include "inv_hca_inventory.h"
 #include "inv_ssd_inventory.h"
+#include "inv_processor_inventory.h"
 #include "logging.h"
 
 using namespace std;
@@ -53,6 +54,12 @@ bool GetFullInventory(csm_full_inventory_t& inventory)
   }
   
   rc = GetSsdInventory(inventory.ssd, inventory.node.discovered_ssds);
+  if (rc == false)
+  {
+    LOG(csmd, warning) << "GetSsdInventory() returned false.";
+  }
+  
+  rc = GetProcessorInventory(inventory.processor, inventory.processor_count);
   if (rc == false)
   {
     LOG(csmd, warning) << "GetSsdInventory() returned false.";

--- a/csmd/src/inv/src/inv_processor_inventory.cc
+++ b/csmd/src/inv/src/inv_processor_inventory.cc
@@ -1,0 +1,205 @@
+/*================================================================================
+   
+    csmd/src/inv/src/inv_processor_inventory.cc
+
+  © Copyright IBM Corporation 2018. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+ 
+================================================================================*/
+#include "inv_processor_inventory.h"
+//#include "inv_functions.h"
+#include "logging.h"
+
+//#include <dirent.h>       // Provides scandir()
+//#include <glob.h>
+
+#include <string>
+//#include <fstream>
+//#include <list>
+//#include <stdint.h>
+
+using namespace std;
+
+// Helper function for copying strings to the processor_inventory structure
+// processor is the specific processor being processed, used for logging
+// field is the name of the value to be set, used for logging
+// value is the actual string to be copied into the processor_inventory structure
+// dest_ptr is a pointer to the destination in the structure (like snprintf)
+// DEST_MAX is the size of the dest_ptr buffer (like snprintf)
+void setProcessorInventoryValue(const string& processor, const string& field, const string& value, char* dest_ptr, const uint32_t& DEST_MAX);
+
+bool GetProcessorInventory(csm_processor_inventory_t processor_inventory[CSM_PROCESSOR_MAX_DEVICES], uint32_t& processor_count)
+{
+  LOG(csmd, trace) << "Enter " << __PRETTY_FUNCTION__;
+
+  processor_count = 0;
+
+#ifdef TODO 
+  // Scan the device-tree for the list of memory dimms
+  // Use globbing "*" for the @XXX portions of the directory names in case they change in the future 
+  // ls -d /proc/device-tree/xscom*/mcbist*/mcs*/mca*/dimm* | sort -t '/' -k8
+  // /proc/device-tree/xscom@603fc00000000/mcbist@2/mcs@8/mca@80/dimm@d000
+  // /proc/device-tree/xscom@603fc00000000/mcbist@2/mcs@8/mca@40/dimm@d001
+  // /proc/device-tree/xscom@603fc00000000/mcbist@2/mcs@4/mca@20/dimm@d002
+  // /proc/device-tree/xscom@603fc00000000/mcbist@2/mcs@4/mca@10/dimm@d003
+  // /proc/device-tree/xscom@603fc00000000/mcbist@1/mcs@2/mca@8/dimm@d004
+  // /proc/device-tree/xscom@603fc00000000/mcbist@1/mcs@2/mca@4/dimm@d005
+  // /proc/device-tree/xscom@603fc00000000/mcbist@1/mcs@1/mca@2/dimm@d006
+  // /proc/device-tree/xscom@603fc00000000/mcbist@1/mcs@1/mca@1/dimm@d007
+  // /proc/device-tree/xscom@623fc00000000/mcbist@2/mcs@8/mca@80/dimm@d008
+  // /proc/device-tree/xscom@623fc00000000/mcbist@2/mcs@8/mca@40/dimm@d009
+  // /proc/device-tree/xscom@623fc00000000/mcbist@2/mcs@4/mca@20/dimm@d00a
+  // /proc/device-tree/xscom@623fc00000000/mcbist@2/mcs@4/mca@10/dimm@d00b
+  // /proc/device-tree/xscom@623fc00000000/mcbist@1/mcs@2/mca@8/dimm@d00c
+  // /proc/device-tree/xscom@623fc00000000/mcbist@1/mcs@2/mca@4/dimm@d00d
+  // /proc/device-tree/xscom@623fc00000000/mcbist@1/mcs@1/mca@2/dimm@d00e
+  // /proc/device-tree/xscom@623fc00000000/mcbist@1/mcs@1/mca@1/dimm@d00f
+  const char PROCESSOR_GLOB_PATH[] = "/proc/device-tree/xscom*/mcbist*/mcs*/mca*/dimm*";
+  std::list<std::string> processorlist;
+
+  int32_t globflags(0);
+  glob_t processorpaths;
+  int32_t rc(0);
+
+  rc = glob(PROCESSOR_GLOB_PATH, globflags, nullptr, &processorpaths);
+  if (rc == 0)
+  {
+    for (uint32_t i=0; i < processorpaths.gl_pathc && i < CSM_PROCESSOR_MAX_DEVICES; i++)
+    {
+      LOG(csmd, debug) << "Found processor = " << processorpaths.gl_pathv[i];
+      processorlist.push_back(processorpaths.gl_pathv[i]);
+    }
+  }
+  else
+  {
+    LOG(csmd, warning) << "glob() returned rc=" << rc << " for " << PROCESSOR_GLOB_PATH << ". Firmware level may not support processor inventory.";
+  } 
+  
+  globfree(&processorpaths);
+  
+  for (list<string>::iterator processor_itr = processorlist.begin(); processor_itr != processorlist.end(); processor_itr++)
+  {
+    string processor = (*processor_itr).substr((*processor_itr).find("processor")) + ": ";   // Used for trace messages
+    bool fields_valid(true);
+ 
+    // Collect the serial number 
+    // cat /proc/device-tree/xscom@603fc00000000/mcbist@2/mcs@8/mca@80/dimm@d000/serial-number | hexdump -C | head -n 1
+    // 00000000  36 e3 d5 b5
+    ifstream serial_in(*processor_itr + "/serial-number", ios::binary);
+    uint32_t serial_integer(0); 
+    string serial_number("");
+    ostringstream serial_out;
+
+    if (serial_in.is_open())
+    {
+      serial_in.read((char*) &serial_integer, sizeof(serial_integer));
+      serial_integer = __builtin_bswap32(serial_integer); 
+      
+      serial_out << hex << serial_integer; 
+      serial_number = serial_out.str();
+     
+      if (serial_in.gcount() == 0)
+      {
+        LOG(csmd, warning) << processor << "detected empty processor serial_number";
+        fields_valid = false;
+      }
+    }
+    else
+    {
+      LOG(csmd, warning) << processor << "failed to read processor serial_number";
+      fields_valid = false;
+    }
+    serial_in.close();
+      
+    // Collect the size
+    // cat /proc/device-tree/xscom@603fc00000000/mcbist@2/mcs@8/mca@80/dimm@d000/size | hexdump -C | head -n 1
+    // 00000000  00 00 80 00 
+    ifstream size_in(*dimm_itr + "/size", ios::binary);
+    uint32_t size(0);
+
+    if (size_in.is_open())
+    {
+      size_in.read((char*) &size, sizeof(size));
+      size = __builtin_bswap32(size); 
+ 
+      if (size_in.gcount() == 0)
+      {
+        LOG(csmd, warning) << processor << "detected empty processor size";
+        fields_valid = false;
+      }
+    }
+    else
+    {
+      LOG(csmd, warning) << processor << "failed to read processor size";
+      fields_valid = false;
+    }
+    size_in.close();
+   
+    // Collect the physical location 
+    // cat /proc/device-tree/xscom@603fc00000000/mcbist@2/mcs@8/mca@80/dimm@d000/ibm,loc-code
+    // UOPWR.7852C0A-Node0-DIMM0
+    ifstream location_in(*processor_itr + "/ibm,loc-code");
+    string physical_location("");
+
+    if (location_in.is_open())
+    {
+      getline(location_in, physical_location);
+      location_in.close();    
+      physical_location = trimString(physical_location);
+ 
+      if (physical_location.empty())
+      {
+        LOG(csmd, warning) << processor << "detected empty processor physical_location";
+        fields_valid = false;
+      }
+    }
+    else
+    {
+      LOG(csmd, warning) << processor << "failed to read processor physical_location";
+      fields_valid = false;
+    }
+ 
+    if ((fields_valid) && (processor_count < CSM_PROCESSOR_MAX_DEVICES))
+    {
+      setProcessorInventoryValue(processor, "serial_number", serial_number, processor_inventory[processor_count].serial_number, CSM_PROCESSOR_SERIAL_NUMBER_MAX);
+      LOG(csmd, info) << processor << "size = " << size;
+      processor_inventory[processor_count].size = size;
+      setProcessorInventoryValue(processor, "physical_location", physical_location, processor_inventory[processor_count].physical_location, CSM_PROCESSOR_PHYSICAL_LOCATION_MAX);
+      processor_count++;
+    }
+  }
+
+  if (processorlist.size() > CSM_PROCESSOR_MAX_DEVICES)
+  {
+    LOG(csmd, warning) << "processor_inventory truncated to " << processor_count << " entries, " << processorlist.size() << " processors discovered.";
+  }
+#endif
+ 
+  return true;
+}
+
+void setProcessorInventoryValue(const string& processor, const string& field, const string& value, char* dest_ptr, const uint32_t& DEST_MAX)
+{
+  if ( !value.empty() )
+  {
+    LOG(csmd, info) << processor << field << " = " << value;
+    
+    strncpy(dest_ptr, value.c_str(), DEST_MAX);
+    dest_ptr[DEST_MAX - 1] = '\0'; 
+    
+    if (value.size() > (DEST_MAX-1))
+    {      
+      LOG(csmd, warning) << processor << field << " truncated to " << (DEST_MAX-1) << " bytes";
+    }
+  }
+  else
+  {
+    LOG(csmd, error) << processor << "Error: could not determine " << field;
+  }
+}

--- a/csmd/src/inv/tests/CMakeLists.txt
+++ b/csmd/src/inv/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 #   
 #    csmd/src/inv/tests/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2017. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -52,6 +52,15 @@ file(GLOB TEST_INV_HCA_INVENTORY
 add_executable(test_inv_hca_inventory ${TEST_INV_HCA_INVENTORY})
 target_link_libraries(test_inv_hca_inventory csmutil fsutil)
 install(TARGETS test_inv_hca_inventory COMPONENT csm-unittest DESTINATION csm/tests/inv)
+
+file(GLOB TEST_INV_PROCESSOR_INVENTORY
+  ../src/inv_processor_inventory.cc
+  test_inv_processor_inventory.cc 
+)
+
+add_executable(test_inv_processor_inventory ${TEST_INV_PROCESSOR_INVENTORY})
+target_link_libraries(test_inv_processor_inventory csmutil fsutil)
+install(TARGETS test_inv_processor_inventory COMPONENT csm-unittest DESTINATION csm/tests/inv)
 
 file(GLOB TEST_INV_SSD_INVENTORY
   ../src/inv_ssd_inventory.cc

--- a/csmd/src/inv/tests/test_inv_processor_inventory.cc
+++ b/csmd/src/inv/tests/test_inv_processor_inventory.cc
@@ -1,0 +1,45 @@
+/*================================================================================
+   
+    csmd/src/inv/tests/test_inv_processor_inventory.cc
+
+  © Copyright IBM Corporation 2018. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+ 
+================================================================================*/
+#include <iostream>
+
+#include "inv_processor_inventory.h"
+
+using std::cout;
+using std::endl;
+
+int main(void)
+{
+  csm_processor_inventory_t processor_inventory[CSM_PROCESSOR_MAX_DEVICES];
+  uint32_t processor_count(0);
+  bool rc(false);
+
+  rc = GetProcessorInventory(processor_inventory, processor_count);
+
+  if (rc == true)
+  {
+    for (uint32_t i = 0; i < processor_count; i++)
+    {
+      cout << "serial_number:          " << processor_inventory[i].serial_number << endl;
+      cout << "physical_location:      " << processor_inventory[i].physical_location << endl;
+      cout << "discovered_cores:       " << processor_inventory[i].discovered_cores << endl;
+    }
+  }
+  else
+  {
+    cout << "GetProcessorInventory() returned false." << endl;
+  }
+
+  return 0;
+}

--- a/csmi/include/csm_api_consts.h
+++ b/csmi/include/csm_api_consts.h
@@ -146,6 +146,15 @@
 #define CSM_HCA_SWITCH_GUID_MAX 20                // csm_hca.switch_guid_port_X
 
 //////////////////////////////////////////////////////////////////////////
+// Constants related to the csm_processor_socket table
+//////////////////////////////////////////////////////////////////////////
+
+// Maximum lengths of strings in the csm_processor_socket table:
+#define CSM_PROCESSOR_MAX_DEVICES 4                 // Maximum number of processor sockets per server
+#define CSM_PROCESSOR_SERIAL_NUMBER_MAX 16          // csm_processor_socket.serial_number
+#define CSM_PROCESSOR_PHYSICAL_LOCATION_MAX 40      // csm_processor_socket.physical_location
+
+//////////////////////////////////////////////////////////////////////////
 // Constants related to the csm_ssd table
 //////////////////////////////////////////////////////////////////////////
 

--- a/csmi/src/inv/include/inv_types.h
+++ b/csmi/src/inv/include/inv_types.h
@@ -165,14 +165,18 @@ typedef struct csm_full_inventory_t
   csm_gpu_inventory_t gpu[CSM_GPU_MAX_DEVICES];
   csm_hca_inventory_t hca[CSM_HCA_MAX_DEVICES];
   csm_ssd_inventory_t ssd[CSM_SSD_MAX_DEVICES];
-  
+  uint32_t processor_count; 
+  csm_processor_inventory_t processor[CSM_PROCESSOR_MAX_DEVICES];
+ 
   // Constructor 
   csm_full_inventory_t() :
   node(),
   dimm(),
   gpu(),
   hca(),
-  ssd()
+  ssd(),
+  processor_count(0),
+  processor()
   {}
 
 } csm_full_inventory_t;

--- a/csmi/src/inv/include/inv_types.h
+++ b/csmi/src/inv/include/inv_types.h
@@ -141,6 +141,23 @@ typedef struct csm_ssd_inventory_t
 
 } csm_ssd_inventory_t;
 
+typedef struct csm_processor_inventory_t
+{
+  char serial_number[CSM_PROCESSOR_SERIAL_NUMBER_MAX];
+  char physical_location[CSM_PROCESSOR_PHYSICAL_LOCATION_MAX];
+  uint32_t discovered_cores;
+  
+  // Constructor 
+  csm_processor_inventory_t()
+  { 
+    // Initialize the whole struct with 0s first; guarantees any pad bytes are also initialized
+    memset(this, 0, sizeof(*this));
+
+    // Set any non-zero defaults here
+  }
+
+} csm_processor_inventory_t;
+
 typedef struct csm_full_inventory_t
 {
   csm_node_inventory_t node;


### PR DESCRIPTION
This pull request contains support for CSM processor socket inventory collection. The processor socket inventory is collected every time csmd starts, like all node inventory items.

Example trace data and API output:
```
# Successful collection from a csmd compute daemon:
[COMPUTE]2018-09-11 14:21:15.949360       csmd::info     | processor@1000: serial_number = YA1934498223
[COMPUTE]2018-09-11 14:21:15.949393       csmd::info     | processor@1000: physical_location = UOPWR.787C48A-Node0-Proc0
[COMPUTE]2018-09-11 14:21:15.949421       csmd::info     | processor@1000: discovered_cores = 22
[COMPUTE]2018-09-11 14:21:15.950236       csmd::info     | processor@1001: serial_number = YA1934498225
[COMPUTE]2018-09-11 14:21:15.950265       csmd::info     | processor@1001: physical_location = UOPWR.787C48A-Node0-Proc1
[COMPUTE]2018-09-11 14:21:15.950290       csmd::info     | processor@1001: discovered_cores = 22

# The same data after it is received by the csmd master daemon for insertion into CSM DB:
2018-09-11 14:30:34.707349       csmd::info     | PROC_INV: c650f99p26-proc0:  - serial_number:         YA1934498223
2018-09-11 14:30:34.707382       csmd::info     | PROC_INV: c650f99p26-proc0:    physical_location:     UOPWR.787C48A-Node0-Proc0
2018-09-11 14:30:34.707416       csmd::info     | PROC_INV: c650f99p26-proc0:    discovered_cores:      22
2018-09-11 14:30:34.707457       csmd::info     | PROC_INV: c650f99p26-proc1:  - serial_number:         YA1934498225
2018-09-11 14:30:34.707491       csmd::info     | PROC_INV: c650f99p26-proc1:    physical_location:     UOPWR.787C48A-Node0-Proc1
2018-09-11 14:30:34.707524       csmd::info     | PROC_INV: c650f99p26-proc1:    discovered_cores:      22

# The same data when queried via csm_node_attributes_query_details:
/opt/ibm/csm/bin/csm_node_attributes_query_details -n c650f99p26 | egrep -A 50 processors_count | egrep -B 50 ssds_count
  processors_count:             2
  processors:
    - serial_number:     YA1934498223
      discovered_cores:  22
      physical_location: UOPWR.787C48A-Node0-Proc0
    - serial_number:     YA1934498225
      discovered_cores:  22
      physical_location: UOPWR.787C48A-Node0-Proc1
  ssds_count:                   1
```

I performed additional tests to confirm successful interoperation between compute and master daemons that either include or do not include processor socket inventory support.

If both daemons contain processor socket inventory support, behavior matches the output above.

If the compute daemon sends processor socket inventory to a master daemon that does not support it, no processor inventory will appear in the CSM DB or CSM API output.

If the compute daemon does not send processor socket inventory to a master daemon that supports it, no processor inventory will appear in the CSM DB or CSM API output.
In addition, a warning like this will appear in the CSM master log:
```
2018-09-11 14:23:00.962403       csmd::warning  | No processor_count received, probable version mismatch: in_payload_str.size() (2772) < offset (2772) + sizeof(out_inventory.processor_count) (4)
```