### PR TITLE
remove the temp file

### DIFF
--- a/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
+++ b/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
@@ -340,8 +340,8 @@ int main(int argc, char *argv[])
 	std::cout << std::endl;
 	
 	// cleaning
-	//command = "rm " + temp_file_name;
-	//std::system(command.c_str());
+	command = "rm " + temp_file_name;
+	system(command.c_str());
 	
 	// gathering flags
 	int ib_flag = INV_IB_CONNECTOR_ACCESS::GetInstance()->GetCompiledWithSupport();


### PR DESCRIPTION
# hotfix remove temp file

## Purpose
we found a temp file that shouldnt exist. 

## Approach
- uncomments a line that removes temp file
- but i'm not sure if we even need to use this temp file to store the data in this way. 
- will look for a better way to avoid making this temp file all together. 

## How to Test

1. if you run the `standalone_ib_collection` program a file named `temp_file.txt` would appear in the directory where you run it
2. now it doesnt

preview after: 
```
[nbuonar@c650f03p41 sbin]$ pwd
/u/nbuonar/repos/CAST/work/csm/sbin
[nbuonar@c650f03p41 sbin]$ 
[nbuonar@c650f03p41 sbin]$ 
[nbuonar@c650f03p41 sbin]$ ls -l
total 296576
-rwxr-xr-x 1 nbuonar users   6060056 Oct  3 14:28 csm_ctrl_cmd
-rwxr-xr-x 1 nbuonar users 134253440 Oct  3 14:28 csmd
-rwxr-xr-x 1 nbuonar users   9901368 Oct  3 14:27 csmrestd
-rwxr-xr-x 1 nbuonar users      2661 Oct  3 14:08 rotate-log-file.sh
-rwxr-xr-x 1 nbuonar users   1526152 Oct  3 14:40 standalone_ib_and_switch_collection
[nbuonar@c650f03p41 sbin]$ 

```