### PR TITLE
General script cleanup

### DIFF
--- a/csmdb/sql/csm_history_table_archive_template.sh
+++ b/csmdb/sql/csm_history_table_archive_template.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #================================================================================
-#   
+#
 #    csm_history_table_archive_template.sh
-# 
+#
 #  © Copyright IBM Corporation 2015-2018. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
@@ -11,7 +11,7 @@
 #
 #    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
 #    restricted by GSA ADP Schedule Contract with IBM Corp.
-# 
+#
 #================================================================================
 
 #================================================================================
@@ -34,7 +34,6 @@ export PGOPTIONS='--client-min-messages=warning'
 OPTERR=0
 
 DEFAULT_DB="csmdb"
-logpath="/var/log/ibm/csm/db"
 logname="csm_db_archive_script.log"
 cd "${BASH_SOURCE%/*}" || exit
 now=$(date '+%Y-%m-%d')
@@ -43,42 +42,21 @@ now=$(date '+%Y-%m-%d')
 # Current user connected
 #-------------------------------------------------------------------------------
 
-current_user=`id -u -n`
 db_username="postgres"
-pid=$BASHPID
 parent_pid=$PPID
-
-#----------------------------------------------------------------
-# These are the variables for the avg processing
-#----------------------------------------------------------------
-
-count=0
-total=0
-average="0"
 
 dbname=$1
 archive_counter=$2
 table_name=$3
 data_dir=$4
 cur_path=$data_dir
-logpath=$data_dir   #<----- This file will live in "/var/log/ibm/csm/db" 
-
-#----------------------------------------------------------------
-# All the raw combined timing results before trimming
-# Along with csm allocation history archive results
-#----------------------------------------------------------------
-
-    time="$(time ( ls ) 2>&1 1>/dev/null )"
 
 #-------------------------------------------------------------------------------
 # psql history archive query execution
 #-------------------------------------------------------------------------------
-return_code=0
-if [ $? -ne 127 ]; then
-
 json_file="$cur_path/$table_name.archive.$now.json"
 swap_file="$cur_path/.$table_name.archive.$now.swp"
-archive_count_$table_name=$(`time psql -q -t -U $db_username -d $dbname << THE_END
+psql -q -t -U $db_username -d $dbname > /dev/null << THE_END
             \set AUTOCOMMIT off
             \set ON_ERROR_ROLLBACK on
             \set ON_ERROR_STOP TRUE
@@ -111,20 +89,11 @@ archive_count_$table_name=$(`time psql -q -t -U $db_username -d $dbname << THE_E
                         COPY (select count(*) from temp_$table_name)
                         to '$cur_path/${parent_pid}_$table_name.count';
            COMMIT;
-THE_END`
-)
+THE_END
 
-# Enrich the 
 awk -v table="$table_name" '{print "{\"type\":\"db-"table"\",\"data\":"$0"}" }' ${swap_file}\
     >> ${json_file}
 if [ $? -eq 0 ]
 then
     rm -f ${swap_file}
-fi
-
-else
-    echo "[Error] Archiving process for $table_name has been interrupted or terminated. please see log file"
-    LogMsg "[Error] Archiving process for $table_name has been interrupted or terminated. please see log file"
-    LogMsg "---------------------------------------------------------------------------------------"
-    return_code=1
 fi


### PR DESCRIPTION
Clean up stray whitespace.
Remove the unused variables.

Drop the initial "if [ $? -ne 127 ]; then" conditional.  This appears
to do little of actual use.  It would be checking the return code from
this line:

   time="$(time ( ls ) 2>&1 1>/dev/null )"

This seems to do nothing more than check if the "ls" command exists.
That seems like a silly check.  Even if checking for the runability
of "ls" made sense, the error and exit should happen immediately after
the check.  We shouldn't wrap the entire real work in this conditional.

Next, the actual psql command.  The output from the command is saved
to a variable named archive_count_$table_name.  This variable is
unused, so we remove that.  Next the command is wrapped in _two_
different subshell mechanisms, $() and ``.  That seems unnecessarily
redundant.  But we can get rid of them both and simply run the
command directly since we don't need to capture the output in a
variable.
