### PR TITLE
change the starting pointer location for the search

### DIFF
--- a/utilities/src/string_tools.c
+++ b/utilities/src/string_tools.c
@@ -311,7 +311,7 @@ int CORAL_stringTools_nodeRangeParser(char* myString, uint32_t* stringCount, cha
 
 		//find the dash
 		char* dash_pointer = NULL;
-		dash_pointer = strchr(myString,'-');
+		dash_pointer = strchr(bracket_pointer,'-');
 
 		if(dash_pointer == NULL)
 		{


### PR DESCRIPTION
# Fix node range

## Purpose
addresses issues raised in #318 

## Related Issues
- working on https://github.com/IBM/CAST/issues/318

## Approach
- change the starting pointer location for the search

## How to Test

1. reproduce the screenshot in #318 
2. reproduce screenshot below after new code. 

## Screenshots

```
[root@c650f03p31-vm02 bin]# ./csm_node_attributes_update -n c650f03p31-vm[06-09] -s "ADMIN_RESERVED"
---
# All 4 record(s) successfully updated.
...
```

