### PR TITLE
Enabling and extending logging capabilities of csm restd

### DIFF
--- a/csmconf/csmrestd.cfg
+++ b/csmconf/csmrestd.cfg
@@ -10,7 +10,7 @@
 			"fileLog"      :   "/var/log/ibm/csm/csmrestd.log",
 			"rotationSize" :   -1,
 			"default_sev"  :   "info",
-            "csmrestd"     :   "info"
+			"csmrestd"     :   "info"
 		}
 	}
 }

--- a/csmconf/csmrestd.cfg
+++ b/csmconf/csmrestd.cfg
@@ -9,7 +9,8 @@
 			"consoleLog"   :   false,
 			"fileLog"      :   "/var/log/ibm/csm/csmrestd.log",
 			"rotationSize" :   -1,
-			"default_sev"  :   "info"
+			"default_sev"  :   "info",
+            "csmrestd"     :   "info"
 		}
 	}
 }

--- a/csmrestd/src/CMakeLists.txt
+++ b/csmrestd/src/CMakeLists.txt
@@ -18,7 +18,7 @@ set(RESTAPI_SRC
 add_executable(csmrestd ${RESTAPI_SRC} )
 install(TARGETS csmrestd COMPONENT csm-restd DESTINATION csm/sbin)
 target_link_libraries(csmrestd ${Boost_LIBRARIES} csmi csm_network_c csmutil fsutil -lpthread -lssl -lcrypto)
-
+target_include_directories(csmrestd PRIVATE ${PROJECT_SOURCE_DIR}/csmd/src/daemon/include )
 
 
 

--- a/csmrestd/src/RestApiServer.cc
+++ b/csmrestd/src/RestApiServer.cc
@@ -18,6 +18,8 @@
 #include <iostream>
 #include "RestApiServer.h"
 
+#include "logging.h"
+
 using namespace std;
 
 
@@ -30,6 +32,8 @@ RestApiServer::RestApiServer(const std::string& address, const std::string& port
     new_connection_(),
     request_handler_(doc_roots) */
 {
+  LOG(csmd, debug ) << "RestApiServer: Initializing...";
+
   // Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
   boost::asio::ip::tcp::resolver resolver(_io_service);
   boost::asio::ip::tcp::resolver::query query(address, port);
@@ -46,6 +50,8 @@ RestApiServer::RestApiServer(const std::string& address, const std::string& port
   _sslContext.set_verify_mode(boost::asio::ssl::verify_peer | 
                               boost::asio::ssl::verify_fail_if_no_peer_cert | 
                               boost::asio::ssl::verify_client_once);       // require client cert...
+
+  LOG( csmd, debug ) << "RestApiServer: Initializiation complete";
 }
 
 
@@ -53,6 +59,7 @@ void RestApiServer::setSslParms(const std::string &certFile,
                                 const std::string &keyFile,
                                 const std::string &certAuthFile)
 {
+    LOG( csmd, debug ) << "RestApiServer: setting SSL parameters";
     _sslContext.use_certificate_chain_file(certFile);
     _sslContext.use_private_key_file(keyFile, boost::asio::ssl::context::pem);
     _sslContext.load_verify_file(certAuthFile);
@@ -93,6 +100,7 @@ void RestApiServer::handleAccept(const boost::system::error_code& e)
   if (!e)
       _connMgr.start(nc);
 
+  LOG( csmd, info ) << "RestApiServer: Accepted new connection.";
 }
 
 void RestApiServer::handleStop()
@@ -102,6 +110,7 @@ void RestApiServer::handleStop()
   // will exit.
   _acceptor.close();
   _connMgr.stopAll();
+  LOG( csmd, info ) << "RestApiServer: Closed all connections for shutdown.";
 }
 
 

--- a/csmrestd/src/RestApiServer.cc
+++ b/csmrestd/src/RestApiServer.cc
@@ -32,7 +32,7 @@ RestApiServer::RestApiServer(const std::string& address, const std::string& port
     new_connection_(),
     request_handler_(doc_roots) */
 {
-  LOG(csmd, debug ) << "RestApiServer: Initializing...";
+  LOG(csmrestd, debug ) << "RestApiServer: Initializing...";
 
   // Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
   boost::asio::ip::tcp::resolver resolver(_io_service);
@@ -51,7 +51,7 @@ RestApiServer::RestApiServer(const std::string& address, const std::string& port
                               boost::asio::ssl::verify_fail_if_no_peer_cert | 
                               boost::asio::ssl::verify_client_once);       // require client cert...
 
-  LOG( csmd, debug ) << "RestApiServer: Initializiation complete";
+  LOG( csmrestd, debug ) << "RestApiServer: Initializiation complete";
 }
 
 
@@ -59,7 +59,7 @@ void RestApiServer::setSslParms(const std::string &certFile,
                                 const std::string &keyFile,
                                 const std::string &certAuthFile)
 {
-    LOG( csmd, debug ) << "RestApiServer: setting SSL parameters";
+    LOG( csmrestd, debug ) << "RestApiServer: setting SSL parameters";
     _sslContext.use_certificate_chain_file(certFile);
     _sslContext.use_private_key_file(keyFile, boost::asio::ssl::context::pem);
     _sslContext.load_verify_file(certAuthFile);
@@ -100,7 +100,7 @@ void RestApiServer::handleAccept(const boost::system::error_code& e)
   if (!e)
       _connMgr.start(nc);
 
-  LOG( csmd, info ) << "RestApiServer: Accepted new connection.";
+  LOG( csmrestd, info ) << "RestApiServer: Accepted new connection.";
 }
 
 void RestApiServer::handleStop()
@@ -110,7 +110,7 @@ void RestApiServer::handleStop()
   // will exit.
   _acceptor.close();
   _connMgr.stopAll();
-  LOG( csmd, info ) << "RestApiServer: Closed all connections for shutdown.";
+  LOG( csmrestd, info ) << "RestApiServer: Closed all connections for shutdown.";
 }
 
 

--- a/csmrestd/src/csmrestd.cc
+++ b/csmrestd/src/csmrestd.cc
@@ -153,9 +153,9 @@ RestApiReply::status_type CsmRestApiServer::csmRasEventCreate(
         }
 
         csm_api_object *csmobj = NULL;
-        LOG( csmrestd, info ) << "csmRasEventCreate: data( msgID=" << msg_id
+        LOG( csmrestd, debug ) << "csmRasEventCreate: msgID=" << msg_id
             << "time=" << time_stamp
-            << "location=" << location_name;
+            << "; location=" << location_name;
         int csmrc = csm_ras_event_create(&csmobj,
                                           msg_id.c_str(),
                                           time_stamp.c_str(),

--- a/csmrestd/src/csmrestd.cc
+++ b/csmrestd/src/csmrestd.cc
@@ -165,7 +165,7 @@ RestApiReply::status_type CsmRestApiServer::csmRasEventCreate(
         if  (csmrc != 0) {
             char *errmsg = csm_api_object_errmsg_get(csmobj);
             jsonOut = string("{\"error\":\"") + "CSMRESTD csm_ras_event_create = " + errmsg + "\"}";
-            LOG(csmrestd, error) << "CSMRESTD csm_ras_event_create = " << rc << " " << errmsg << endl << flush;
+            LOG(csmrestd, error) << "CSMRESTD csm_ras_event_create error. Is CSMD running? rc=" << csmrc << " (" << errmsg << ")";
             rc = RestApiReply::internal_server_error;
             // put this into an error return too...
         }
@@ -268,7 +268,7 @@ RestApiReply::status_type CsmRestApiServer::csmRasEventQuery(
         if  (csmrc != 0) {
             char *errmsg = csm_api_object_errmsg_get(csmobj);
             jsonOut = string("{\"error\":\"") + "CSMRESTD csm_ras_event_create = " + errmsg + "\"}";
-            LOG(csmrestd, info)  << "CSMRESTD csm_ras_event_query = " << rc << " " << errmsg << endl << flush;
+            LOG( csmrestd, error ) << "CSMRESTD csm_ras_event_query error. Is CSMD running? rc=" << csmrc << " (" << errmsg << ")";
             rc = RestApiReply::internal_server_error;
         } 
         else {
@@ -417,8 +417,7 @@ CsmRestdMain::CsmRestdMain() :
 
 CsmRestdMain::~CsmRestdMain()
 {
-    if (_csminit)
-        csm_term_lib();
+  csm_term_lib();
 }
 
 void CsmRestdMain::displayUsage() 
@@ -498,24 +497,24 @@ int CsmRestdMain::main (int argc, char *argv[])
    string listen_ip = GetValueInConfig(CONFIG_FILE_KEY_LISTENIP);
    if (listen_ip.empty())
    {
-      LOG(csmrestd, critical) << "Error: " << CONFIG_FILE_KEY_LISTENIP << " not set in " << config_file << endl;
+      LOG(csmrestd, critical) << "Error: " << CONFIG_FILE_KEY_LISTENIP << " not set in " << config_file;
       return 9;
    }
 
    string port = GetValueInConfig(CONFIG_FILE_KEY_PORT);
    if (port.empty())
    {
-      LOG(csmrestd, critical) << "Error: " << CONFIG_FILE_KEY_PORT << " not set in " << config_file << endl;
+      LOG(csmrestd, critical) << "Error: " << CONFIG_FILE_KEY_PORT << " not set in " << config_file;
       return 9;
    }
 
    int rc = csm_init_lib();     // singleton csmi initialization..
    if (rc != 0)
    {
-      LOG(csmrestd, critical) << "csm_init_lib failed: rc=" << rc << " (" << strerror( rc ) << ")" << endl;
-      return(1);
+      LOG(csmrestd, warning) << "csm_init_lib: rc=" << rc << " (" << strerror( rc ) << ") Please check CSM Daemon status! Will try to contact daemon at next request.";
    }
-   _csminit = true;
+   else
+     _csminit = true;
 
    //
    // todo, make the connection here much more robust, or move this into some sort
@@ -549,7 +548,7 @@ int CsmRestdMain::main (int argc, char *argv[])
    }
    catch (std::exception& e)
    {
-      cerr << "exception: " << e.what() << endl;
+     LOG( csmrestd, error ) << "exception: " << e.what();
    }
 
    return(0);


### PR DESCRIPTION
This enables the restd logging as intended by the restd config file.

The logging was running unconfigured in existing code because the setup code was commented out and some parts were using very outdated ways to find and configure the logging. This has been fixed and therefore logging is enabled now.

The PR also adds several new log lines to help debugging problems.