### PR TITLE
hcdiag: Fix missing 'warn' key in VERBOSE_LEVEL

### DIFF
--- a/hcdiag/src/framework/hcdiag_run.py
+++ b/hcdiag/src/framework/hcdiag_run.py
@@ -71,7 +71,8 @@ def list_available_test_bucket(tconfig, alist) :
 #------------------------------------------------------------------------------ 
 
 VERBOSE_LEVEL= {
-   'info'       : logging.INFO, 
+   'info'       : logging.INFO,
+   'warn'       : logging.WARN,
    'error'      : logging.ERROR,
    'critical'   : logging.CRITICAL,
    'debug'      : logging.DEBUG,


### PR DESCRIPTION
Fixes the following exception:
```
# /opt/ibm/csm/hcdiag/bin/hcdiag_run.py --test daxpy --verbose warn
Traceback (most recent call last):
  File "/opt/ibm/csm/hcdiag/bin/hcdiag_run.py", line 186, in <module>
    console_level=VERBOSE_LEVEL[mconfig['console_verbose'].lower()]
KeyError: 'warn'
```
I'm an IBMer, no need for CLA.