### PR TITLE
UFM config fix

### DIFF
--- a/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
+++ b/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
@@ -44,7 +44,7 @@ public:
 
   static INV_SWITCH_CONNECTOR_ACCESS* GetInstance(){ if( _Instance == nullptr ){ _Instance = new INV_SWITCH_CONNECTOR_ACCESS(); } return _Instance; } // get the istance of the class object
   int GetCompiledWithSupport(); // get compiled_with_support_flag
-  int ExecuteDataCollection(std::string rest_address, std::string authentication_string_for_the_http_request, std::string csm_inv_log_dir); // execute data collection
+  int ExecuteDataCollection(std::string rest_address, std::string authentication_string_for_the_http_request, std::string csm_inv_log_dir, std::string switch_errors); // execute data collection
   std::string ReturnFieldValue(unsigned long int vector_id, unsigned long int index_in_the_vector); // return the value of the field
   int TotalNumberOfRecords();
   ~INV_SWITCH_CONNECTOR_ACCESS();

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -377,6 +377,8 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			}
 
 			std::cout << std::endl;
+
+			bad_ib_cable_records << "\nTotal Bad Records: " << NA_serials_count + missing_cable_info_count << "\n" << std::endl;
 		
 			// closing the input file
 			input_file.close();
@@ -389,7 +391,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::cout << "Exception thrown during IB inventory connection: " << e.what() << std::endl;
 	}
 
-	return 1;
+	return 0;
 }
 
 std::string INV_IB_CONNECTOR_ACCESS::ReturnFieldValue(unsigned long int vector_id, unsigned long int index_in_the_vector)

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -231,7 +231,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 				// check if this is one of the strange lines (cable not complete)
 				if ( line.find("\"cable_info\": {},") != std::string::npos ){
 					//copy the missing cable_info fields to the bad_record file
-					bad_ib_cable_records << "Cable: " << vector_of_the_part_numbers.size()-1 << std::endl;
+					bad_ib_cable_records << "Cable: " << total_ib_records + 1 << std::endl;
 					bad_ib_cable_records << "part_number:      " << "NOT AVAILABLE" << std::endl;
 					bad_ib_cable_records << "length:           " << "NOT AVAILABLE" << std::endl;
 					bad_ib_cable_records << "serial_number:    " << "NOT AVAILABLE" << std::endl;
@@ -344,7 +344,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 							case 13:
 								//special case with a bad serial number. 
 								//copy the already added fields to the bad_record file
-								bad_ib_cable_records << "Cable: " << vector_of_the_part_numbers.size()-1 << std::endl;
+								bad_ib_cable_records << "Cable: " << total_ib_records + 1<< std::endl;
 								bad_ib_cable_records << "part_number:      " << vector_of_the_part_numbers[vector_of_the_part_numbers.size()-1] << std::endl;
 								bad_ib_cable_records << "length:           " << vector_of_the_lengths[vector_of_the_lengths.size()-1] << std::endl;
 								bad_ib_cable_records << "serial_number:    " << line << std::endl;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -145,7 +145,13 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		}
 		
 		// opening output file
-		std::string output_file_name = csm_inv_log_dir + "/ufm_ib_cable_output_file.txt";
+
+        //TEMP 
+        // ToDo: replace this buffer push to a config file update like error paths below. 
+        std::string ufm_ib_cable_output_filename = "ufm_ib_cable_output_file.txt";
+
+
+		std::string output_file_name = csm_inv_log_dir + "/" + ufm_ib_cable_output_filename;
 		std::ofstream output_file(output_file_name.c_str(),std::ios::out);
 		
 		// checking if output file is open
@@ -200,15 +206,12 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			
 			// csm_inv_log_dir is path
 			// ib_cable_errors is file
-			std::cout << "ib error full path: " << csm_inv_log_dir << "/" << ib_cable_errors << std::endl;
+			//std::cout << "ib error full path: " << csm_inv_log_dir << "/" << ib_cable_errors << std::endl;
 			
 			bad_ib_cable_records.open (csm_inv_log_dir + "/" + ib_cable_errors);
 			bad_ib_cable_records << "CSM IB cable inventory collection" << std::endl;
 			bad_ib_cable_records << "File created: " << asctime(timeinfo) << std::endl;
 			bad_ib_cable_records << "The following records are incomplete and can not be inserted into CSM database.\n" << std::endl;
-	
-			// printing
-			std::cout << "reading input file" << std::endl;
 			
 			//helper variable to keep track of a bad serial number for a record. 
 			bool bad_record = false;
@@ -359,18 +362,21 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 					}
 				}
 			}
+
+			std::cout << "UFM reported " << total_ib_records << " IB records." << std::endl;
+			std::cout << "This report from UFM can be found in '" << ufm_ib_cable_output_filename << "' located at '" << csm_inv_log_dir << std::endl;
 	
 			if(NA_serials_count > 0){
-				std::cerr << "\nWARNING: " << NA_serials_count << " IB cables found with 'NA' serial numbers and have been removed from CSM inventory collection data." << std::endl;
-				std::cerr << "These records copied into 'bad_ib_cable_records.txt' located at '/var/log/ibm/csm/inv/' \n" << std::endl;
+				std::cerr << "WARNING: " << NA_serials_count << " IB cables found with 'NA' serial numbers and have been removed from CSM inventory collection data." << std::endl;
+				std::cerr << "These records copied into '" << ib_cable_errors <<"' located at '" << csm_inv_log_dir << std::endl;
 			}
 			
 			if(missing_cable_info_count > 0){
-				std::cerr << "\nWARNING: " << missing_cable_info_count << " IB cables found with no 'cable_info' and have been removed from CSM inventory collection data." << std::endl;
-				std::cerr << "These records copied into 'bad_ib_cable_records.txt' located at '/var/log/ibm/csm/inv/' \n" << std::endl;
+				std::cerr << "WARNING: " << missing_cable_info_count << " IB cables found with no 'cable_info' and have been removed from CSM inventory collection data." << std::endl;
+				std::cerr << "These records copied into '" << ib_cable_errors <<"' located at '" << csm_inv_log_dir << std::endl;
 			}
-			
-			std::cout << "\nUFM reported " << total_ib_records << " IB records.\n" << std::endl;
+
+			std::cout << std::endl;
 		
 			// closing the input file
 			input_file.close();

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -101,6 +101,11 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 {
 	try
 	{	
+        //Helper Variables
+		//helper variable to keep track of total records.
+		int total_switch_records = 0;
+
+
 		// Get a list of endpoints corresponding to the server name.
 		boost::asio::io_service io_service;
 		tcp::resolver resolver(io_service);
@@ -169,10 +174,15 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 			//LOG(csmd, debug) << &response;
 			//std::cout << &response;
 		}
+
+
+
+		// TEMP 
+        // ToDo: replace this buffer push to a config file update like error paths below. 
+        std::string ufm_switch_output_filename = "ufm_switch_output_file.txt";
 		
 		// opening output file
-		std::string output_file_name = csm_inv_log_dir + "/ufm_switch_output_file.txt";
-		std::cout << "output file name: " << output_file_name << std::endl;
+		std::string output_file_name = csm_inv_log_dir + "/" + ufm_switch_output_filename;
 		std::ofstream output_file(output_file_name.c_str(),std::ios::out);
 
 		// checking if output file is open
@@ -210,7 +220,6 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 
 		// opening input file
 		std::string input_file_name = output_file_name;
-		std::cout << "input file name: " << input_file_name << std::endl;
 		std::ifstream input_file(input_file_name.c_str(),std::ios::in);
 
 		// checking if input file is open
@@ -220,8 +229,6 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 			std::cout << "Input file " << input_file_name << " not open, return" << std::endl;
 			return 1;
 		}else{
-			// printing
-			std::cout << "reading input file..." << std::endl;
 
 			// setting the number of lines to skip
 			int number_of_lines_to_skip = 0;
@@ -562,6 +569,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 								//LOG(csmd, debug) << "updating vector of the switch names";
 								//std::cout << "updating vector of the switch names" <<std::endl;
 								vector_of_the_switch_names.push_back(line);
+								total_switch_records++;
 								break;
 							case 1:
 								//LOG(csmd, debug) << "updating vector of the serial numbers";
@@ -655,6 +663,9 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 					}
 				}
 			}
+
+			std::cout << "UFM reported " << total_switch_records << " switch records." << std::endl;
+			std::cout << "This report from UFM can be found in '" << ufm_switch_output_filename << "' located at '" << csm_inv_log_dir << "'\n" << std::endl;
 
 			// closing the input file
 			input_file.close();

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -281,7 +281,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 							//check for the broken "[],"
 							if(line.find("[],") != std::string::npos){
 								//push num_modules
-								vector_of_the_num_modules.push_back(std::to_string(number_of_modules_found));
+								//vector_of_the_num_modules.push_back(std::to_string(number_of_modules_found));
 								
 								//Should prob report some error here.
 								
@@ -299,7 +299,9 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 								std::getline(input_file, line);
 								
 								// determine if 'slim' or 'expanded'
-								if(line.find("{") == std::string::npos){
+								if(line.find("{") == std::string::npos)
+								{
+									//did not find a "{"
 									// 'slim' case
 									// only a list of module names are found
 
@@ -637,8 +639,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 						switch (i)
 						{
 							case 0:
-								if(bad_record){ bad_switch_records << "switch_name: " << line << std::endl; } 
-							    else{ vector_of_the_switch_names.push_back(line); }
+								vector_of_the_switch_names.push_back(line);
 							    total_switch_records++;
 								break;
 							case 1:
@@ -670,11 +671,14 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 								//last record for bad record
 								// unfortunately only record
 								if(bad_record){ 
-									bad_switch_records << "model: " << line << std::endl; 
+									bad_switch_records << "model:                 " << line << std::endl; 
 									//because its last field. pad the record with a new line. 
 									bad_switch_records << std::endl;
 								} 
 							    else{ vector_of_the_model.push_back(line); }
+							    // because last field of ufm record. 
+							    //reset to a new record
+								bad_record = false;
 								break;
 							case 7:
 								//LOG(csmd, debug) << "updating vector of the types";
@@ -735,55 +739,53 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 								vector_of_the_os_versions.push_back(line);
 								break;
 						}
+
+						//I think unfortunately for now . we have to do this here. this way
+						if(bad_record)
+						{
+							//copy the already added fields to the bad_record file
+							bad_switch_records << "Switch: " << total_switch_records << std::endl;
+							bad_switch_records << "ip:                    " << vector_of_the_ips[vector_of_the_ips.size()-1] << std::endl;
+							bad_switch_records << "fw_version:            " << vector_of_the_firmware_versions[vector_of_the_firmware_versions.size()-1] << std::endl;
+							bad_switch_records << "total_alarms:          " << vector_of_the_total_alarms[vector_of_the_total_alarms.size()-1] << std::endl;
+							bad_switch_records << "psid:                  " << vector_of_the_ps_ids[vector_of_the_ps_ids.size()-1] << std::endl;
+							bad_switch_records << "guid:                  " << vector_of_the_guids[vector_of_the_guids.size()-1] << std::endl;
+							bad_switch_records << "state:                 " << vector_of_the_states[vector_of_the_states.size()-1] << std::endl;
+							bad_switch_records << "role:                  " << vector_of_the_roles[vector_of_the_roles.size()-1] << std::endl;
+							bad_switch_records << "type:                  " << vector_of_the_types[vector_of_the_types.size()-1] << std::endl;
+							bad_switch_records << "vendor:                " << vector_of_the_vendors[vector_of_the_vendors.size()-1] << std::endl;
+							bad_switch_records << "description:           " << vector_of_the_descriptions[vector_of_the_descriptions.size()-1] << std::endl;
+							bad_switch_records << "has_ufm_agent:         " << vector_of_the_has_ufm_agents[vector_of_the_has_ufm_agents.size()-1] << std::endl;
+							bad_switch_records << "server_operation_mode: " << vector_of_the_server_operation_modes[vector_of_the_server_operation_modes.size()-1] << std::endl;
+							bad_switch_records << "sm_mode:               " << vector_of_the_sm_modes[vector_of_the_sm_modes.size()-1] << std::endl;
+							bad_switch_records << "system_name:           " << vector_of_the_system_names[vector_of_the_system_names.size()-1] << std::endl;
+							bad_switch_records << "sw_version:            " << vector_of_the_sw_versions[vector_of_the_sw_versions.size()-1] << std::endl;
+							bad_switch_records << "system_guid:           " << vector_of_the_system_guids[vector_of_the_system_guids.size()-1] << std::endl;
+							bad_switch_records << "name:                  " << vector_of_the_switch_names[vector_of_the_switch_names.size()-1] << std::endl;
+							bad_switch_records << "modules:               ???" << std::endl;
+							bad_switch_records << "serial_number:         N/A" << std::endl;
+
+							//remove already added fields to lists.
+							vector_of_the_ips.pop_back();
+							vector_of_the_firmware_versions.pop_back();
+							vector_of_the_total_alarms.pop_back();
+							vector_of_the_ps_ids.pop_back();
+							vector_of_the_guids.pop_back();
+							vector_of_the_states.pop_back();
+							vector_of_the_roles.pop_back();
+							vector_of_the_types.pop_back();
+							vector_of_the_vendors.pop_back();
+							vector_of_the_descriptions.pop_back();
+							vector_of_the_has_ufm_agents.pop_back();
+							vector_of_the_server_operation_modes.pop_back();
+							vector_of_the_sm_modes.pop_back();
+							vector_of_the_system_names.pop_back();
+							vector_of_the_sw_versions.pop_back();
+							vector_of_the_system_guids.pop_back();
+							vector_of_the_switch_names.pop_back();
+						}
 					}
-
-					//I think unfortunately for now . we have to do this here. this way
-					if(bad_record)
-					{
-						//copy the already added fields to the bad_record file
-						bad_switch_records << "Switch: " << total_switch_records << std::endl;
-						bad_switch_records << "ip:                    " << vector_of_the_ips[vector_of_the_ips.size()-1] << std::endl;
-						bad_switch_records << "fw_version:            " << vector_of_the_firmware_versions[vector_of_the_firmware_versions.size()-1] << std::endl;
-						bad_switch_records << "total_alarms:          " << vector_of_the_total_alarms[vector_of_the_total_alarms.size()-1] << std::endl;
-						bad_switch_records << "psid:                  " << vector_of_the_ps_ids[vector_of_the_ps_ids.size()-1] << std::endl;
-						bad_switch_records << "guid:                  " << vector_of_the_guids[vector_of_the_guids.size()-1] << std::endl;
-						bad_switch_records << "state:                 " << vector_of_the_states[vector_of_the_states.size()-1] << std::endl;
-						bad_switch_records << "role:                  " << vector_of_the_roles[vector_of_the_roles.size()-1] << std::endl;
-						bad_switch_records << "type:                  " << vector_of_the_types[vector_of_the_types.size()-1] << std::endl;
-						bad_switch_records << "vendor:                " << vector_of_the_vendors[vector_of_the_vendors.size()-1] << std::endl;
-						bad_switch_records << "description:           " << vector_of_the_descriptions[vector_of_the_descriptions.size()-1] << std::endl;
-						bad_switch_records << "has_ufm_agent:         " << vector_of_the_has_ufm_agents[vector_of_the_has_ufm_agents.size()-1] << std::endl;
-						bad_switch_records << "server_operation_mode: " << vector_of_the_server_operation_modes[vector_of_the_server_operation_modes.size()-1] << std::endl;
-						bad_switch_records << "sm_mode:               " << vector_of_the_sm_modes[vector_of_the_sm_modes.size()-1] << std::endl;
-						bad_switch_records << "system_name:           " << vector_of_the_system_names[vector_of_the_system_names.size()-1] << std::endl;
-						bad_switch_records << "sw_version:            " << vector_of_the_sw_versions[vector_of_the_sw_versions.size()-1] << std::endl;
-						bad_switch_records << "system_guid:           " << vector_of_the_system_guids[vector_of_the_system_guids.size()-1] << std::endl;
-						bad_switch_records << "name:                  " << vector_of_the_switch_names[vector_of_the_switch_names.size()-1] << std::endl;
-						bad_switch_records << "modules:               ???" << std::endl;
-
-						//remove already added fields to lists.
-						vector_of_the_ips.pop_back();
-						vector_of_the_firmware_versions.pop_back();
-						vector_of_the_total_alarms.pop_back();
-						vector_of_the_ps_ids.pop_back();
-						vector_of_the_guids.pop_back();
-						vector_of_the_states.pop_back();
-						vector_of_the_roles.pop_back();
-						vector_of_the_types.pop_back();
-						vector_of_the_vendors.pop_back();
-						vector_of_the_descriptions.pop_back();
-						vector_of_the_has_ufm_agents.pop_back();
-						vector_of_the_server_operation_modes.pop_back();
-						vector_of_the_sm_modes.pop_back();
-						vector_of_the_system_names.pop_back();
-						vector_of_the_sw_versions.pop_back();
-						vector_of_the_system_guids.pop_back();
-						vector_of_the_switch_names.pop_back();
-					}
-				}
-
-				//reset to a new record
-				bad_record = false;
+				}				
 			}
 
 			std::cout << "UFM reported " << total_switch_records << " switch records." << std::endl;
@@ -794,12 +796,9 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 				std::cerr << "These records copied into '" << switch_errors <<"' located at '" << csm_inv_log_dir << std::endl;
 			}
 
-			if(bad_record == true)
-			{
-				std::cout << "bad records" << std::endl;
-			}
-
 			std::cout << std::endl;
+
+			bad_switch_records << "\nTotal Bad Records: " << NA_serials_count << "\n" << std::endl;
 
 			// closing the input file
 			input_file.close();
@@ -813,7 +812,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		std::cout << "Exception thrown during Switch inventory connection: " << e.what() << std::endl;
 	}
 
-	return 1;
+	return 0;
 }
 
 std::string INV_SWITCH_CONNECTOR_ACCESS::ReturnFieldValue(unsigned long int vector_id, unsigned long int index_in_the_vector)

--- a/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
+++ b/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
@@ -468,8 +468,15 @@ int main(int argc, char *argv[])
 		} 
 		else 
 		{
+			int returnCode = 0;
 			// execute data collection for the ib cables
-			INV_IB_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, ib_cable_errors);
+			returnCode = INV_IB_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, ib_cable_errors);
+			if(returnCode == 1)
+			{
+				// return error
+				std::cout << "INV_IB_CONNECTOR_ACCESS failed" << std::endl;
+				return 1;
+			}
 		}
 	} 
 
@@ -484,8 +491,15 @@ int main(int argc, char *argv[])
 		} 
 		else 
 		{
+			int returnCode = 0;
 			// execute data collection for the switch cables
-			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, switch_errors);
+			returnCode = INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, switch_errors);
+			if(returnCode == 1)
+			{
+				// return error
+				std::cout << "INV_SWITCH_CONNECTOR_ACCESS failed" << std::endl;
+				return 1;
+			}
 		}
 	}
 
@@ -500,8 +514,15 @@ int main(int argc, char *argv[])
 		} 
 		else 
 		{
+			int returnCode = 0;
 			// execute data collection for the ib cables
-			INV_IB_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, ib_cable_errors);
+			returnCode = INV_IB_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, ib_cable_errors);
+			if(returnCode == 1)
+			{
+				// return error
+				std::cout << "INV_IB_CONNECTOR_ACCESS failed" << std::endl;
+				return 1;
+			}
 		}
 
 		// checking switch flag
@@ -512,8 +533,15 @@ int main(int argc, char *argv[])
 		}
 		else
 		{
+			int returnCode = 0;
 			// execute data collection for the switch cables
-			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, switch_errors);
+			returnCode = INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, switch_errors);
+			if(returnCode == 1)
+			{
+				// return error
+				std::cout << "INV_SWITCH_CONNECTOR_ACCESS failed" << std::endl;
+				return 1;
+			}
 		}
 	}
 

--- a/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
+++ b/csmd/src/inv/ib_and_switch/src/standalone_ib_and_switch_collection.cc
@@ -485,7 +485,7 @@ int main(int argc, char *argv[])
 		else 
 		{
 			// execute data collection for the switch cables
-			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir);
+			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, switch_errors);
 		}
 	}
 
@@ -513,7 +513,7 @@ int main(int argc, char *argv[])
 		else
 		{
 			// execute data collection for the switch cables
-			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir);
+			INV_SWITCH_CONNECTOR_ACCESS::GetInstance()->ExecuteDataCollection(rest_address,authentication_string_for_the_http_request, csm_inv_log_dir, switch_errors);
 		}
 	}
 


### PR DESCRIPTION
# Fixes edge case bug for UFM/CSM Inventory collection

## Purpose
Fixes edge case bug for UFM/CSM Inventory collection along with improving error debug information for a system admin. 

## Approach
- accounts for missing key values in `csm_master.cfg`
- improves the output files located in `/var/log/ibm/csm/inv`
  - now 4 files there: 
    - bad_ib_cable_records.txt  
    - bad_switch_records.txt  
    - ufm_ib_cable_output_file.txt  
    - ufm_switch_output_file.txt
- fixes issue with constructing the error path.
- switches with missing serial numbers are no longer inserted into the CSM database. 

## Origin:
- Issue: https://github.com/NickyDaB/CAST/issues/27
- @fpizzano noticed originally 

## How to Test
1. @pdlun92 talk to nick

