### PR TITLE
remove bb_cmd test program from RPM

### DIFF
--- a/csmi/src/bb/bb_cmds/CMakeLists.txt
+++ b/csmi/src/bb/bb_cmds/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmi/src/bb/bb_cmds/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2017. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -17,9 +17,9 @@
 include (${CMAKE_SOURCE_DIR}/csmd/csmd.cmake)
 
 # helloWorld testing executable for csm_bb_cmd
-add_executable(helloWorld bb_cmds_helloWorld.c)
-install(TARGETS helloWorld COMPONENT csm-api DESTINATION csm/bb_cmds)
-target_include_directories(helloWorld PRIVATE ./)
-target_link_libraries(helloWorld csmi csm_network_c csmutil)
+# add_executable(helloWorld bb_cmds_helloWorld.c)
+# install(TARGETS helloWorld COMPONENT csm-api DESTINATION csm/bb_cmds)
+# target_include_directories(helloWorld PRIVATE ./)
+# target_link_libraries(helloWorld csmi csm_network_c csmutil)
 
 add_definitions(-DUSE_SC_LOGGER)


### PR DESCRIPTION
# remove bb_cmd test program from RPM

## Purpose
A year ago we had a program `helloworld` that printed "hello world" to the console. we used this program to test the white list feature of the CSM API `csm_bb_cmd`. We no longer want to ship this program in the RPM. @fpizzano  requested this change. No issue was made. 

## Approach
The CMake file has been edited. the lines where the program was bundled into the RPM have been commented out. 
- *Note*: This makes some test cases located in `csmi\src\bb\tests` no longer able to run correctly because the above program no longer exists. 
- I discuss with @pdlun92 . He said we do not use these test cases, so it is ok. 

## How to Test

1. run an old build
2. see the program there
3. run the new build
2. see that the program is no longer there

