### PR TITLE
BDS msg caching at aggregator

### DIFF
--- a/csmconf/csm_aggregator.cfg
+++ b/csmconf/csm_aggregator.cfg
@@ -58,7 +58,7 @@
                 "host" : "__LOGSTASH__",
                 "port" : 10522,
                 "reconnect_interval_max" : 5,
-                "data_cache_expiration" : 50
+                "data_cache_expiration" : 600
         }
     }
 }

--- a/csmconf/csm_aggregator.cfg
+++ b/csmconf/csm_aggregator.cfg
@@ -57,7 +57,8 @@
         {
                 "host" : "__LOGSTASH__",
                 "port" : 10522,
-                "reconnect_interval_max" : 5
+                "reconnect_interval_max" : 5,
+                "data_cache_expiration" : 50
         }
     }
 }

--- a/csmd/src/daemon/include/bds_info.h
+++ b/csmd/src/daemon/include/bds_info.h
@@ -30,14 +30,16 @@ class BDS_Info
   std::string _Hostname;
   std::string _Port;
   unsigned _Reconnect_interval_max;
+  unsigned _Data_cache_expiration;
 
 public:
   BDS_Info( const std::string host = "",
             const std::string port = "",
-            const unsigned reconn_interval_max = 0 )
+            const unsigned reconn_interval_max = 0,
+            const unsigned data_cache_expiration = 0 )
   {
     if(( host != "" ) && ( port != "" ))
-      Init( host, port, reconn_interval_max );
+      Init( host, port, reconn_interval_max, data_cache_expiration );
     else
     {
       _Hostname = "";
@@ -50,10 +52,12 @@ public:
   std::string GetHostname() const { return _Hostname; }
   std::string GetPort() const { return _Port; }
   unsigned GetReconnectIntervalMax() const { return _Reconnect_interval_max; }
+  unsigned GetDataCacheExpiration() const { return _Data_cache_expiration; }
 
   void Init( const std::string host,
              const std::string port,
-             const unsigned reconn_interval_max )
+             const unsigned reconn_interval_max,
+             const unsigned data_cache_expiration )
   {
     _Hostname = host;
 
@@ -72,6 +76,12 @@ public:
     if( _Reconnect_interval_max > 300 )
       LOG( csmd, warning ) << "BDS reconnection interval is set to a long interval (" << _Reconnect_interval_max
         << "s). This may cause unnecessary env-data not recorded in BDS.";
+
+    _Data_cache_expiration = data_cache_expiration;
+    if( _Data_cache_expiration > 1000 )
+      LOG( csmd, warning ) << "BDS data cache expiration is set to a long interval (" << _Data_cache_expiration
+        << "s). This may cause high memory usage in csmd.";
+
   }
 
   bool Active() const { return ! ( _Hostname.empty() || _Port.empty() ) ; }

--- a/csmd/src/daemon/include/bds_info.h
+++ b/csmd/src/daemon/include/bds_info.h
@@ -78,7 +78,7 @@ public:
         << "s). This may cause unnecessary env-data not recorded in BDS.";
 
     _Data_cache_expiration = data_cache_expiration;
-    if( _Data_cache_expiration > 1000 )
+    if( _Data_cache_expiration > 3600 )
       LOG( csmd, warning ) << "BDS data cache expiration is set to a long interval (" << _Data_cache_expiration
         << "s). This may cause high memory usage in csmd.";
 

--- a/csmd/src/daemon/include/csm_bds_event.h
+++ b/csmd/src/daemon/include/csm_bds_event.h
@@ -16,6 +16,11 @@
 #ifndef CSMD_SRC_DAEMON_INCLUDE_CSM_BDS_EVENT_H_
 #define CSMD_SRC_DAEMON_INCLUDE_CSM_BDS_EVENT_H_
 
+#include "csm_core_event.h"
+
+#include <string>
+#include <deque>
+
 namespace csm {
 namespace daemon {
 

--- a/csmd/src/daemon/src/csm_bds_manager.cc
+++ b/csmd/src/daemon/src/csm_bds_manager.cc
@@ -300,7 +300,7 @@ csm::daemon::EventManagerBDS::CheckCachedData()
     CSMLOG( csmd, trace ) << "@: " << GetTimestamp().time_since_epoch().count() << "; Found entry with age: " << expired.count();
     if( expired.count() > _BDS_Info.GetDataCacheExpiration() )
     {
-      CSMLOG( csmd, debug ) << "Dropping expired BDS msg: " << BDS_TRUNCATED_MSG( e->_BDSMsg );
+      CSMLOG( csmd, warning ) << "Dropping expired BDS msg: " << BDS_TRUNCATED_MSG( e->_BDSMsg );
       _CachedMsgQueue.pop_front(); // drop expired entry
       delete e;
     }
@@ -321,7 +321,7 @@ csm::daemon::EventManagerBDS::AddToCache( const std::string bds_msg )
     e->_TimeStamp = GetTimestamp();
     _CachedMsgQueue.push_back( e );
     CSMLOG( csmd, trace ) << "Create cache entry with timestamp: " << e->_TimeStamp.time_since_epoch().count();
-    CSMLOG( csmd, info ) << "Caching msg: " << BDS_TRUNCATED_MSG( bds_msg );
+    CSMLOG( csmd, debug ) << "Caching msg: " << BDS_TRUNCATED_MSG( bds_msg );
     CheckCachedData();
   }
   catch( ... )

--- a/csmd/src/daemon/src/csm_bds_manager.cc
+++ b/csmd/src/daemon/src/csm_bds_manager.cc
@@ -23,6 +23,18 @@
 #include "csm_daemon_config.h"
 #include "include/csm_bds_manager.h"
 
+/*
+ * max display length of BDS msgs in the csm log
+ */
+#define BDS_MSG_TRUNCATION (80)
+
+/*
+ * truncate long BDS msg and add '...' to the end if truncation happened
+ */
+#define BDS_TRUNCATED_MSG( msg ) (msg).substr(0, BDS_MSG_TRUNCATION ) << ( (msg).length() > (BDS_MSG_TRUNCATION-1)? "..." : "" )
+
+
+
 void BDSManagerMain( csm::daemon::EventManagerBDS *aMgr )
 {
   aMgr->GreenLightWait();
@@ -64,13 +76,12 @@ void BDSManagerMain( csm::daemon::EventManagerBDS *aMgr )
         continue;
 
       // send string to bds connection
-      if( aMgr->SendData( content ) )
+      if( ! aMgr->SendData( content ) )
       {
-        CSMLOG( csmd, trace ) << "Sent data to BDS: " << content;
-      }
-      else
-      {
-        CSMLOG( csmd, warning ) << "Failed sending to BDS: " << content.substr(0, 50 ) << ( content.length() > 49 ? "..." : "" );
+        if( ! aMgr->AddToCache( content ) )
+        {
+          CSMLOG( csmd, warning ) << "Failed sending to BDS: " << BDS_TRUNCATED_MSG( content );
+        }
       }
     }
   }
@@ -82,7 +93,9 @@ csm::daemon::EventManagerBDS::EventManagerBDS( const csm::daemon::BDS_Info &i_BD
   _IdleRetryBackOff( "BDSMgr", csm::daemon::RetryBackOff::SleepType::CONDITIONAL,
                      csm::daemon::RetryBackOff::SleepType::INTERRUPTIBLE_SLEEP,
                      0, 10000000, 1 ),
-  _Socket( 0 )
+  _Socket( 0 ),
+  _CachedMsgQueue(),
+  _CurrentTime( std::chrono::system_clock::now() )
 {
   _Sink = new csm::daemon::EventSinkBDS( &_IdleRetryBackOff );
 
@@ -96,7 +109,6 @@ csm::daemon::EventManagerBDS::EventManagerBDS( const csm::daemon::BDS_Info &i_BD
   Unfreeze();
   _LastConnect = std::chrono::system_clock::now();
   _LastConnectInterval = 1;
-
 }
 
 bool
@@ -108,7 +120,8 @@ csm::daemon::EventManagerBDS::Connect()
   hints.ai_socktype = SOCK_STREAM;
   int tmp_errno = 0;
 
-  std::chrono::seconds last_conn = std::chrono::duration_cast<std::chrono::seconds>( std::chrono::system_clock::now() - _LastConnect );
+  UpdateCurrentTime();
+  std::chrono::seconds last_conn = std::chrono::duration_cast<std::chrono::seconds>( GetTimestamp() - _LastConnect );
   if( last_conn.count() < _LastConnectInterval )
   {
     CSMLOG( csmd, debug ) << "Last connect attempt (" << last_conn.count()
@@ -211,6 +224,16 @@ csm::daemon::EventManagerBDS::Connect()
     return false;
   }
 
+  // now that we're connected, go and send the cached msgs
+  while( ! _CachedMsgQueue.empty() )
+  {
+    const BDSRetryEntry_t *e = _CachedMsgQueue.front();
+    if( SendData( e->_BDSMsg ) == false )
+      break; // stop trying to send if it fails
+    _CachedMsgQueue.pop_front();
+    delete e;
+  }
+
   return true;
 }
 
@@ -257,9 +280,56 @@ csm::daemon::EventManagerBDS::SendData( const std::string data )
       rc = 0;
   }
 
+  if( remain == 0 )
+  {
+    CSMLOG( csmd, debug ) << "Sent data to BDS: " << BDS_TRUNCATED_MSG( data );
+  }
+
   return ((rc >= 0) && ( remain == 0 ));
 }
 
+void
+csm::daemon::EventManagerBDS::CheckCachedData()
+{
+//  csm::daemon::TimeType deadline = _DaemonState->GetTimestamp() - std::chrono::seconds( 10 );
+
+  while( ! _CachedMsgQueue.empty() )
+  {
+    const BDSRetryEntry_t *e = _CachedMsgQueue.front();
+    std::chrono::seconds expired = std::chrono::duration_cast<std::chrono::seconds>( GetTimestamp() - e->_TimeStamp );
+    CSMLOG( csmd, trace ) << "@: " << GetTimestamp().time_since_epoch().count() << "; Found entry with age: " << expired.count();
+    if( expired.count() > _BDS_Info.GetDataCacheExpiration() )
+    {
+      CSMLOG( csmd, debug ) << "Dropping expired BDS msg: " << BDS_TRUNCATED_MSG( e->_BDSMsg );
+      _CachedMsgQueue.pop_front(); // drop expired entry
+      delete e;
+    }
+    else
+      break; // since queue is sorted by time, stop on first encounter of non-expired entry
+  }
+}
+
+bool
+csm::daemon::EventManagerBDS::AddToCache( const std::string bds_msg )
+{
+  if( _BDS_Info.GetDataCacheExpiration() == 0 )
+    return false;
+  try
+  {
+    BDSRetryEntry_t *e = new BDSRetryEntry_t;
+    e->_BDSMsg = bds_msg;
+    e->_TimeStamp = GetTimestamp();
+    _CachedMsgQueue.push_back( e );
+    CSMLOG( csmd, trace ) << "Create cache entry with timestamp: " << e->_TimeStamp.time_since_epoch().count();
+    CSMLOG( csmd, info ) << "Caching msg: " << BDS_TRUNCATED_MSG( bds_msg );
+    CheckCachedData();
+  }
+  catch( ... )
+  {
+    return false;
+  }
+  return true;
+}
 
 csm::daemon::EventManagerBDS::~EventManagerBDS()
 {
@@ -272,4 +342,5 @@ csm::daemon::EventManagerBDS::~EventManagerBDS()
   _Thread->join();
   CSMLOG( csmd, info ) << "Terminating BDSMgr complete";
   delete _Thread;
+  _CachedMsgQueue.clear();
 }

--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -1178,9 +1178,6 @@ void Configuration::CreateThreadPool()
       rci_max_val = "5";
 
     std::string dce_val = GetValueInConfig( std::string("csm.bds.data_cache_expiration") );
-    if( rci_max_val.empty() )
-      rci_max_val = "25";
-
 
     if( enabled )
     {
@@ -1193,14 +1190,21 @@ void Configuration::CreateThreadPool()
         return;
       }
 
-      errno = 0;
-      unsigned dce = (unsigned)std::strtoul( dce_val.c_str(), nullptr, 10 );
-      if( errno != 0 )
+      unsigned dce = 0;
+      if( dce_val.empty() ) // if not configured, the default is 5x of rci
+        dce = rci_max * 5;
+      else
       {
-        CSMLOG( csmd, warning ) << "Invalid or missing BDS configuration. No attempts to access BDS will be made. ("
-          << host_val << ":" << port_val << ")";
-        return;
+        errno = 0;
+        dce = (unsigned)std::strtoul( dce_val.c_str(), nullptr, 10 );
+        if( errno != 0 )
+        {
+          CSMLOG( csmd, warning ) << "Invalid or missing BDS configuration. No attempts to access BDS will be made. ("
+            << host_val << ":" << port_val << ")";
+          return;
+        }
       }
+
       if(( dce > 0 ) && ( dce < rci_max ))
         CSMLOG( csmd, warning ) << "BDS data cache expires faster than the maximum reconnection interval. This might cause data loss when BDS is restarted.";
 

--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -1192,8 +1192,8 @@ void Configuration::CreateThreadPool()
       }
 
       unsigned dce = 0;
-      if( dce_val.empty() ) // if not configured, the default is 5x of rci
-        dce = rci_max * 5;
+      if( dce_val.empty() )
+        dce = 600;
       else
       {
         errno = 0;

--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -1181,11 +1181,12 @@ void Configuration::CreateThreadPool()
 
     if( enabled )
     {
+      char *strend;
       errno = 0;
-      unsigned rci_max = (unsigned)std::strtoul( rci_max_val.c_str(), nullptr, 10 );
-      if( errno != 0 )
+      unsigned rci_max = (unsigned)std::strtoul( rci_max_val.c_str(), &strend, 10 );
+      if(( errno != 0 ) || (*strend != '\0' ) || ( rci_max_val.c_str()[0] == '-' ) )
       {
-        CSMLOG( csmd, warning ) << "Invalid or missing BDS configuration. No attempts to access BDS will be made. ("
+        CSMLOG( csmd, warning ) << "Invalid BDS configuration entry reconnect_interval_max. No attempts to access BDS will be made. ("
           << host_val << ":" << port_val << ")";
         return;
       }
@@ -1196,10 +1197,10 @@ void Configuration::CreateThreadPool()
       else
       {
         errno = 0;
-        dce = (unsigned)std::strtoul( dce_val.c_str(), nullptr, 10 );
-        if( errno != 0 )
+        dce = (unsigned)std::strtoul( dce_val.c_str(), &strend, 10 );
+        if(( errno != 0 ) || (*strend != '\0' ) || ( dce_val.c_str()[0] == '-' ))
         {
-          CSMLOG( csmd, warning ) << "Invalid or missing BDS configuration. No attempts to access BDS will be made. ("
+          CSMLOG( csmd, warning ) << "Invalid BDS configuration entry data_cache_expiration. No attempts to access BDS will be made. ("
             << host_val << ":" << port_val << ")";
           return;
         }

--- a/csmd/src/daemon/src/csm_event_sinks/csm_sink_bds.h
+++ b/csmd/src/daemon/src/csm_event_sinks/csm_sink_bds.h
@@ -16,10 +16,10 @@
 #ifndef CSMD_SRC_DAEMON_SRC_CSM_EVENT_SINKS_CSM_SINK_BDS_H_
 #define CSMD_SRC_DAEMON_SRC_CSM_EVENT_SINKS_CSM_SINK_BDS_H_
 
-#include <mutex>
-#include <deque>
-
 #include "include/csm_bds_event.h"
+#include "include/csm_event_sink.h"
+
+#include <mutex>
 
 namespace csm {
 namespace daemon {


### PR DESCRIPTION
This pull request will add a caching feature to the aggregator.
If the aggregator has lost the connection to the BDS, it will cache any BDS messages (e.g. environmental data from compute nodes) for a configurable amount of time.

This will help to prevent BDS data to get dropped due to temporary failures or restarts of the BDS service.

The expiration time of cached messages can be configured in the config file via a new option:

```
        "bds" :
        {
                "host" : "__LOGSTASH__",
                "port" : 10522,
                "reconnect_interval_max" : 5,
                "data_cache_expiration" : 50
        }
```
* If the ```data_cache_expiration``` parameter is omitted, there will be a default expiration time that is 5x of the configured (or default) reconnect interval.
* If expiration is set to 0, then caching is disabled and data gets dropped while the BDS is down
* If the expiration is configured smaller than the reconnect interval, there will be a non-critical warning about potential data loss
* If the expiration is set to an interval longer than 1000s, there will be a non-critical warning about memory usage.

##How to test
- general test approach would probably be to stop or disconnect the BDS for a time that is shorter than the cache expiration and when BDS is brought back there should be no data missing.
- in case of a longer outage of the BDS, only data that has not expired in the cache would show up

1) run existing config without any configured expiration the time limit should be 5x of the reconnect interval
2) configure expiration of 0 and expect all data to get dropped while BDS is down
3) configure an expiration and expect BDS data to get cached and sent to BDS for that configured time span

Note: the expiration time isn't enforced down to the millisecond. So you might see cases where messages get sent to BDS even if they expired shortly before the reconnect. I intentionally didn't aim for high precision timing of the expiration because I think it's not necessary. If anyone thinks it should be enforced precisely, please let me know.
