### PR TITLE
 change log and output file location for UFM inv collection

### DIFF
--- a/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
+++ b/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
@@ -44,7 +44,7 @@ public:
 
   static INV_SWITCH_CONNECTOR_ACCESS* GetInstance(){ if( _Instance == nullptr ){ _Instance = new INV_SWITCH_CONNECTOR_ACCESS(); } return _Instance; } // get the istance of the class object
   int GetCompiledWithSupport(); // get compiled_with_support_flag
-  int ExecuteDataCollection(std::string rest_address, std::string authentication_string_for_the_http_request); // execute data collection
+  int ExecuteDataCollection(std::string rest_address, std::string authentication_string_for_the_http_request, std::string csm_inv_log_dir); // execute data collection
   std::string ReturnFieldValue(unsigned long int vector_id, unsigned long int index_in_the_vector); // return the value of the field
   int TotalNumberOfRecords();
   ~INV_SWITCH_CONNECTOR_ACCESS();

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -145,7 +145,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		}
 		
 		// opening output file
-		std::string output_file_name = "output_file.txt";
+		std::string output_file_name = csm_inv_log_dir + "/ufm_ib_cable_output_file.txt";
 		std::ofstream output_file(output_file_name.c_str(),std::ios::out);
 		
 		// checking if output file is open
@@ -178,7 +178,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::string comparing_string;
 		
 		// opening input file
-		std::string input_file_name = "output_file.txt";
+		std::string input_file_name = output_file_name;
 		std::ifstream input_file(input_file_name.c_str(),std::ios::in);
 		
 		// checking if input file is open

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -97,7 +97,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::GetCompiledWithSupport()
 	return compiled_with_support;
 }
 
-int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std::string authentication_string_for_the_http_request)
+int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std::string authentication_string_for_the_http_request, std::string csm_inv_log_dir)
 {
 	try
 	{	
@@ -171,7 +171,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		}
 		
 		// opening output file
-		std::string output_file_name = "output_file.txt";
+		std::string output_file_name = csm_inv_log_dir + "/ufm_switch_output_file.txt";
 		std::cout << "output file name: " << output_file_name << std::endl;
 		std::ofstream output_file(output_file_name.c_str(),std::ios::out);
 
@@ -209,7 +209,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		std::string comparing_string;
 
 		// opening input file
-		std::string input_file_name = "output_file.txt";
+		std::string input_file_name = output_file_name;
 		std::cout << "input file name: " << input_file_name << std::endl;
 		std::ifstream input_file(input_file_name.c_str(),std::ios::in);
 

--- a/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
+++ b/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
@@ -386,7 +386,7 @@ int main(int argc, char *argv[])
 		else 
 		{
 			// execute data collection for the switch cables
-			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request);
+			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir);
 		}
 	}
 
@@ -420,7 +420,7 @@ int main(int argc, char *argv[])
 		else
 		{
 			// execute data collection for the switch cables
-			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request);
+			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir);
 		}
 	}
 


### PR DESCRIPTION
# change log and output file location for UFM inv collection

## Purpose
we dont want to create output and log files in the same directory that we run the inv collection for ufm

## Approach
- store logs and output to dir specified in master config
- also makes output file names more obvious

## How to Test
1. run the ib switch inv collection
2. look in `/var/log/ibm/csm/inv`
3. Do you see the new files: 
```
[root@c650f03p31-mgt inv]# ls -l
total 100
-rw-r--r-- 1 root root  4553 Mar  6 23:35 bad_ib_cable_records.txt
-rw-r--r-- 1 root root 52440 Mar  6 23:35 ufm_ib_cable_output_file.txt
-rw-r--r-- 1 root root 40361 Mar  6 23:35 ufm_switch_output_file.txt

```
4. look in the ./ dir where you ran the collection program. you should no longer see an "output.txt" file

@pdlun92 you may need to update older test cases for UFM inv collection. 



