### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/csm_big_data/data-aggregators/ufm/ufmCollection.py
+++ b/csm_big_data/data-aggregators/ufm/ufmCollection.py
@@ -188,7 +188,7 @@ def main(args):
         elif o in ("--ufm_restAPI_args-objects"):
             POST_PAYLOAD["objects"]=a.split(',')
     
-    if ( ufm_url == None or logstash == None ):
+    if ( ufm_url is None or logstash is None ):
         print( "Script requires both `ufm` and `logstash` to be set" )
         return 2
 

--- a/csm_big_data/python/cast_helper.py
+++ b/csm_big_data/python/cast_helper.py
@@ -113,7 +113,7 @@ def build_time_range(start_time, end_time,
     start_field and end_field) collides with the range defined by start_time and end_time.
 
     The logic used in these time range queries is : 
-        `start_field <= end_time && ( end_field >= start_time || end_field == None)`
+        `start_field <= end_time && ( end_field >= start_time || end_field is None)`
 
     :param string start_time:  The start of the time range to find records in.
     :param string end_time:    The end of the time range to find records in.

--- a/csm_big_data/python/findJobKeys.py
+++ b/csm_big_data/python/findJobKeys.py
@@ -55,7 +55,7 @@ def main(args):
     args = parser.parse_args()
 
     # If the target wasn't specified check the environment for the target value, printing help on failure.
-    if args.target == None:
+    if args.target is None:
         if TARGET_ENV in os.environ:
             args.target = os.environ[TARGET_ENV]
         else:

--- a/csm_big_data/python/findJobMetrics.py
+++ b/csm_big_data/python/findJobMetrics.py
@@ -53,7 +53,7 @@ def main(args):
     args = parser.parse_args()
 
     # If the target wasn't specified check the environment for the target value, printing help on failure.
-    if args.target == None:
+    if args.target is None:
         if TARGET_ENV in os.environ:
             args.target = os.environ[TARGET_ENV]
         else:

--- a/csm_big_data/python/findJobTimeRange.py
+++ b/csm_big_data/python/findJobTimeRange.py
@@ -54,7 +54,7 @@ def main(args):
     args = parser.parse_args()
 
     # If the target wasn't specified check the environment for the target value, printing help on failure.
-    if args.target == None:
+    if args.target is None:
         if TARGET_ENV in os.environ:
             args.target = os.environ[TARGET_ENV]
         else:

--- a/csm_big_data/python/findJobsInRange.py
+++ b/csm_big_data/python/findJobsInRange.py
@@ -47,7 +47,7 @@ def main(args):
     args = parser.parse_args()
 
     # If the target wasn't specified check the environment for the target value, printing help on failure.
-    if args.target == None:
+    if args.target is None:
         if TARGET_ENV in os.environ:
             args.target = os.environ[TARGET_ENV]
         else:

--- a/csm_big_data/python/findJobsRunning.py
+++ b/csm_big_data/python/findJobsRunning.py
@@ -44,7 +44,7 @@ def main(args):
     args = parser.parse_args()
 
     # If the target wasn't specified check the environment for the target value, printing help on failure.
-    if args.target == None:
+    if args.target is None:
         if TARGET_ENV in os.environ:
             args.target = os.environ[TARGET_ENV]
         else:

--- a/csm_big_data/python/findUserJobs.py
+++ b/csm_big_data/python/findUserJobs.py
@@ -65,7 +65,7 @@ def main(args):
     args = parser.parse_args()
 
     # If the target wasn't specified check the environment for the target value, printing help on failure.
-    if args.target == None:
+    if args.target is None:
         if TARGET_ENV in os.environ:
             args.target = os.environ[TARGET_ENV]
         else:

--- a/csm_big_data/python/findWeightedErrors.py
+++ b/csm_big_data/python/findWeightedErrors.py
@@ -147,7 +147,7 @@ def main(args):
     args = parser.parse_args()
 
     # If the target wasn't specified check the environment for the target value, printing help on failure.
-    if args.target == None:
+    if args.target is None:
         if TARGET_ENV in os.environ:
             args.target = os.environ[TARGET_ENV]
         else:

--- a/hcdiag/src/framework/base_harness.py
+++ b/hcdiag/src/framework/base_harness.py
@@ -237,7 +237,7 @@ class BaseHarness(object):
    def run_test(self, test):
       stime= datetime.now()
       cmd = self.prepare_run(test)
-      if cmd == None: return 89, stime.strftime("%Y-%m-%d-%H:%M:%S.%f")   
+      if cmd is None: return 89, stime.strftime("%Y-%m-%d-%H:%M:%S.%f")
       # open log files
       self.open_logfile(test)   
                                      
@@ -398,7 +398,7 @@ class BaseHarness(object):
          return False   
       # if bucket exists, test(s) exist and is valid
       self.tests = self.tconfig.get_bucket_tests(b)
-      if self.tests == None:
+      if self.tests is None:
          return False
       return True
 

--- a/hcdiag/src/framework/config_parser.py
+++ b/hcdiag/src/framework/config_parser.py
@@ -382,7 +382,7 @@ class TestProperties(DiagProperties):
             # it is a bucket, make sure it has tests
             try:
                ts=self.get_bucket_tests(section[len(self.bucket_prefix):])
-               if ts == None:
+               if ts is None:
                   print 'ERROR: ', file, ' contains ', section, ' with no tests attribute or it is empty. Exiting...'
                   sys.exit(98)
                

--- a/hcdiag/src/framework/node_interface.py
+++ b/hcdiag/src/framework/node_interface.py
@@ -52,7 +52,7 @@ class NodeInterface(TargetInterface):
    #------------------------------------------------------------------- 
    def get_node_info(self, nodes, target):
       nodelist=validate_noderange(nodes)
-      if nodelist == None:
+      if nodelist is None:
          self.logger.error('Could not validate the target. When running in Node mode, only comma separated nodes syntax is accepted.')
          return False
 


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations