### PR TITLE
add debug/test env-data source

### DIFF
--- a/csmd/src/daemon/include/bucket_item_type_definitions.h
+++ b/csmd/src/daemon/include/bucket_item_type_definitions.h
@@ -13,6 +13,7 @@
 
 ================================================================================*/
 // USE UPPER CASE for each bucket item
+bucket_item(DEBUG)
 bucket_item(CPU)
 bucket_item(GPU)
 bucket_item(NETWORK)

--- a/csmd/src/daemon/include/csm_bds_keys.h
+++ b/csmd/src/daemon/include/csm_bds_keys.h
@@ -27,6 +27,7 @@
 #define CSM_BDS_TYPE_PROCESSOR_ENV "csm-processor-env"
 #define CSM_BDS_TYPE_GPU_ENV       "csm-gpu-env"
 #define CSM_BDS_TYPE_DIMM_ENV      "csm-dimm-env"
+#define CSM_BDS_TYPE_TEST_ENV      "csm-test-env"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // CSM_BDS_KEY_SOURCE - the source from which the reported data was collected 

--- a/csmd/src/daemon/include/csm_environmental_data.h
+++ b/csmd/src/daemon/include/csm_environmental_data.h
@@ -48,6 +48,8 @@ public:
 
   bool HasData() const;
 
+  void GenerateTestData();
+
 private:
    friend class boost::serialization::access;
 

--- a/csmd/src/daemon/src/csm_environmental_data.cc
+++ b/csmd/src/daemon/src/csm_environmental_data.cc
@@ -419,6 +419,17 @@ void CSM_Environmental_Data::AddDataItem(const boost::property_tree::ptree &data
    _data_list.push_back(data_pt);
 }
 
+void CSM_Environmental_Data::GenerateTestData()
+{
+  boost::property_tree::ptree dpt;
+  dpt.put(CSM_BDS_KEY_TYPE, CSM_BDS_TYPE_TEST_ENV);
+  dpt.put(CSM_BDS_KEY_SOURCE, _source_node);
+  dpt.put(CSM_BDS_KEY_TIME_STAMP, _timestamp);
+  dpt.put("data.debug", "Fixed generated debug/test data" );
+  _data_list.push_back( dpt );
+
+}
+
 bool CSM_Environmental_Data::HasData() const
 {
   return !_data_list.empty();

--- a/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.cc
@@ -74,6 +74,10 @@ void CSM_ENVIRONMENTAL::Process( const csm::daemon::CoreEvent &aEvent,
 
             break;
           }
+          case csm::daemon::DEBUG:
+            LOG( csmenv, info ) << "ENVDATA Collection debug.";
+            envData.GenerateTestData();
+            break;
           case csm::daemon::CPU:
           {
             LOG(csmenv, debug) << "Collecting CPU data.";


### PR DESCRIPTION
Adding a debug or test source for environmental data collection and BDS testing.

When running on a system that's not P9 and/or has no DCGM active, there will be no environmental data collection visible to the user or the aggregator or to BDS. This PR adds a DEBUG source that sends some fixed data (+time stamp and host name) an an env-data dummy.
The sole purpose is for testing if the env data from the compute node arrives in BDS at the configured interval for testbeds that have no hardware or firmware support for our existing data collection.

When configuring:
```
        "data_collection" :
        {
            "buckets":
                [
                    {
                        "execution_interval":"00:00:10",
                        "item_list" : ["debug"]
                    }
                ]
         }
```

This is an example test string that would be sent to BDS every 10s:
```
{"type":"csm-test-env","source":"hostname","timestamp":"2018-09-25 15:07:12.367419","data":{"debug":"Fixed generated debug\/test data"}}
```

This is obviously a low priority PR. I'm not assigning a milestone to it.
@fpizzano should decide whether we want that added or not.
