### PR TITLE
limiting BDS reconnect frequency

### DIFF
--- a/csmconf/csm_aggregator.cfg
+++ b/csmconf/csm_aggregator.cfg
@@ -56,7 +56,8 @@
         "bds" :
         {
                 "host" : "__LOGSTASH__",
-                "port" : 10522 
+                "port" : 10522,
+                "reconnect_interval_max" : 5
         }
     }
 }

--- a/csmd/src/daemon/include/bds_info.h
+++ b/csmd/src/daemon/include/bds_info.h
@@ -29,13 +29,15 @@ class BDS_Info
 {
   std::string _Hostname;
   std::string _Port;
+  unsigned _Reconnect_interval_max;
 
 public:
   BDS_Info( const std::string host = "",
-            const std::string port = "" )
+            const std::string port = "",
+            const unsigned reconn_interval_max = 0 )
   {
     if(( host != "" ) && ( port != "" ))
-      Init( host, port );
+      Init( host, port, reconn_interval_max );
     else
     {
       _Hostname = "";
@@ -47,9 +49,11 @@ public:
 
   std::string GetHostname() const { return _Hostname; }
   std::string GetPort() const { return _Port; }
+  unsigned GetReconnectIntervalMax() const { return _Reconnect_interval_max; }
 
   void Init( const std::string host,
-            const std::string port )
+             const std::string port,
+             const unsigned reconn_interval_max )
   {
     _Hostname = host;
 
@@ -63,6 +67,11 @@ public:
       throw csm::daemon::Exception("Invalid port found while initializing BDS_info");
 
     _Port = port;
+
+    _Reconnect_interval_max = reconn_interval_max;
+    if( _Reconnect_interval_max > 300 )
+      LOG( csmd, warning ) << "BDS reconnection interval is set to a long interval (" << _Reconnect_interval_max
+        << "s). This may cause unnecessary env-data not recorded in BDS.";
   }
 
   bool Active() const { return ! ( _Hostname.empty() || _Port.empty() ) ; }

--- a/csmd/src/daemon/include/csm_bds_manager.h
+++ b/csmd/src/daemon/include/csm_bds_manager.h
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <memory>
+#include <chrono>
 
 #include <signal.h>
 #include <time.h>
@@ -41,6 +42,7 @@ namespace daemon {
 
 class EventManagerBDS : public EventManager
 {
+  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
   BDS_Info _BDS_Info;
   boost::thread * _Thread;
   volatile std::atomic<bool> _KeepThreadRunning;
@@ -49,6 +51,7 @@ class EventManagerBDS : public EventManager
   std::atomic_bool _ReadyToRun;
   csm::daemon::RetryBackOff _IdleRetryBackOff;
 
+  TimeType _LastConnect;
   int _Socket;
 
 public:

--- a/csmd/src/daemon/include/csm_bds_manager.h
+++ b/csmd/src/daemon/include/csm_bds_manager.h
@@ -52,6 +52,7 @@ class EventManagerBDS : public EventManager
   csm::daemon::RetryBackOff _IdleRetryBackOff;
 
   TimeType _LastConnect;
+  unsigned _LastConnectInterval;
   int _Socket;
 
 public:

--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -1173,9 +1173,14 @@ void Configuration::CreateThreadPool()
     if( port_val.empty() )
       enabled = false;
 
+    std::string rci_max_val = GetValueInConfig( std::string("csm.bds.reconnect_interval_max") );
+    if( rci_max_val.empty() )
+      rci_max_val = "5";
+
     if( enabled )
     {
-      _BDS_Info.Init( host_val, port_val );
+      unsigned rci_max = (unsigned)std::strtoul( rci_max_val.c_str(), nullptr, 10 );
+      _BDS_Info.Init( host_val, port_val, rci_max );
       CSMLOG( csmd, info ) << "Configuring BDS access with: " << _BDS_Info.GetHostname() << ":" << _BDS_Info.GetPort();
     }
     else


### PR DESCRIPTION
This PR introduces a limited reconnect frequency for BDS access.

## Purpose
The pull request will prevent the BDS mgr from trying to connect for each and every env data item that arrives at an aggregator. Instead, it will only try to connect after a configurable interval.
The interval will increase from 1s to the configured max to allow more frequent retries after initial failure and slow down the connection attempts as it keeps failing.

## Approach
The BDS mgr remembers the time of the last failed connection attempt as well as the current interval for retries. Each time a new request arrives, it checks whether a new connection attempt is due or not.

#### Open Questions and Pre-Merge TODOs
- [ ] current default is set to 5 seconds max interval, need to decide whether this is a good default or not (@fpizzano )


## How to Test
1. Setup an env source with a short interval (to see the effect quicker)
2. Start test env (all daemons) without running BDS, so the connections fail
3. Each time any env data is sent, you would see either something similar to:
```
[AGG]2018-10-04 17:46:11.001578       csmd::debug    | BDSMGR: Connection to BDS is down.
[AGG]2018-10-04 17:46:11.001616       csmd::debug    | BDSMGR: Last connect attempt (5s ago ) was within the past 7s (max=10), skipping...
[AGG]2018-10-04 17:46:11.001647       csmd::warning  | BDSMGR: Failed sending to BDS: {"type":"csm-test-env","source":"hostname","time...
```
when the BDS connect is skipped. Or:
```
[AGG]2018-10-04 17:45:58.003517       csmd::debug    | BDSMGR: Connection to BDS is down.
[AGG]2018-10-04 17:45:58.004530       csmd::warning  | BDSMGR: Unable to connect to BDS at localhost:10522 No functional connection path found.
[AGG]2018-10-04 17:45:58.004598       csmd::warning  | BDSMGR: Failed sending to BDS: {"type":"csm-test-env","source":"hostname","time...
```
when the BDS connection failed
