### PR TITLE
csm: candidate solution for #311 preventing additional output or errors

### DIFF
--- a/csmd/src/daemon/src/csm_daemon.cc
+++ b/csmd/src/daemon/src/csm_daemon.cc
@@ -63,7 +63,9 @@ int csm::daemon::Daemon::Run( int argc, char **argv )
 
   csm::daemon::EventManagerPool evMgrPool;
   csm::daemon::ThreadManager *threadMgr = nullptr;
-  
+
+  setLoggingLevel(csmd, info); // start with info level logging until it's changed by config
+
   csm::daemon::RetryBackOff ConnectRetry( "ConnectMain",
                                           RetryBackOff::SleepType::MICRO_SLEEP,
                                           RetryBackOff::SleepType::MICRO_SLEEP,

--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -556,7 +556,7 @@ bool Configuration::ParseCommandLineOptions( int argc, char **argv )
   {
       std::cerr << usage << std::endl;
       errno = 0;
-      throw csm::daemon::Exception("Invalid command line Option.");
+      exit(0);
   }
 
   // add cmd-line options to property_tree


### PR DESCRIPTION
This PR removes any additional output from execution of ```csmd -h```
It performs a rough exit(0) instead of a detailed tear-down, however, it should be fine because at that point there are not many structures created (if any at all).