### PR TITLE
Explicitly mark configuration file as readable by group/other

### DIFF
--- a/bb/scripts/bbactivate.pl
+++ b/bb/scripts/bbactivate.pl
@@ -315,6 +315,7 @@ sub makeConfigFile
     my $jsonoo = JSON->new->allow_nonref->canonical;
     my $out    = $jsonoo->pretty->encode($json);
     writeConfiguration($CFG{"outputconfig"}, $out);
+    cmd("chmod u=rw,go=r " . $CFG{"outputconfig"});
 }
 
 sub makeLNConfigFile


### PR DESCRIPTION
bb.cfg should be marked 0644, but its possible the bbactivate caller's umask may not be 0022.  
