### PR TITLE
Issue 1006: disconnect from bbserver on hello having zero devices

### DIFF
--- a/bb/src/connections.cc
+++ b/bb/src/connections.cc
@@ -1031,7 +1031,8 @@ int xchgWithBBserver(const string& name)
     rc = bbproxy_SayHello(name);
     if(rc)
     {
-        LOG(bb,error) << "Hello exchange with bbserver failed";
+        LOG(bb,error) << "Hello exchange with bbserver failed. Closing connection";
+        closeConnectionFD(name);
         return -2;
     }
     return rc;


### PR DESCRIPTION
When bbserver returns 0 devices on the Hello response, bbproxy now disconnects from the bbserver.
A query of active connections against bbproxy will show no active servers.

Tested using gdb and setting rc to nonzero after calling sayHello.  Small change (two lines of code).

