### PR TITLE
Fix csm_db_history_archive.py parse error

### DIFF
--- a/csmdb/sql/csm_db_history_archive.py
+++ b/csmdb/sql/csm_db_history_archive.py
@@ -90,7 +90,7 @@ def dump_table( db, user, table_name, count, target_dir, is_ras=False ):
                 file.write('{{ "type":"db-{0}", "data":{1} }}\n'.format(
                     table_name, json.dumps(dict(zip(colnames, row)), default=str)))
     except Exception as e:
-        print( "Exception caught: {0}".format(e)
+        print "Exception caught: {0}".format(e)
         cursor.execute("DROP TABLE IF EXISTS temp_{0}".format(table_name))
         db_conn.rollback()
         db_conn.close()


### PR DESCRIPTION
Remove stray open parenthesis.

Fixes #392
