### PR TITLE
CSM ENV: remove GPU temperature sensors with invalid values from collected data

### DIFF
--- a/csmd/src/daemon/src/csm_environmental_data.cc
+++ b/csmd/src/daemon/src/csm_environmental_data.cc
@@ -345,9 +345,9 @@ bool CSM_Environmental_Data::CollectEnvironmentalData()
             for (auto sensor_itr = gpu_itr->begin(); sensor_itr != gpu_itr->end(); sensor_itr++)
             {
                auto occ_itr = current_values[chip].find(*sensor_itr);
-               if (occ_itr != current_values[chip].end())
+               if ( (occ_itr != current_values[chip].end()) && (occ_itr->second.sample != 0))
                {
-                  if ( (*sensor_itr == "TEMPGPU0") || (*sensor_itr == "TEMPGPU1") || (*sensor_itr == "TEMPGPU2") ) 
+                  if ( (*sensor_itr == "TEMPGPU0") || (*sensor_itr == "TEMPGPU1") || (*sensor_itr == "TEMPGPU2") )
                   {
                      check_and_insert_gpu_id_fields();
                      gpu_pt.put( "data.gpu_temp", std::to_string(occ_itr->second.sample) );


### PR DESCRIPTION
This pull request removes GPU sensor output with invalid data from the set of collected data in the environmental bucket.

Example data collected prior to this code change on a 4 GPU system:
```
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:09:41.001035","data":{"gpu_id":"0","gpu_temp":"23","gpu_temp_min":"23","gpu_temp_max":"24","gpu_mem_temp":"22","gpu_mem_temp_min":"21","gpu_mem_temp_max":"22"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:09:41.001035","data":{"gpu_id":"1","gpu_temp":"22","gpu_temp_min":"22","gpu_temp_max":"24","gpu_mem_temp":"21","gpu_mem_temp_min":"21","gpu_mem_temp_max":"22"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:09:41.001035","data":{"gpu_id":"2","gpu_temp":"0","gpu_temp_min":"65535","gpu_temp_max":"0","gpu_mem_temp":"0","gpu_mem_temp_min":"65535","gpu_mem_temp_max":"0"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:09:41.001035","data":{"gpu_id":"3","gpu_temp":"22","gpu_temp_min":"21","gpu_temp_max":"23","gpu_mem_temp":"22","gpu_mem_temp_min":"21","gpu_mem_temp_max":"22"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:09:41.001035","data":{"gpu_id":"4","gpu_temp":"24","gpu_temp_min":"24","gpu_temp_max":"25","gpu_mem_temp":"22","gpu_mem_temp_min":"22","gpu_mem_temp_max":"23"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:09:41.001035","data":{"gpu_id":"5","gpu_temp":"0","gpu_temp_min":"65535","gpu_temp_max":"0","gpu_mem_temp":"0","gpu_mem_temp_min":"65535","gpu_mem_temp_max":"0"}}
```

Example data collected after this code change on a 4 GPU system:
```
{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:21:56.000643","data":{"gpu_id":"0","gpu_temp":"23","gpu_temp_min":"23","gpu_temp_max":"23","gpu_mem_temp":"22","gpu_mem_temp_min":"21","gpu_mem_temp_max":"22"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:21:56.000643","data":{"gpu_id":"1","gpu_temp":"23","gpu_temp_min":"23","gpu_temp_max":"23","gpu_mem_temp":"21","gpu_mem_temp_min":"21","gpu_mem_temp_max":"21"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:21:56.000643","data":{"gpu_id":"3","gpu_temp":"22","gpu_temp_min":"22","gpu_temp_max":"22","gpu_mem_temp":"22","gpu_mem_temp_min":"21","gpu_mem_temp_max":"22"}}

{"type":"csm-gpu-env","source":"c650f99p18","timestamp":"2018-10-02 16:21:56.000643","data":{"gpu_id":"4","gpu_temp":"24","gpu_temp_min":"24","gpu_temp_max":"24","gpu_mem_temp":"22","gpu_mem_temp_min":"22","gpu_mem_temp_max":"23"}}
```