### PR TITLE
csm: add switches to enable/disable recurring tasks in config

### DIFF
--- a/csmconf/csm_master.cfg
+++ b/csmconf/csm_master.cfg
@@ -96,8 +96,10 @@
 
         "recurring_tasks":
         {
+            "enabled" : false,
             "soft_fail_recovery" :
             {
+                "enabled" : false,
                 "interval" : "00:01:00",
                 "retry" : 3
             }

--- a/csmd/src/daemon/include/csm_recurring_tasks.h
+++ b/csmd/src/daemon/include/csm_recurring_tasks.h
@@ -28,6 +28,7 @@ typedef struct
 {
   unsigned _Interval;
   unsigned _Retry;
+  bool _Enabled;
 } SoftFailRecovery_t;
 
 class RecurringTasks
@@ -52,10 +53,11 @@ public:
   inline bool IsEnabled() const { return _Enabled; }
 
   inline SoftFailRecovery_t GetSoftFailRecovery() const { return _SFRecovery; }
-  inline void SetSoftFailRecovery( const unsigned i_Interval, const unsigned i_Retry )
+  inline void SetSoftFailRecovery( const unsigned i_Interval, const unsigned i_Retry, const bool i_Enabled )
   {
     _SFRecovery._Interval = i_Interval;
     _SFRecovery._Retry = i_Retry;
+    _SFRecovery._Enabled = i_Enabled;
   }
 
   inline void UpdateLCM()


### PR DESCRIPTION
Introduce switches to enable or disable recurring tasks separately or entirely in config

#### Open Questions and Pre-Merge TODOs
The defaults currently set: false for everything because the corresponding handler only is a placeholder for later development.

## How to Test
```
        "recurring_tasks":
        {
            "enabled" : false,
            "soft_fail_recovery" :
            {
                "enabled" : false,
                "interval" : "00:01:00",
                "retry" : 3
            }
        }
```
* With everything set to false, the log should print info-level msg that shows the feature disabled.
* same should happen if you enable just the soft-fail-recovery section
* If recurring.tasks.enabled = true, the log should print info-level msg that indicates the feature disabled because there are no active tasks
* if both is set true, you should see info-level msg showing the settings for soft-fail-recovery (and the values should match the config; also, every minute you should see output from the placeholder handler
```
2018-09-25 17:51:40.567310       csmd::info     | INTERVAL_HDLR: INTERVAL: triggered handler to process
```
