### PR TITLE
csm: using steady clock

### DIFF
--- a/csmd/src/daemon/include/csm_bds_manager.h
+++ b/csmd/src/daemon/include/csm_bds_manager.h
@@ -113,7 +113,7 @@ public:
   bool AddToCache( const std::string bsd_msg );
 
 private:
-  inline void UpdateCurrentTime() { _CurrentTime = std::chrono::system_clock::now(); }
+  inline void UpdateCurrentTime() { _CurrentTime = std::chrono::steady_clock::now(); }
   inline BDSTimeType GetTimestamp() { return _CurrentTime; };
   void CheckCachedData();
 };

--- a/csmd/src/daemon/include/csm_timer_event.h
+++ b/csmd/src/daemon/include/csm_timer_event.h
@@ -29,35 +29,35 @@ namespace daemon {
 class TimerContent
 {
 public:
-  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
-  
+  typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
+
   TimerContent(
     const uint64_t& aMilliSeconds, 
     uint64_t aTargetState = UINT64_MAX ) : 
         _timerInterval(aMilliSeconds),
         _targetStateId(aTargetState)
   {
-    _startTime = std::chrono::system_clock::now();
+    _startTime = std::chrono::steady_clock::now();
     _endTime =  _startTime + std::chrono::milliseconds(_timerInterval);
   }
-  
+
   TimerContent( const TimerContent &in )
   : _timerInterval( in._timerInterval ),
     _targetStateId( in._targetStateId ),
     _endTime( in._endTime ),
     _startTime( in._startTime )
   { }
-  
+
   // keep this for debugging purpose
   uint64_t GetTimerInterval() const { return _timerInterval; }
 
   uint64_t GetTargetStateId() const { return _targetStateId; }
-  
+
   TimeType GetEndTime() const
   {
     return _endTime;
   }
-  
+
   TimeType GetStartTime() const
   {
     return _startTime;
@@ -66,20 +66,20 @@ public:
   bool TimerExpired() const
   {
 #if 0
-     if (std::chrono::system_clock::now() >= _endTime)
+     if (std::chrono::steady_clock::now() >= _endTime)
      {
-       std::time_t tt_now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-       std::time_t tt_end = std::chrono::system_clock::to_time_t(_endTime);
-       std::time_t tt_start = std::chrono::system_clock::to_time_t(_startTime);
+       std::time_t tt_now = std::chrono::steady_clock::to_time_t(std::chrono::steady_clock::now());
+       std::time_t tt_end = std::chrono::steady_clock::to_time_t(_endTime);
+       std::time_t tt_start = std::chrono::steady_clock::to_time_t(_startTime);
        LOG(csmd, debug) << "now: " << std::ctime(&tt_now) << " end: " << std::ctime(&tt_end) << " start: " << std::ctime(&tt_start) << " interval: " << _timerInterval;
      }
-#endif     
-     return ( std::chrono::system_clock::now() >= _endTime );
+#endif
+     return ( std::chrono::steady_clock::now() >= _endTime );
   }
-  
+
   int64_t RemainingMicros() const
   {
-    return std::chrono::duration_cast<std::chrono::microseconds>( _endTime - std::chrono::system_clock::now() ).count();
+    return std::chrono::duration_cast<std::chrono::microseconds>( _endTime - std::chrono::steady_clock::now() ).count();
   }
   
   virtual ~TimerContent()

--- a/csmd/src/daemon/include/interval_trigger.h
+++ b/csmd/src/daemon/include/interval_trigger.h
@@ -25,20 +25,20 @@ namespace daemon {
 
 class IntervalTrigger
 {
-  std::chrono::time_point<std::chrono::system_clock> _NextTrigger;
+  std::chrono::time_point<std::chrono::steady_clock> _NextTrigger;
   std::chrono::milliseconds _Interval;
 public:
   IntervalTrigger( const uint64_t i_IntervalMilli )
   {
     _Interval = std::chrono::milliseconds( i_IntervalMilli );
-    _NextTrigger = std::chrono::system_clock::now() + _Interval;
+    _NextTrigger = std::chrono::steady_clock::now() + _Interval;
   }
   ~IntervalTrigger() {}
 
   bool IsReady()
   {
     bool ready = false;
-    std::chrono::time_point<std::chrono::system_clock> current = std::chrono::system_clock::now();
+    std::chrono::time_point<std::chrono::steady_clock> current = std::chrono::steady_clock::now();
     if( current > _NextTrigger )
     {
       ready = true;

--- a/csmd/src/daemon/include/message_control.h
+++ b/csmd/src/daemon/include/message_control.h
@@ -87,7 +87,7 @@ static const uint64_t MSG_SEQ_NUMBER_HALFPOINT = (MSG_SEQ_NUMBER_MAX >> 1);
 
 struct MessageContextContainer
 {
-  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
+  typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
   csm::network::MessageAndAddress_sptr _MsgAddr;
   csm::daemon::EventContext_sptr _Context;
   csm::daemon::VirtualNetworkChannel_sptr _Connection;
@@ -101,7 +101,7 @@ struct MessageContextContainer
                            const uint32_t i_Timeout )
   : _MsgAddr( i_MsgAddr ), _Context( i_Context ), _Connection( i_Connection ), _RespCount( i_RespCount )
   {
-    _Timeout = std::chrono::system_clock::now() + std::chrono::seconds( i_Timeout );
+    _Timeout = std::chrono::steady_clock::now() + std::chrono::seconds( i_Timeout );
     LOG( csmd, trace ) << "Create MsgCtxContainer: (" << _MsgAddr << "," << (void*)(_Context.get()) << ")";
   }
   ~MessageContextContainer()
@@ -121,7 +121,7 @@ typedef std::unordered_map<uint64_t, uint64_t> ClientMessageIDMapping;
 
 class MessageControl
 {
-  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
+  typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
   MessageContextStore _OutboundContextStore;
   std::queue<uint64_t> _GarbageCollectedIDs;
   MessageContextStore _InboundContextStore;

--- a/csmd/src/daemon/include/throttle.h
+++ b/csmd/src/daemon/include/throttle.h
@@ -21,7 +21,7 @@
 namespace csm {
 namespace daemon {
 
-typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
+typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
 
 template<uint32_t THROTTLE_GRANULARITY>
 class Throttle
@@ -42,9 +42,9 @@ public:
             const uint64_t i_Duration )
   : _RemainingSteps( 0 ),
     _EpochDuration( std::chrono::seconds( i_Duration )),
-    _EndOfEpoch( std::chrono::system_clock::now() + _EpochDuration ),
+    _EndOfEpoch( std::chrono::steady_clock::now() + _EpochDuration ),
     _StepLimit( i_MaxSteps ),
-    _LastThrottleTime( std::chrono::system_clock::now() ),
+    _LastThrottleTime( std::chrono::steady_clock::now() ),
     _StepCount( 0 ),
     _DownThrottleRate( 1 ),
     _ThrottleName( i_Name )
@@ -67,7 +67,7 @@ public:
     if( NeedsThrottle() )
     {
       // todo: replace with daemon clock to avoid syscalls
-      TimeType newThrottleTime = std::chrono::system_clock::now();
+      TimeType newThrottleTime = std::chrono::steady_clock::now();
       std::chrono::seconds interval = std::chrono::duration_cast<std::chrono::seconds>( newThrottleTime - _LastThrottleTime );
 
       if( interval.count() > 0 )
@@ -109,7 +109,7 @@ public:
   inline void Update()
   {
     // todo: replace with daemon clock to avoid syscalls
-    TimeType currentTime = std::chrono::system_clock::now();
+    TimeType currentTime = std::chrono::steady_clock::now();
     if( currentTime < _EndOfEpoch )
     {
       std::chrono::seconds pause = std::chrono::duration_cast<std::chrono::seconds>( _EndOfEpoch - currentTime );

--- a/csmd/src/daemon/include/virtual_network_channel.h
+++ b/csmd/src/daemon/include/virtual_network_channel.h
@@ -37,7 +37,7 @@ class VirtualNetworkChannel {
 
   friend class VirtualNetworkChannelPool;
 
-  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
+  typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
   typedef std::pair< csm::network::MessageAndAddress_sptr, csm::daemon::EventContext_sptr > MsgAndCtxType;
   typedef std::deque< csm::daemon::CoreEvent* > ConnectionEventQueue;
   typedef std::deque< MsgAndCtxType > ConnectionMessageQueue;
@@ -70,7 +70,7 @@ public:
                 csm::daemon::EventContext_sptr &o_Ctx,
                 const uint32_t i_TimeoutMicroSeconds = DEFAULT_NET_REQUEST_TIMEOUT )
   {
-    TimeType ts = std::chrono::system_clock::now() + std::chrono::microseconds( i_TimeoutMicroSeconds );
+    TimeType ts = std::chrono::steady_clock::now() + std::chrono::microseconds( i_TimeoutMicroSeconds );
     MsgAndCtxType msgCtx;
 
     if( _State < RESERVED )
@@ -91,7 +91,7 @@ public:
       }
       _QueueLock.unlock();
       sched_yield();
-    } while( std::chrono::system_clock::now() < ts );
+    } while( std::chrono::steady_clock::now() < ts );
 
     if( msgCtx.first != nullptr )
     {
@@ -123,7 +123,7 @@ public:
     }
     _ManagerWakeup->WakeUp();
     // todo: timeout options... (right now missing forwarded successful ACK)
-    // TimeType ts = std::chrono::system_clock::now() + std::chrono::seconds( i_TimeoutMicroSeconds );
+    // TimeType ts = std::chrono::steady_clock::now() + std::chrono::seconds( i_TimeoutMicroSeconds );
     return i_MsgAddr->_Msg.GetDataLen();
   }
 

--- a/csmd/src/daemon/src/csm_bds_manager.cc
+++ b/csmd/src/daemon/src/csm_bds_manager.cc
@@ -95,7 +95,7 @@ csm::daemon::EventManagerBDS::EventManagerBDS( const csm::daemon::BDS_Info &i_BD
                      0, 10000000, 1 ),
   _Socket( 0 ),
   _CachedMsgQueue(),
-  _CurrentTime( std::chrono::system_clock::now() )
+  _CurrentTime( std::chrono::steady_clock::now() )
 {
   _Sink = new csm::daemon::EventSinkBDS( &_IdleRetryBackOff );
 
@@ -107,7 +107,7 @@ csm::daemon::EventManagerBDS::EventManagerBDS( const csm::daemon::BDS_Info &i_BD
   if( BDSActive() )
     Connect();
   Unfreeze();
-  _LastConnect = std::chrono::system_clock::now();
+  _LastConnect = std::chrono::steady_clock::now();
   _LastConnectInterval = 1;
 }
 
@@ -209,7 +209,7 @@ csm::daemon::EventManagerBDS::Connect()
     }
     else
     {
-      _LastConnect = std::chrono::system_clock::now();
+      _LastConnect = std::chrono::steady_clock::now();
       close( _Socket );
       _Socket = 0;
     }

--- a/csmd/src/daemon/src/csm_db_manager.cc
+++ b/csmd/src/daemon/src/csm_db_manager.cc
@@ -55,7 +55,7 @@ void DBManagerMain( csm::daemon::EventManagerDB *aMgr )
 
         if (dbevent == nullptr )
         {
-          if(dbConnPool->GetHeartbeatTimer() < std::chrono::system_clock::now())
+          if(dbConnPool->GetHeartbeatTimer() < std::chrono::steady_clock::now())
           {
             // check db status and/or try to reconnect
             dbConnPool->Heartbeat();

--- a/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_infrastructure_test.h
@@ -151,7 +151,7 @@ public:
    // number of the received msg from CNs
    std::atomic<size_t> _RecvCNs;
    // stored time stamp to check if timer event works properly
-   std::chrono::time_point<std::chrono::system_clock> _timer_reference;
+   std::chrono::time_point<std::chrono::steady_clock> _timer_reference;
 };
 
 

--- a/csmd/src/daemon/src/message_control.cc
+++ b/csmd/src/daemon/src/message_control.cc
@@ -32,8 +32,8 @@ csm::daemon::MessageControl::MessageControl( const uint64_t aDaemonID )
              csm::daemon::MSG_SEQ_NUMBER_HALFPOINT,
              csm::daemon::MSGID_HALF_TIME_LIMIT )
 {
-  _GCTimer = std::chrono::system_clock::now() + std::chrono::seconds( csm::daemon::DEFAULT_GC_INTERVAL );
-  _MsgIDTimer = std::chrono::system_clock::now() + std::chrono::seconds( csm::daemon::MSGID_HALF_TIME_LIMIT );
+  _GCTimer = std::chrono::steady_clock::now() + std::chrono::seconds( csm::daemon::DEFAULT_GC_INTERVAL );
+  _MsgIDTimer = std::chrono::steady_clock::now() + std::chrono::seconds( csm::daemon::MSGID_HALF_TIME_LIMIT );
 }
 
 csm::daemon::MessageControl::~MessageControl()
@@ -159,7 +159,7 @@ csm::daemon::MessageControl::GCCleanup( const TimeType &aStartTime,
 
     TimeType current;
     // every now and then, check if we're taking too long...
-    if(( ((++removed) & 0x3F) == 0 ) && ( ( current = std::chrono::system_clock::now()) >= aDeadline))
+    if(( ((++removed) & 0x3F) == 0 ) && ( ( current = std::chrono::steady_clock::now()) >= aDeadline))
     {
       completed = false;
       LOG( csmd, info ) << "GC: reached limit for cleanup after " << removed << " of " << toRemoveEntries
@@ -173,7 +173,7 @@ csm::daemon::MessageControl::GCCleanup( const TimeType &aStartTime,
   // did we remove anything, then do some logging
   if( removed > 0 )
   {
-    TimeType GC_Finished = std::chrono::system_clock::now();
+    TimeType GC_Finished = std::chrono::steady_clock::now();
     uint64_t micros = std::chrono::duration_cast<std::chrono::microseconds>(GC_Finished-aStartTime).count();
 
     LOG( csmd, debug ) << "GC: removed " << removed << " of " << toRemoveEntries
@@ -227,7 +227,7 @@ csm::daemon::MessageControl::GCScan( const TimeType &aStartTime,
     {
       TimeType current;
       // every now and then, check if we're taking too long...
-      if(( (iteration & 0x7F) == 0 ) && ( ( current = std::chrono::system_clock::now()) >= aDeadline))
+      if(( (iteration & 0x7F) == 0 ) && ( ( current = std::chrono::steady_clock::now()) >= aDeadline))
       {
         completed = false;
         // if we found less than 1/10th of the map, we continue from here next time
@@ -259,7 +259,7 @@ csm::daemon::MessageControl::GarbageCollect( const uint64_t aTimeLimit )
 {
   bool completed = true;
 
-  TimeType GC_Time = std::chrono::system_clock::now();
+  TimeType GC_Time = std::chrono::steady_clock::now();
   TimeType GC_Limit = GC_Time + std::chrono::microseconds( aTimeLimit );
 
   /* GC Strategy:

--- a/csmd/src/db/include/DBConnectionPool.h
+++ b/csmd/src/db/include/DBConnectionPool.h
@@ -219,7 +219,7 @@ public:
     return (_FreeConnPool.size() + _LockedConnPool.size()) > 0;
   }
 
-  std::chrono::time_point<std::chrono::system_clock> GetHeartbeatTimer() const
+  std::chrono::time_point<std::chrono::steady_clock> GetHeartbeatTimer() const
   {
     return _HeartbeatTimer;
   }
@@ -263,12 +263,12 @@ public:
     // don't update the timer if no free connections are available and no bad connections exist
     if(heartbeat || retry)
     {
-      _HeartbeatTimer = std::chrono::system_clock::now() + _HeartbeatInterval;
+      _HeartbeatTimer = std::chrono::steady_clock::now() + _HeartbeatInterval;
     }
     else
     {
       LOG(csmd,debug) << "DBConnectionPool::Heartbeat(): no connections available";
-      _HeartbeatTimer = std::chrono::system_clock::now() + _HeartbeatWait;
+      _HeartbeatTimer = std::chrono::steady_clock::now() + _HeartbeatWait;
     }
 
     bool heartbeat_failed = false;
@@ -343,7 +343,7 @@ public:
     }
     if(_DisconnectedPool.empty())
     {
-      _HeartbeatTimer = std::chrono::system_clock::now() + _HeartbeatInterval;
+      _HeartbeatTimer = std::chrono::steady_clock::now() + _HeartbeatInterval;
     }
     _TimerLock.unlock();
   }
@@ -366,7 +366,7 @@ private:
     draining(false)
   {
     Connect();
-    _HeartbeatTimer = std::chrono::system_clock::now() + _HeartbeatInterval;
+    _HeartbeatTimer = std::chrono::steady_clock::now() + _HeartbeatInterval;
   }
 
   static DBConnectionPool *_instance;
@@ -387,7 +387,7 @@ private:
 
   std::chrono::seconds _HeartbeatInterval;
   std::chrono::seconds _HeartbeatWait;
-  std::chrono::time_point<std::chrono::system_clock> _HeartbeatTimer;
+  std::chrono::time_point<std::chrono::steady_clock> _HeartbeatTimer;
 
   std::condition_variable DrainedPoolCondition;
   std::atomic<bool> draining;

--- a/csmnet/src/CPP/endpoint_heartbeat.h
+++ b/csmnet/src/CPP/endpoint_heartbeat.h
@@ -35,7 +35,7 @@ namespace network {
 class EndpointHeartbeat_stateless
 {
 public:
-  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
+  typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
 
 protected:
   TimeType _EndOfHappy; // at the end of the happy, we send a heartbeat
@@ -130,7 +130,7 @@ public:
   virtual void updateRecvSuccess()
   {
     // make the end of happy about 75% of the configured Interval
-    TimeType current = std::chrono::system_clock::now();
+    TimeType current = std::chrono::steady_clock::now();
     _EndOfHappy = current + std::chrono::seconds( _Interval );
   }
 
@@ -225,7 +225,7 @@ public:
   virtual void updateRecvSuccess()
   {
     // make the end of unsure about 125% of the configured Interval
-    TimeType current = std::chrono::system_clock::now();
+    TimeType current = std::chrono::steady_clock::now();
     _EndOfHappy = current + std::chrono::seconds( _Interval );
     _EndOfUnsure = current + std::chrono::seconds( (_Interval * 20) >> 4 );
     _Status = HAPPY;
@@ -235,7 +235,7 @@ public:
   // update the send deadline; e.g. after a successful send operation
   virtual void updateSendSuccess()
   {
-    TimeType current = std::chrono::system_clock::now();
+    TimeType current = std::chrono::steady_clock::now();
     _EndOfUnsure = current + std::chrono::seconds( (_Interval * 20) >> 4 );
     CSMLOG( csmnet, debug ) << ( _Address == nullptr ? "" : _Address->Dump() ) << " Successful send. Status: " << _Status;
   }

--- a/csmnet/src/CPP/endpoint_multi_unix.cc
+++ b/csmnet/src/CPP/endpoint_multi_unix.cc
@@ -294,7 +294,7 @@ csm::network::EndpointMultiUnix::Sync( const SyncAction aSync )
       throw csm::network::Exception("Unrecognized sync action requested.");
   }
 
-  EndpointHeartbeat::TimeType ref = std::chrono::system_clock::now();
+  EndpointHeartbeat::TimeType ref = std::chrono::steady_clock::now();
   if( _Heartbeat.dueSend( ref ) )
   {
     csm::network::NetworkCtrlInfo *tail = ret;

--- a/csmnet/src/CPP/endpoint_multi_unix.h
+++ b/csmnet/src/CPP/endpoint_multi_unix.h
@@ -41,7 +41,7 @@ typedef std::deque<csm::network::EndpointVirtualUnix*> EndpointVirtualFifo;
 // this is holding the master Unix socket
 // if it's a server socket, it's going to be unconnected (and will stay unconnected)
 class EndpointMultiUnix : public EndpointDualUnix {
-  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
+  typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
   EndpointVirtualMap _Known;
   EndpointVirtualFifo _ToAccept;
   EndpointVirtualFifo _Removed;

--- a/csmnet/src/CPP/endpoint_ptp.cc
+++ b/csmnet/src/CPP/endpoint_ptp.cc
@@ -148,7 +148,7 @@ csm::network::NetworkCtrlInfo* csm::network::EndpointPTP_base::Sync( const csm::
     return nullptr;
 
   csm::network::NetworkCtrlInfo *ctrlInfo = nullptr;
-  EndpointHeartbeat::TimeType ref = std::chrono::system_clock::now();
+  EndpointHeartbeat::TimeType ref = std::chrono::steady_clock::now();
   if( _Heartbeat.peerDead( ref ) )
   {
     throw csm::network::ExceptionEndpointDown("Heartbeat: Peer not responding.", ENETDOWN );

--- a/csmnet/src/CPP/endpoint_ptp_sec.cc
+++ b/csmnet/src/CPP/endpoint_ptp_sec.cc
@@ -397,7 +397,7 @@ csm::network::EndpointPTP_sec_base::SSLConnectPrep()
   LOG( csmnet, debug ) << "SSL Connecting...";
   ERR_clear_error();
   bool keep_retrying = true;
-  std::chrono::time_point< std::chrono::system_clock > end = std::chrono::system_clock::now() + std::chrono::milliseconds( 1000 );
+  std::chrono::time_point< std::chrono::steady_clock > end = std::chrono::steady_clock::now() + std::chrono::milliseconds( 1000 );
 
   while( keep_retrying )
   {
@@ -430,7 +430,7 @@ csm::network::EndpointPTP_sec_base::SSLConnectPrep()
             rc = csm::network::EndpointPTP_base::CheckConnectActivity( bsock, true ); // check read and write activity
             if( rc != 0 )
               throw csm::network::ExceptionEndpointDown( "SSL Connection failed.", rc );
-            if( std::chrono::system_clock::now() > end )
+            if( std::chrono::steady_clock::now() > end )
               throw csm::network::ExceptionEndpointDown( "SSL Connection timed out", ETIMEDOUT );
             break;
 

--- a/csmnet/src/CPP/message_ack.h
+++ b/csmnet/src/CPP/message_ack.h
@@ -82,7 +82,7 @@ public:
   typedef std::unordered_set<AckKeyType, AckKeyTypeHash> AckSet;
 
 private:
-  typedef std::chrono::time_point< std::chrono::system_clock > TimeType;
+  typedef std::chrono::time_point< std::chrono::steady_clock > TimeType;
 
   class TimedMessageType
   {
@@ -110,7 +110,7 @@ public:
   ~MessageACK() {}
 
   void SetDefaultTimeout( const uint64_t aTimeout ) { _DefaultTimeout = aTimeout; }
-  void UpdateClock() { _CurrentClock = std::chrono::system_clock::now(); }
+  void UpdateClock() { _CurrentClock = std::chrono::steady_clock::now(); }
 
   csm::network::MessageAndAddress* CheckCreateACKMsg( const csm::network::MessageAndAddress& aMsgAddr,
                                                       const csm::network::Address_sptr aDestAddr,
@@ -217,7 +217,7 @@ public:
 private:
   TimeType CalculateEndTime( const uint64_t aTimeout ) const
   {
-    TimeType end = std::chrono::system_clock::now() + std::chrono::seconds( aTimeout );
+    TimeType end = std::chrono::steady_clock::now() + std::chrono::seconds( aTimeout );
     return end;
   }
   inline AckKeyType MakeKey( const uint64_t aMsgId, const uint32_t aReply, const uint32_t aRefCount = 1 )


### PR DESCRIPTION
This PR replaces csmd usage of system_clock with steady_clock to reduce the chances for hickups when timezone changes between daylight and standart time or the clock gets adjusted for other reasons.

Especially covering any adjustments where the new time is in the past. This would cause any timers to take longer to trigger causing delays in heartbeats (e.g. for connection error detection) and other timers that got set to observe API timeouts and more.

There are a few instances of system time left in the CSM API section that would have to be reviewed by corresponding code owners (probably @NickyDaB or @mew2057). As far as I can tell, the changes in this PR have no impact on the creation of any user-visible or BDS-inserted time stamps. @besawn might want to check that statement from the RAS and Inventory perspective.

Note: a forward adjustment of system time might still cause issues in the sense of timers that expire too early. However, I can only think of issues that would cause API timeouts. The connection heartbeats require 3 timer intervals to expire before shutting down connections and a single time adjustment would only affect one interval.