### PR TITLE
Change timeout for csm_bb_cmd

### DIFF
--- a/csmconf/csm_api.cfg
+++ b/csmconf/csm_api.cfg
@@ -6,5 +6,6 @@
    "csm_allocation_step_end" : 120,
    "csm_allocation_step_begin" : 120,
    "csm_allocation_query" : 120,
+   "csm_bb_cmd" : 120,
    "csm_jsrun_cmd" : 60
 }


### PR DESCRIPTION
## Purpose
The burst buffer commands can exceed the 30 second CSM default timeout, particularly failover.  Increasing timeout of the csm_bb_cmd() to 2 minutes.  
