### PR TITLE
bb: If a file handle registry entry is not removed because of a concu…

### DIFF
--- a/bb/src/bbproxy.cc
+++ b/bb/src/bbproxy.cc
@@ -3479,6 +3479,8 @@ void msgin_file_transfer_complete_for_file(txp::Id id, const string& pConnection
 
                     case -2:
                     {
+                        // NOTE:  fh will be NULL in this leg
+
                         // File handle found, but not removed because restart transfer processing is
                         // in progress for this file.  The file handle found is the newly opened
                         // handle for restart processing.  The original file handle has already been

--- a/bb/src/fh.cc
+++ b/bb/src/fh.cc
@@ -303,6 +303,9 @@ int removeFilehandle(filehandle* &fh, uint64_t jobid, uint64_t handle, uint32_t 
             {
                 LOG(bb,info) << "removeFilehandle: fh=" << fh << " jobid=" << jobid << " handle=" << handle << " contribid=" << contrib << " index=" << index << " rc=" << rc \
                              << ". File handle found but is for restart transfer processing. The original file handle has already been closed.";
+                // NOTE:  If we do not remove the registry entry, set the file handle to NULL
+                //        so our invoker cannot erase/destroy it...
+                fh = NULL;
                 rc = -2;
             }
         }


### PR DESCRIPTION
…rrent restart, do not return the pointer to the file handle to the invoker.  The invoker may/will destroy/erase the file handle.


# Pull Request Title

## Purpose
_Describe the problem or feature in addition to a link to the issues._

## Approach
_How does this change address the problem?_

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.
- [ ] Assign both @pdlun92 and @williammorrison2 to review (So they can check regression)
- [ ] Assign 1 developer to sanity check the code. (Working on automatically doing this via `./github/CODEOWNERS.md`)
- [ ] Replace suggested text in this template with real PR information. 
- [ ] Appropriatly label
- [ ] Assign a milestone. 

## How to Test

1. Think about what you want to test.
2. Test it.

## Screenshots

