### PR TITLE
csm: issue #260; extended log msg to include forwarded error msg

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csmi_forward_handler.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_forward_handler.cc
@@ -121,9 +121,6 @@ void CSMI_FORWARD_HANDLER::Process( const csm::daemon::CoreEvent &aEvent, std::v
       std::string payload=msg.GetData();
       if ( msg.GetErr() || (! msg.Validate()) )
       {
-        LOG(csmd, info) << "CSMI_FORWARD_HANDLER: Forwarding ErrorMsg to client "
-            << ( dst_addr != nullptr ? dst_addr->Dump() : "N/A" )
-            << " for cmd: " << csmi_cmds_to_str( msg.GetCommandType() );
         csmi_err_t *err = csmi_err_unpack(msg.GetData().c_str(), msg.GetDataLen());
         if (err) 
         {
@@ -140,6 +137,10 @@ void CSMI_FORWARD_HANDLER::Process( const csm::daemon::CoreEvent &aEvent, std::v
               payload = std::string(buf, bufLen);
               free(buf);
             }
+            LOG(csmd, info) << csmi_cmds_to_str( msg.GetCommandType() )
+                << "[" << msg.GetReservedID() << "];"
+                << " CSMI_FORWARD_HANDLER: to client " << ( dst_addr != nullptr ? dst_addr->Dump() : "N/A" )
+                << "; ErrorMsg: " << err->errmsg;
           }
           csmi_err_free(err);
         }


### PR DESCRIPTION
Extending the log msg of the FWD handler to include the forwarded error msg

## Purpose
To improve debugging (see #260)

Adjusted the output to the info-level format of csmapi ( line begins with: cmd[id]; ) to help tracing command execution in case of failures.

## How to Test
Start the CSM infrastructure and call an API (anything other than the infrastructure health check) to cause an error (e.g. create allocation on non-existing node)
