### PR TITLE
Fix for environmental, database and step timestamps.

### DIFF
--- a/csm_big_data/elasticsearch/mappings/templates/cast-counters-gpfs.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-counters-gpfs.json
@@ -12,6 +12,8 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
             }

--- a/csm_big_data/elasticsearch/mappings/templates/cast-counters-gpu.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-counters-gpu.json
@@ -12,6 +12,8 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
                 "data": {

--- a/csm_big_data/elasticsearch/mappings/templates/cast-counters-ufm.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-counters-ufm.json
@@ -12,6 +12,8 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
             }

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-dimm-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-dimm-env.json
@@ -12,12 +12,14 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },
-                "timestamp " : { "type" : "date" },
+                "timestamp"  : { "type" : "date", "format" : "yyyy-MM-dd HH:mm:ss.SSSSSS" },
                 "tags"       : { "type" : "text" },
-                "type"       : { "type" : "text" } ,
+                "type"       : { "type" : "text" },
                 "source"     : { "type" : "text" },
                 "data": {
                     "type" : "nested",

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-gpu-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-gpu-env.json
@@ -12,12 +12,14 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },
-                "timestamp"  : { "type" : "date" },
+                "timestamp"  : { "type" : "date", "format" : "yyyy-MM-dd HH:mm:ss.SSSSSS" },
                 "tags"       : { "type" : "text" },
-                "type"       : { "type" : "text" } ,
+                "type"       : { "type" : "text" },
                 "source"     : { "type" : "text" },
                 "data": {
 		            "type" : "nested",

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-node-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-node-env.json
@@ -12,12 +12,14 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },
-                "timestamp " : { "type" : "date" },
+                "timestamp"  : { "type" : "date",  "format" : "yyyy-MM-dd HH:mm:ss.SSSSSS" },
                 "tags"       : { "type" : "text" },
-                "type"       : { "type" : "text" } ,
+                "type"       : { "type" : "text" },
                 "source"     : { "type" : "text" },
                 "data": {
 		            "type" : "nested",

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-processor-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-processor-env.json
@@ -12,12 +12,14 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },
-                "timestamp " : { "type" : "date" },
+                "timestamp"  : { "type" : "date",  "format" : "yyyy-MM-dd HH:mm:ss.SSSSSS" },
                 "tags"       : { "type" : "text" },
-                "type"       : { "type" : "text" } ,
+                "type"       : { "type" : "text" },
                 "source"     : { "type" : "text" },
                 "data": {
 		            "type" : "nested",

--- a/csm_big_data/elasticsearch/mappings/templates/cast-db-csm.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-db-csm.json
@@ -1,5 +1,5 @@
 {
-    "index_patterns": ["cast-csmdb*"],
+    "index_patterns": ["cast-db-csm*"],
     "order" : 1,
     "settings" :{
         "index" : { 
@@ -8,10 +8,12 @@
         }
     },
     "aliases" : {
-        "cast-csmdb" : {}
+        "cast-db-csm" : {}
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast-log-console.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-log-console.json
@@ -12,6 +12,8 @@
     },
     "mappings": {
         "_doc" : {
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
                 "hostname"     : { "type" : "text" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast.json
@@ -12,7 +12,9 @@
                 "@timestamp" : { "type" : "date" },
                 "tags"       : { "type" : "text" },
                 "type"       : { "type" : "text" } 
-            }
+            },
+	        "dynamic_date_formats" : 
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"]
         }
     }
 }


### PR DESCRIPTION
The following pull request makes changes to the timestamp parsers in the elasticsearch index templates. This *should* repair all currently shipped timestamps.