### PR TITLE
non-blocking BDS connect

### DIFF
--- a/csmd/src/daemon/src/csm_bds_manager.cc
+++ b/csmd/src/daemon/src/csm_bds_manager.cc
@@ -236,6 +236,8 @@ csm::daemon::EventManagerBDS::SendData( const std::string data )
       remain -= rc;
       done += rc;
     }
+    if(( rc == -1 ) && ( errno == EINTR ))
+      rc = 0;
   }
 
   return ((rc >= 0) && ( remain == 0 ));

--- a/csmnet/src/CPP/endpoint_ptp.h
+++ b/csmnet/src/CPP/endpoint_ptp.h
@@ -196,17 +196,16 @@ protected:
           // check if the non-blocking socket completed the connect() or not, if not, use select+getsockopt to go check completion or error
           if( stored_errno == EINPROGRESS )
           {
-            --retries; // this is an incomplete connect, so we cannot count it as a "retry"
             stored_errno = CheckConnectActivity( _Socket );
             if( stored_errno == 0 )
               rc = 0;
           }
           // there are some error cases where we just shouldn't retry immediately
-          if(( stored_errno == EALREADY ) || ( stored_errno == EHOSTUNREACH ))
+          if(( stored_errno == EALREADY ) || ( stored_errno == EHOSTUNREACH ) || ( stored_errno == ECONNABORTED ))
             throw csm::network::ExceptionEndpointDown("Error while connecting. Not retrying immediately", stored_errno );
 
           LOG(csmnet, debug ) << "Connection attempt " << retries << " to :" << aSrvAddr->Dump()
-              << " failed: rc/errno=" << rc << "/" << errno
+              << " failed: rc/errno=" << rc << "/" << stored_errno
               << " Retrying after "
               << retries * 100 << "ms.";
 

--- a/csmnet/src/CPP/endpoint_ptp.h
+++ b/csmnet/src/CPP/endpoint_ptp.h
@@ -88,39 +88,9 @@ public:
 
   virtual int GetSocket() const { return _Socket; }
 
-protected:
-  virtual ssize_t SendMsgWrapper( const struct msghdr *aMsg, const int aFlags );
-  int SetGeneralSockopts();
-  void SetHeartbeatAddress( const Address_sptr &aAddr ) { _Heartbeat.setAddr( aAddr ); }
-
-  template<typename AddressClass>
-  int PrepareServerSocket()
-  {
-    int value = 1;
-    int rc = setsockopt( _Socket, SOL_SOCKET, SO_REUSEADDR, &value, sizeof( int ) );
-    if( rc )
-      throw csm::network::Exception("setsocket: SO_REUSEADDR");
-
-    rc = bind( _Socket,
-               (sockaddr*)&( dynamic_cast<AddressClass*>(_LocalAddr.get())->_SockAddr ),
-               sizeof( sockaddr_in ) );
-    if( rc )
-      throw csm::network::ExceptionEndpointDown("Bind error");
-
-    LOG(csmnet, debug) << "PrepareServerSocket(): bind to " << *dynamic_cast<AddressClass*>(_LocalAddr.get());
-
-    rc = listen( _Socket, 128 );
-    if( rc )
-      throw csm::network::Exception("Listen");
-    LOG(csmnet, debug) << "PrepareServerSocket(): Now listening on addr: "
-       << dynamic_cast<AddressClass*>(_LocalAddr.get())->Dump();
-
-    return rc;
-  }
-
   // checks if there's any available data on a socket
   // and retrieves and returns any errors via getsockopt
-  int CheckConnectActivity( int aSocket, bool aWithRead = false )
+  static inline int CheckConnectActivity( int aSocket, bool aWithRead = false )
   {
     int rc = 0;
 
@@ -153,6 +123,35 @@ protected:
     return rc;
   }
 
+protected:
+  virtual ssize_t SendMsgWrapper( const struct msghdr *aMsg, const int aFlags );
+  int SetGeneralSockopts();
+  void SetHeartbeatAddress( const Address_sptr &aAddr ) { _Heartbeat.setAddr( aAddr ); }
+
+  template<typename AddressClass>
+  int PrepareServerSocket()
+  {
+    int value = 1;
+    int rc = setsockopt( _Socket, SOL_SOCKET, SO_REUSEADDR, &value, sizeof( int ) );
+    if( rc )
+      throw csm::network::Exception("setsocket: SO_REUSEADDR");
+
+    rc = bind( _Socket,
+               (sockaddr*)&( dynamic_cast<AddressClass*>(_LocalAddr.get())->_SockAddr ),
+               sizeof( sockaddr_in ) );
+    if( rc )
+      throw csm::network::ExceptionEndpointDown("Bind error");
+
+    LOG(csmnet, debug) << "PrepareServerSocket(): bind to " << *dynamic_cast<AddressClass*>(_LocalAddr.get());
+
+    rc = listen( _Socket, 128 );
+    if( rc )
+      throw csm::network::Exception("Listen");
+    LOG(csmnet, debug) << "PrepareServerSocket(): Now listening on addr: "
+       << dynamic_cast<AddressClass*>(_LocalAddr.get())->Dump();
+
+    return rc;
+  }
 
   template<typename AddressClass>
   int ConnectPrep( const csm::network::Address_sptr aSrvAddr )


### PR DESCRIPTION
Non-blocking connection to BDS to solve issue #248 

## Approach
same mechanism as for daemon-to-daemon connections via non-blocking socket and check for activity via select with short timeout to avoid having to wait the default network timeout in worst case.

#### Open Questions and Pre-Merge TODOs
- So far, I haven't bothered to change the whole communication with BDS into non-blocking. So there's still some potential for send() operations to get stuck until timeout.

## How to Test
I have not been able to reliably reproduce the stuck connection.
Since we've never seen this in the wild, testing should focus on 'existing functionality preserved' for now. I'll update issue/PR/test team if I stumble over the problem again

## note:
the diff of endpoint_ptp.h shows an unrelated function being moved when actually CheckConnectActivity() has been moved to public and made static inline.