### PR TITLE
CSM FVT Improvements

### DIFF
--- a/csmtest/buckets/basic/fvt_allocation_create_and_delete.py
+++ b/csmtest/buckets/basic/fvt_allocation_create_and_delete.py
@@ -61,11 +61,11 @@ else:
 # Allocation Delete
 alloc_delete_input=wm.allocation_delete_input_t()
 alloc_delete_input.allocation_id=aid
-rc,handler,alloc_output=wm.allocation_delete(alloc_delete_input)
+rc,handler=wm.allocation_delete(alloc_delete_input)
 if (rc == 0):
-    print("Allocation " + str(alloc_delete_input.allocation.allocation_id) + " successfully deleted")
+    print("Allocation " + str(alloc_delete_input.allocation_id) + " successfully deleted")
 else:
-    print("Failed to delete allocation " + str(alloc_delete_input.allocation.allocation_id))
+    print("Failed to delete allocation " + str(alloc_delete_input.allocation_id))
     csm.api_object_destroy(handler)
     csm.term_lib()
     sys.exit(rc)

--- a/csmtest/buckets/basic/fvt_allocation_create_and_delete.py
+++ b/csmtest/buckets/basic/fvt_allocation_create_and_delete.py
@@ -1,0 +1,75 @@
+#!/bin/python
+# encoding: utf-8
+#================================================================================
+#
+#    allocation_create.py   
+#
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+import sys
+sys.path.append('/opt/ibm/csm/lib')
+
+import lib_csm_py as csm
+import lib_csm_wm_py as wm
+from pprint import pprint
+
+csm.init_lib()
+
+alloc_input=wm.allocation_t()
+alloc_input.primary_job_id=1
+alloc_input.job_submit_time="now"
+
+nodes=[str(sys.argv[1])]
+
+# Allocation Create
+alloc_input.set_compute_nodes(nodes)
+rc,handler,aid=wm.allocation_create(alloc_input)
+
+if (rc == 0):
+    print("Created allocation: " + str(aid))
+else: 
+    print("Create Failed")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+# Allocation Query
+alloc_query_input=wm.allocation_query_input_t()
+alloc_query_input.allocation_id=aid
+rc,handler,alloc_output=wm.allocation_query(alloc_query_input)
+
+if (rc == 0):
+    print("Query Successful:")
+    print("\tAllocation ID: " + str(alloc_output.allocation.allocation_id))
+    print("\tPrimary Job ID: " +  str(alloc_output.allocation.primary_job_id))
+    print("\tNumber of Nodes: " + str(alloc_output.allocation.num_nodes))
+else:
+    print("Query Failed")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+# Allocation Delete
+alloc_delete_input=wm.allocation_delete_input_t()
+alloc_delete_input.allocation_id=aid
+rc,handler,alloc_output=wm.allocation_delete(alloc_delete_input)
+if (rc == 0):
+    print("Allocation " + str(alloc_delete_input.allocation.allocation_id) + " successfully deleted")
+else:
+    print("Failed to delete allocation " + str(alloc_delete_input.allocation.allocation_id))
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+csm.api_object_destroy(handler)
+
+csm.term_lib()

--- a/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
+++ b/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
@@ -43,6 +43,9 @@ if(rc == csm.csmi_cmd_err_t.CSMI_SUCCESS):
         print("node_state_value: " + str(node.state))
 else:
     print("No matching records found.")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
 
 if(str(node.state) == "CSM_NODE_DISCOVERED"):
     print("node state is DISCOVERED. Updating to IN_SERVICE")
@@ -57,6 +60,16 @@ if(str(node.state) == "CSM_NODE_DISCOVERED"):
         node = output.get_results(0)
         print("node: " + str(node.node_name))
         print("node_state_value: " + str(node.state))
+        if (str(node.state) != str(csm.csmi_node_state_t.CSM_NODE_IN_SERVICE)):
+            print("Error: Node not IN_SERVICE after update")
+            csm.api_object_destroy(handler)
+            csm.term_lib()
+            sys.exit(rc)
+    else:
+        print("Error updating node.")
+        csm.api_object_destroy(handler)
+        csm.term_lib()
+        sys.exit(rc)
 
 csm.api_object_destroy(handler)
 

--- a/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
+++ b/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
@@ -29,7 +29,7 @@ from pprint import pprint
 csm.init_lib()
 
 input = inv.node_attributes_query_input_t()
-nodes=["c650f99p18"]
+nodes=[str(sys.argv[1])]
 input.set_node_names(nodes)
 input.limit=-1
 input.offset=-1

--- a/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
+++ b/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
@@ -1,0 +1,63 @@
+#!/bin/python
+# encoding: utf-8
+#================================================================================
+#
+#    node_attributes_query.py
+#
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+import sys
+
+#add the python library to the path
+sys.path.append('/opt/ibm/csm/lib')
+
+# eventually append the path as part of an rpm install
+
+import lib_csm_py as csm
+import lib_csm_inv_py as inv
+from pprint import pprint
+
+csm.init_lib()
+
+input = inv.node_attributes_query_input_t()
+nodes=["c650f99p18"]
+input.set_node_names(nodes)
+input.limit=-1
+input.offset=-1
+
+rc,handler,output = inv.node_attributes_query(input)
+
+if(rc == csm.csmi_cmd_err_t.CSMI_SUCCESS):
+    for i in range (0, output.results_count):
+        node = output.get_results(i)
+        print("node: " + str(node.node_name))
+        print("node_state_value: " + str(node.state))
+else:
+    print("No matching records found.")
+
+if(str(node.state) == "CSM_NODE_DISCOVERED"):
+    print("node state is DISCOVERED. Updating to IN_SERVICE")
+    input = inv.node_attributes_update_input_t()
+    input.set_node_names(nodes)
+    input.state = csm.csmi_node_state_t.CSM_NODE_IN_SERVICE
+    rc,handler,output = inv.node_attributes_update(input)
+    if (rc == csm.csmi_cmd_err_t.CSMI_SUCCESS):
+        input = inv.node_attributes_query_input_t()
+        input.set_node_names(nodes)
+        rc,handler,output = inv.node_attributes_query(input)
+        node = output.get_results(0)
+        print("node: " + str(node.node_name))
+        print("node_state_value: " + str(node.state))
+
+csm.api_object_destroy(handler)
+
+csm.term_lib()

--- a/csmtest/buckets/basic/python_libraries.sh
+++ b/csmtest/buckets/basic/python_libraries.sh
@@ -1,0 +1,59 @@
+#================================================================================
+#
+#    buckets/basic/python_libraries.sh
+#
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+# Bucket for CSM python library testing
+# run through CSM FVT python scripts that utilize CSM python libraries
+
+# Try to source the configuration file to get global configuration variables
+if [ -f "${BASH_SOURCE%/*}/../../csm_test.cfg" ]
+then
+        . "${BASH_SOURCE%/*}/../../csm_test.cfg"
+else
+        echo "Could not find csm_test.cfg file expected at "${BASH_SOURCE%/*}/../csm_test.cfg", exitting."
+        exit 1
+fi
+
+# Local Variables
+LOG=${LOG_PATH}/buckets/basic/python_libraries.log
+TEMP_LOG=${LOG_PATH}/buckets/basic/python_libraries_temp.log
+FLAG_LOG=${LOG_PATH}/buckets/basic/python_libraries_flags.log
+
+if [ -f "${BASH_SOURCE%/*}/../../include/functions.sh" ]
+then
+        . "${BASH_SOURCE%/*}/../../include/functions.sh"
+else
+        echo "Could not find functions file expected at /../../include/functions.sh, exitting."
+fi
+
+echo "------------------------------------------------------------" >> ${LOG}
+echo "             Starting Python Libraries Bucket" >> ${LOG}
+echo "------------------------------------------------------------" >> ${LOG}
+date >> ${LOG}
+echo "------------------------------------------------------------" >> ${LOG}
+
+# Test Case 1: Inventory Library - fvt_node_attributes_query_and_update.py
+${FVT_PATH}/buckets/basic/fvt_node_attributes_query_and_update.py ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 1: Inventory Library - fvt_node_attributes_query_and_update.py"
+
+# Test Case 2: Workload Manager Library - fvt_allocation_create_and_delete.py
+${FVT_PATH}/buckets/basic/fvt_allocation_create_and_delete.py ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 2: Workload Manager Library - fvt_allocation_create_and_delete.py"
+
+rm -f ${TEMP_LOG}
+
+echo "------------------------------------------------------------" >> ${LOG}
+echo "             Python Libraries Bucket COMPLETED" >> ${LOG}
+echo "------------------------------------------------------------" >> ${LOG}
+exit 0

--- a/csmtest/buckets/error_injection/allocation.sh
+++ b/csmtest/buckets/error_injection/allocation.sh
@@ -56,15 +56,15 @@ allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
 # Test Case 3: csm_allocation_create node does not exist
 ${CSM_PATH}/csm_allocation_create -j 1 -n doesnotexist > ${TEMP_LOG} 2>&1
-check_return_flag_nz $? 25 "Test Case 3: csm_allocation_create node does not exist"
+check_return_flag_nz $? 46 "Test Case 3: csm_allocation_create node does not exist"
 
 # Test Case 4: csm_allocation_create allocation already exists
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
-check_return_flag_nz $? 25 "Test Case 4: csm_allocation_create allocation already exists"
+check_return_flag_nz $? 47 "Test Case 4: csm_allocation_create allocation already exists"
 
 # Test Case 5: csm_allocation_create new job, but node is busy
 ${CSM_PATH}/csm_allocation_create -j 2 -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
-check_return_flag_nz $? 25 "Test Case 5: csm_allocation_create new job, but node is busy"
+check_return_flag_nz $? 47 "Test Case 5: csm_allocation_create new job, but node is busy"
 
 # Test Case 6: csm_allocation_create invalid -j input
 ${CSM_PATH}/csm_allocation_create -j xxx -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
@@ -177,7 +177,7 @@ check_return_flag_nz $? 9 "Test Case 32: csm_allocation_delete NO ARGS"
 
 # Test Case 33: csm_allocation_delete allocation does not exist
 ${CSM_PATH}/csm_allocation_delete -a 123456789 > ${TEMP_LOG} 2>&1
-check_return_flag_nz $? 25 "Test Case 33: csm_allocation_delete allocation does not exist"
+check_return_flag_nz $? 50 "Test Case 33: csm_allocation_delete allocation does not exist"
 
 # Test Case 34: csm_allocation_delete invalid -a input
 ${CSM_PATH}/csm_allocation_delete -a xxx > ${TEMP_LOG} 2>&1

--- a/csmtest/config.template
+++ b/csmtest/config.template
@@ -19,6 +19,7 @@ export AGGREGATOR_B=
 export COMPUTE_NODES=
 export SINGLE_COMPUTE=
 export UFM_ADDR=
+export LOGSTASH=
 
 # Users
 export USER=

--- a/csmtest/include/hcdiag/clustconf.yaml
+++ b/csmtest/include/hcdiag/clustconf.yaml
@@ -304,6 +304,114 @@ node_info:
     temp:
       celsius_high: "100.0"
       celsius_low: "14.0"
+
+  - case: c650f99p[18,30]
+    ncpus: 176
+    clock:   
+      max: 4.50
+      min: 2.0
+    firmware: 
+      name: "unknown version"
+      versions:
+        - 'BMC Firmware Product:   ibm-v2.1-438-g0030304-r15-0-g19832d3 (Active)*' 
+        - 'HOST Firmware Product:   IBM-witherspoon-ibm-OP9-v2.0.8-2.2-prod (Active)*' 
+        - 'HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126'
+        - 'HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4'
+        - 'HOST Firmware Product: -- additional info: hcode-hw080418a.op920'
+        - 'HOST Firmware Product: -- additional info: hostboot-binaries-hw080418a.op920'
+        - 'HOST Firmware Product: -- additional info: hostboot-d033213-pfb2e171'
+        - 'HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-p328018f'
+        - 'HOST Firmware Product: -- additional info: machine-xml-7cd20a6'
+        - 'HOST Firmware Product: -- additional info: occ-084756c'
+        - 'HOST Firmware Product: -- additional info: op-build-v2.0.8-1-gc51594f'
+        - 'HOST Firmware Product: -- additional info: petitboot-v1.7.2-p8f11e93'
+        - 'HOST Firmware Product: -- additional info: sbe-55d6eb2'
+        - 'HOST Firmware Product: -- additional info: skiboot-v6.0.7'
+    memory: 
+      total: 636
+      banks: 16
+      bank_size:  32
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.5 Beta (Maipo)"
+    kernel:
+      release: "4.14.0-43.el7a.ppc64le"
+    software:
+        - ibm-csm: 1.3.0-1271 
+    temp:
+      celsius_high: "100.0"
+      celsius_low: "14.0"
+
+  - case: c650f99p[26,28]
+    ncpus: 176
+    clock:   
+      max: 4.50
+      min: 2.0
+    firmware: 
+      name: "unknown version"
+      versions:
+        - 'BMC Firmware Product:   ibm-v2.1-438-g0030304-r15-0-g19832d3 (Active)*' 
+        - 'HOST Firmware Product:   IBM-witherspoon-ibm-OP9-v2.0.8-2.2-prod (Active)*' 
+        - 'HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126'
+        - 'HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4'
+        - 'HOST Firmware Product: -- additional info: hcode-hw080418a.op920'
+        - 'HOST Firmware Product: -- additional info: hostboot-binaries-hw080418a.op920'
+        - 'HOST Firmware Product: -- additional info: hostboot-d033213-pfb2e171'
+        - 'HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-p328018f'
+        - 'HOST Firmware Product: -- additional info: machine-xml-7cd20a6'
+        - 'HOST Firmware Product: -- additional info: occ-084756c'
+        - 'HOST Firmware Product: -- additional info: op-build-v2.0.8-1-gc51594f'
+        - 'HOST Firmware Product: -- additional info: petitboot-v1.7.2-p8f11e93'
+        - 'HOST Firmware Product: -- additional info: sbe-55d6eb2'
+        - 'HOST Firmware Product: -- additional info: skiboot-v6.0.7'
+    memory: 
+      total: 572
+      banks: 16
+      bank_size:  32
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.5 Beta (Maipo)"
+    kernel:
+      release: "4.14.0-43.el7a.ppc64le"
+    software:
+        - ibm-csm: 1.3.0-1271 
+    temp:
+      celsius_high: "100.0"
+      celsius_low: "14.0"
+
+  - case: c650f99p36
+    ncpus: 176
+    clock:   
+      max: 4.50
+      min: 2.0
+    firmware: 
+      name: "unknown version"
+      versions:
+        - 'BMC Firmware Product:   ibm-v2.1-438-g0030304-r15-0-g19832d3 (Active)*' 
+        - 'HOST Firmware Product:   IBM-witherspoon-ibm-OP9-v2.0.8-2.2-prod (Active)*' 
+        - 'HOST Firmware Product: -- additional info: buildroot-2018.02.1-6-ga8d1126'
+        - 'HOST Firmware Product: -- additional info: capp-ucode-p9-dd2-v4'
+        - 'HOST Firmware Product: -- additional info: hcode-hw080418a.op920'
+        - 'HOST Firmware Product: -- additional info: hostboot-binaries-hw080418a.op920'
+        - 'HOST Firmware Product: -- additional info: hostboot-d033213-pfb2e171'
+        - 'HOST Firmware Product: -- additional info: linux-4.16.13-openpower1-p328018f'
+        - 'HOST Firmware Product: -- additional info: machine-xml-7cd20a6'
+        - 'HOST Firmware Product: -- additional info: occ-084756c'
+        - 'HOST Firmware Product: -- additional info: op-build-v2.0.8-1-gc51594f'
+        - 'HOST Firmware Product: -- additional info: petitboot-v1.7.2-p8f11e93'
+        - 'HOST Firmware Product: -- additional info: sbe-55d6eb2'
+        - 'HOST Firmware Product: -- additional info: skiboot-v6.0.7'
+    memory: 
+      total: 218
+      banks: 16
+      bank_size:  8
+    os:
+      pretty_name: "Red Hat Enterprise Linux Server 7.5 Beta (Maipo)"
+    kernel:
+      release: "4.14.0-43.el7a.ppc64le"
+    software:
+        - ibm-csm: 1.3.0-1271 
+    temp:
+      celsius_high: "100.0"
+      celsius_low: "14.0"
 #
 # gpfs mounts expected on all nodes.
 gpfs_mounts: 

--- a/csmtest/setup/csm_install.sh
+++ b/csmtest/setup/csm_install.sh
@@ -209,6 +209,13 @@ if [ ${AGGREGATOR_A} == ${AGGREGATOR_B} ]
 		sed -i -- "s/__AGGREGATOR_A__/${AGGREGATOR_B}/g" csm_compute_B.cfg
 		sed -i -- "s/__AGGREGATOR_B__/${AGGREGATOR_A}/g" csm_compute_B.cfg
 fi
+if [ ! -z $LOGSTASH ]
+	then
+		sed -i -- "s/__LOGSTASH__/${LOGSTASH}/g" csm_aggregator_A.cfg
+		sed -i -- "s/__LOGSTASH__/${LOGSTASH}/g" csm_aggregator_B.cfg
+	else
+		echo "LOGSTASH not defined in csm_test.cfg.  Skipping BDS setup" 
+fi
 
 # Configuration file distribution
 xdsh csm_comp,utility "mkdir -p /etc/ibm/csm"

--- a/csmtest/tools/complete_fvt.sh
+++ b/csmtest/tools/complete_fvt.sh
@@ -31,61 +31,41 @@ fi
 
 source /etc/profile.d/xcat.sh
 
-check_return () {
-	if [ $1 -ne 0 ]
+run_bucket () {
+	bucket_type=$1
+	bucket_name=$2
+	${FVT_PATH}/buckets/${bucket_type}/${bucket_name}.sh
+	rc=$?
+	if [ "$rc" -ne 0 ]
 	then
 		exit 1
 	fi
 }
 
-
-${FVT_PATH}/buckets/basic/node.sh
-check_return $?
-${FVT_PATH}/buckets/basic/allocation.sh
-check_return $?
-${FVT_PATH}/buckets/basic/jsrun_cmd.sh
-check_return $?
-${FVT_PATH}/buckets/basic/ras.sh
-check_return $?
-${FVT_PATH}/buckets/basic/step.sh
-check_return $?
-${FVT_PATH}/buckets/basic/bb.sh
-check_return $?
-${FVT_PATH}/buckets/basic/db_script.sh
-check_return $?
-${FVT_PATH}/buckets/basic/ib_inventory.sh
-check_return $?
-${FVT_PATH}/buckets/basic/switch_inventory.sh
-check_return $?
-${FVT_PATH}/buckets/basic/inventory_collection.sh
-check_return $?
-${FVT_PATH}/buckets/basic/compute_node.sh
-check_return $?
-${FVT_PATH}/buckets/advanced/allocation.sh
-check_return $?
-${FVT_PATH}/buckets/error_injection/allocation.sh
-check_return $?
-${FVT_PATH}/buckets/error_injection/bb.sh
-check_return $?
-${FVT_PATH}/buckets/error_injection/node.sh
-check_return $?
-${FVT_PATH}/buckets/error_injection/ib_inventory.sh
-check_return $?
-${FVT_PATH}/buckets/error_injection/switch_inventory.sh
-check_return $?
-${FVT_PATH}/buckets/error_injection/messaging.sh
-check_return $?
-#${FVT_PATH}/buckets/timing/allocation.sh
-#check_return $?
-${FVT_PATH}/buckets/basic/hcdiag.sh
-check_return $?
-${FVT_PATH}/buckets/basic/csm_ctrl_cmd.sh
-check_return $?
+run_bucket "basic" "node"
+run_bucket "basic" "allocation"
+run_bucket "basic" "jsrun_cmd"
+run_bucket "basic" "ras"
+run_bucket "basic" "step"
+run_bucket "basic" "bb"
+run_bucket "basic" "db_script"
+run_bucket "basic" "ib_inventory"
+run_bucket "basic" "switch_inventory"
+run_bucket "basic" "inventory_collection"
+run_bucket "basic" "compute_node"
+run_bucket "advanced" "allocation"
+run_bucket "error_injection" "allocation"
+run_bucket "error_injection" "bb"
+run_bucket "error_injection" "node"
+run_bucket "error_injection" "ib_inventory"
+run_bucket "error_injection" "switch_inventory"
+run_bucket "error_injection" "messaging"
+run_bucket "basic" "hcdiag"
+run_bucket "basic" "csm_ctrl_cmd"
 ${FVT_PATH}/tools/dual_aggregator/shutdown_daemons.sh
 sleep 5
 ${FVT_PATH}/setup/csm_setup.sh
-${FVT_PATH}/buckets/error_injection/infrastructure.sh
-check_return $?
-${FVT_PATH}/buckets/error_injection/versioning.sh
-check_return $?
-${FVT_PATH}/setup/csm_setup.sh
+run_bucket "error_injection" "infrastructure"
+run_bucket "error_injection" "versioning"
+${FVT_PATH}/setup/csm_uninstall.sh
+${FVT_PATH}/setup/csm_install.sh

--- a/csmtest/tools/complete_fvt.sh
+++ b/csmtest/tools/complete_fvt.sh
@@ -69,3 +69,4 @@ run_bucket "error_injection" "infrastructure"
 run_bucket "error_injection" "versioning"
 ${FVT_PATH}/setup/csm_uninstall.sh
 ${FVT_PATH}/setup/csm_install.sh
+run_bucket "basic" "python_libraries"

--- a/csmtest/tools/update_computes_in_service.sh
+++ b/csmtest/tools/update_computes_in_service.sh
@@ -1,0 +1,32 @@
+#================================================================================
+#
+#    tools/update_computes_in_service.sh
+#
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+# Try to source the configuration file to get global configuration variables
+if [ -f "${BASH_SOURCE%/*}/../csm_test.cfg" ]
+then
+        . "${BASH_SOURCE%/*}/../csm_test.cfg"
+else
+        echo "Could not find csm_test.cfg file expected at "${BASH_SOURCE%/*}/../csm_test.cfg", exitting."
+        exit 1
+fi
+
+${CSM_PATH}/csm_node_attributes_update -n ${COMPUTE_NODES} -s IN_SERVICE
+if [ $? -eq 0 ]
+then
+	echo "${COMPUTE_NODES} are IN_SERVICE"
+else
+	echo "Failed to put ${COMPUTE_NODES} IN_SERVICE, exiting"
+	exit 1
+fi


### PR DESCRIPTION
# CSM FVT Improvements

## Purpose
Several improvements to CSM regression including:
- Updated error codes according to Pull Request #382 
- New bucket and sub-components for testing CSM python libraries
- Additional test cases for cascading allocation/lv delete functionality in basic csm_bb bucket
- Allow for install script to connect to BDS
- New tool(s) to update nodes to IN_SERVICE for manual test cases
- Additional fields added to included clustconf.yaml for hcdiag regression in FVT environment

Will leave this as an open Pull Request for a while in case anybody wants to take a look / try to catch a mistake.  But I do think we want to get this merged as soon as possible.  I've been running regression using this branch for the past few days and has functioned properly

