### PR TITLE
Reset OCC CSM sensor min and max values whenever environmental data is collected

### DIFF
--- a/csmd/src/daemon/src/csm_environmental_data.cc
+++ b/csmd/src/daemon/src/csm_environmental_data.cc
@@ -404,6 +404,13 @@ bool CSM_Environmental_Data::CollectEnvironmentalData()
       }
    }
 
+   // Reset the OCC CSM sensor min and max values for the next collection period
+   bool reset_successful = csm::daemon::helper::ResetOccCsmSensorMinMax();
+   if ( !reset_successful )
+   {
+      LOG(csmenv, warning) << "ResetOccCsmSensorMinMax() failed.";
+   }
+
    LOG(csmenv, debug) << "Finish CollectEnvironmentalData()";
 
    return success;

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/OCCSensorData.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/OCCSensorData.h
@@ -192,6 +192,13 @@ struct CsmOCCSensorRecord
 bool GetExtendedOCCSensorData( std::unordered_map<std::string,CsmOCCSensorRecord> &inMap, 
     std::vector<std::unordered_map<std::string,CsmOCCSensorRecord>> &outValues);
 
+/**
+ *  @brief Resets the CSM min and max sensor values for all chips in the node.
+ *
+ *  @return True if sensors were reset.
+ */
+bool ResetOccCsmSensorMinMax();
+
 } // helper
 } // daemon
 } // csm


### PR DESCRIPTION
OCC sensors provide a current value and min and max value for each sensor. The intended use of the min and max value is to capture the most extreme variations in sensor values that occur during a particular sample period. This pull request implements support in CSM for resetting the min and max values that CSM monitors so that they represent the min and max values that occurred since the last time CSM read the sensor values.

Some example data showing how the min and max sensors behave now that they are reset during each data collection period. In this test, the GPUs start out idle, then ramp up to run a heavy workload for 30 seconds, then return to idle. The data below is 8 data points for the same GPU, collected every 10 seconds. The data below shows periods where the temperature min and max have a large spread due to the GPU utilization ramping up or down during the collection period. There are also periods where the min and max have a small spread, indicating consistent GPU temperature (and utilization) during that period.

```
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:39:45.000678","data":{"gpu_id":"0","gpu_temp":"23","gpu_temp_min":"23","gpu_temp_max":"23","gpu_mem_temp":"22","gpu_mem_temp_min":"22","gpu_mem_temp_max":"22"}}
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:39:55.000573","data":{"gpu_id":"0","gpu_temp":"24","gpu_temp_min":"23","gpu_temp_max":"24","gpu_mem_temp":"22","gpu_mem_temp_min":"22","gpu_mem_temp_max":"22"}}
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:40:05.000772","data":{"gpu_id":"0","gpu_temp":"40","gpu_temp_min":"26","gpu_temp_max":"40","gpu_mem_temp":"34","gpu_mem_temp_min":"23","gpu_mem_temp_max":"34"}}
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:40:15.000747","data":{"gpu_id":"0","gpu_temp":"37","gpu_temp_min":"37","gpu_temp_max":"40","gpu_mem_temp":"39","gpu_mem_temp_min":"35","gpu_mem_temp_max":"39"}}
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:40:25.001126","data":{"gpu_id":"0","gpu_temp":"40","gpu_temp_min":"40","gpu_temp_max":"41","gpu_mem_temp":"36","gpu_mem_temp_min":"36","gpu_mem_temp_max":"36"}}
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:40:35.000721","data":{"gpu_id":"0","gpu_temp":"25","gpu_temp_min":"25","gpu_temp_max":"40","gpu_mem_temp":"25","gpu_mem_temp_min":"25","gpu_mem_temp_max":"36"}}
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:40:45.000776","data":{"gpu_id":"0","gpu_temp":"24","gpu_temp_min":"24","gpu_temp_max":"24","gpu_mem_temp":"24","gpu_mem_temp_min":"23","gpu_mem_temp_max":"25"}}
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-09-28 10:40:55.001112","data":{"gpu_id":"0","gpu_temp":"24","gpu_temp_min":"24","gpu_temp_max":"24","gpu_mem_temp":"23","gpu_mem_temp_min":"23","gpu_mem_temp_max":"24"}}

```


