### PR TITLE
CSM API: Added call to csm_init_struct in csmi_ras_event_create to initialize struct version_id

### DIFF
--- a/csmi/src/ras/src/csmi_ras_event_create.c
+++ b/csmi/src/ras/src/csmi_ras_event_create.c
@@ -2,7 +2,7 @@
 
     csmi/src/ras/src/csmi_ras_event_create.c
 
-  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+  © Copyright IBM Corporation 2015-2018. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -46,7 +46,10 @@ int csm_ras_event_create(
     // EARLY RETURN
     // Create a csm_api_object and sets its csmi cmd and the destroy function
     create_csm_api_object(csm_obj, expected_cmd, NULL);
-    
+   
+    // CSM API initialize struct 
+    csm_init_struct(API_PARAMETER_INPUT_TYPE, input);
+ 
     // Populate the struct.
     input.msg_id        = msg_id        ? strdup(msg_id)        : NULL;
     input.time_stamp    = time_stamp    ? strdup(time_stamp)    : NULL;


### PR DESCRIPTION
Lars discovered a problem with csmi_ras_event_create while testing csmrestd on his laptop:
```
[csmapi][error] Failed to pack arguments, make sure version is set!
(null) FAILED: errcode: 28 errmsg: Message packing error
```
Valgrind also detected the following errors that went away after the fix contained in this pull request was applied:
```
==122293== Conditional jump or move depends on uninitialised value(s)
==122293==    at 0x40E828C: serialize_csm_ras_event_create_input_t (csmi_ras_serialization.c:330)
==122293==    by 0x40E2A07: csm_ras_event_create (csmi_ras_event_create.c:59)
==122293==    by 0x10001E0F: main (csm_ras_event_create.c:184)
==122293== 
==122293== Conditional jump or move depends on uninitialised value(s)
==122293==    at 0x40E7904: len_csm_ras_event_create_input_t (csm_ras_event_create_input.def:50)
==122293==    by 0x40E829F: serialize_csm_ras_event_create_input_t (csmi_ras_serialization.c:333)
==122293==    by 0x40E2A07: csm_ras_event_create (csmi_ras_event_create.c:59)
==122293==    by 0x10001E0F: main (csm_ras_event_create.c:184)
==122293== 
==122293== Conditional jump or move depends on uninitialised value(s)
==122293==    at 0x40E7AEC: pack_csm_ras_event_create_input_t (csm_ras_event_create_input.def:50)
==122293==    by 0x40E8367: serialize_csm_ras_event_create_input_t (csmi_ras_serialization.c:350)
==122293==    by 0x40E2A07: csm_ras_event_create (csmi_ras_event_create.c:59)
==122293==    by 0x10001E0F: main (csm_ras_event_create.c:184)
==122293== 
==122293== Conditional jump or move depends on uninitialised value(s)
==122293==    at 0x40DEA60: csm_header_check_sum (csm_network_msg_c.h:129)
==122293==    by 0x40DEF33: csm_net_msg_CheckSumCalculate (csm_network_msg_c.h:423)
==122293==    by 0x40DEF97: csm_net_msg_CheckSumUpdate (csm_network_msg_c.h:433)
==122293==    by 0x40DF247: csm_net_msg_SetDataAndChksum (csm_network_msg_c.h:574)
==122293==    by 0x40DF3AB: csm_net_msg_Init (csm_network_msg_c.h:655)
==122293==    by 0x40DF60F: csmi_sendrecv_cmd_ext (csmi_common_utils.c:82)
==122293==    by 0x40DFE77: csmi_sendrecv_cmd (csmi_common_utils.c:251)
==122293==    by 0x40E2ACB: csm_ras_event_create (csmi_ras_event_create.c:64)
==122293==    by 0x10001E0F: main (csm_ras_event_create.c:184)
==122293== 
==122293== Conditional jump or move depends on uninitialised value(s)
==122293==    at 0x40DF3E8: csm_net_msg_Init (csm_network_msg_c.h:661)
==122293==    by 0x40DF60F: csmi_sendrecv_cmd_ext (csmi_common_utils.c:82)
==122293==    by 0x40DFE77: csmi_sendrecv_cmd (csmi_common_utils.c:251)
==122293==    by 0x40E2ACB: csm_ras_event_create (csmi_ras_event_create.c:64)
==122293==    by 0x10001E0F: main (csm_ras_event_create.c:184)
==122293== 
==122293== Conditional jump or move depends on uninitialised value(s)
==122293==    at 0x41B7F00: csm_net_unix_Send (csm_network_local.c:729)
==122293==    by 0x40DD3BF: csmi_net_unix_Send (csm_api_common.c:174)
==122293==    by 0x40DF6B7: csmi_sendrecv_cmd_ext (csmi_common_utils.c:98)
==122293==    by 0x40DFE77: csmi_sendrecv_cmd (csmi_common_utils.c:251)
==122293==    by 0x40E2ACB: csm_ras_event_create (csmi_ras_event_create.c:64)
==122293==    by 0x10001E0F: main (csm_ras_event_create.c:184)
```

The root cause was due to csmi_ras_event_create() missing a call to csm_init_struct() before sending the request to csmd.