### PR TITLE
Add shutdown option to bbactivate for mmaddcallback

### DIFF
--- a/bb/scripts/bbactivate.pl
+++ b/bb/scripts/bbactivate.pl
@@ -146,6 +146,7 @@ GetOptions(
     "server!"         => \$CFG{"bbServer"},
     "ln!"             => \$CFG{"bbcmd"},
     "health!"         => \$CFG{"bbhealth"},
+    "shutdown!"       => \$CFG{"shutdown"},
     "envdir=s"        => \$CFG{"envdir"},
     "lsfdir=s"        => \$CFG{"lsfdir"},
     "bscfswork=s"     => \$CFG{"bscfswork"},
@@ -174,6 +175,13 @@ if(! isRoot())
 }
 
 getNodeName();
+
+if($CFG{"shutdown"})
+{
+    stopServices();
+    exit(0);
+}
+
 makeConfigFile() if($CFG{"skip"} !~ /config/i);
 
 if($CFG{"bbServer"})
@@ -216,6 +224,7 @@ sub setDefaults
     &def("bbServer",         1, 0);
     &def("bbcmd",            1, 0);
     &def("bbhealth",         1, 1);
+    &def("shutdown",         1, 0);
     &def("sslcert",          1, "default");
     &def("sslpriv",          1, "default");
     &def("metadata",         1, "");
@@ -575,6 +584,14 @@ sub startHealth
 {
     setprefix("Starting bbHealth: ");
     cmd("service bbhealth restart") if($CFG{"bbhealth"});
+}
+
+sub stopServices
+{
+    setprefix("Stop Services: ");
+    cmd("service bbhealth stop");
+    cmd("service bbproxy stop");
+    cmd("service bbserver stop");
 }
 
 sub isNVMeTargetOffloadCapable

--- a/bb/scripts/bbactivate.pod
+++ b/bb/scripts/bbactivate.pod
@@ -65,6 +65,9 @@ Enable or disable utilizing CSM infrastructure.  CSM agents must be active on th
 On login/launch node, CSM infrastructure will be used to send bbcmd rather than using passwordless ssh.
 On bbProxy, volume group and logical volumes will be tracked in CSM databases.  RAS messages will also be sent to CSM.  
 
+=item B<--shutdown>
+
+Shutdown all burst buffer services running on the node.  
 
 =item B<--sslcert>
 


### PR DESCRIPTION
Shutdown of Spectrum Scale was inhibited by bbServer running on the I/O nodes.  This fix adds an option to shutdown burst buffer services that can be called via mmaddcallback.  

e.g.,:
mmaddcallback BBShutdown --command /opt/ibm/bb/scripts/bbactivate --parms '--shutdown' --event preShutdown
