### PR TITLE
CSM RAS and UFM Event integration

### DIFF
--- a/csm_big_data/logstash/patterns/events.yml
+++ b/csm_big_data/logstash/patterns/events.yml
@@ -32,6 +32,12 @@ data_sources:                                  # Mandatory, Map with the keys co
        ras_msg_id: "ib.connection.%{cableEvent}"
        action:     ".send_ras;"
 
+     - tag: "UFM_GENERIC"
+       pattern:    "%{MELLANOXMSG}"
+       ras_msg_id: "test.msg.nick"
+       action:     ".send_ras;"
+
+
     mmsysmon:
      - tag: "MMSYSMON_CLEAN_MOUNT"
        pattern: "filesystem %{NOTSPACE} was (?<mountEvent>(un)?mounted)"

--- a/csm_big_data/logstash/patterns/events.yml
+++ b/csm_big_data/logstash/patterns/events.yml
@@ -32,12 +32,6 @@ data_sources:                                  # Mandatory, Map with the keys co
        ras_msg_id: "ib.connection.%{cableEvent}"
        action:     ".send_ras;"
 
-    eventlog:
-     - tag: "UFM_GENERIC"
-       pattern:    "."
-       ras_msg_id: "test.msg.nick"
-       action:     ".send_ras;"
-
     mmsysmon:
      - tag: "MMSYSMON_CLEAN_MOUNT"
        pattern: "filesystem %{NOTSPACE} was (?<mountEvent>(un)?mounted)"
@@ -48,4 +42,17 @@ data_sources:                                  # Mandatory, Map with the keys co
        pattern: "filesystem %{NOTSPACE} was.*forced.*unmount"
        ras_msg_id: "spectrumscale.fs.unmount_forced"
        action: ".send_ras;"
+ log-mellanox-event:
+  ras_location:  "hostname"
+  ras_timestamp: "timestamp"
+  event_data:    "message" 
+  category_key:  "program_name" 
+  categories:
+   eventlog:
+     - tag:        "UFM_GENERIC"
+       pattern:    "."
+       ras_msg_id: "ufm.%{event_type}.%{event_id}"
+       action:     ".send_ras;" 
+
+
 ...

--- a/csm_big_data/logstash/patterns/events.yml
+++ b/csm_big_data/logstash/patterns/events.yml
@@ -32,11 +32,11 @@ data_sources:                                  # Mandatory, Map with the keys co
        ras_msg_id: "ib.connection.%{cableEvent}"
        action:     ".send_ras;"
 
+    eventlog:
      - tag: "UFM_GENERIC"
-       pattern:    "%{MELLANOXMSG}"
+       pattern:    "."
        ras_msg_id: "test.msg.nick"
        action:     ".send_ras;"
-
 
     mmsysmon:
      - tag: "MMSYSMON_CLEAN_MOUNT"


### PR DESCRIPTION
# CSM RAS and UFM Event integration

## Purpose
Dev goal of: creating CSM RAS events from ufm events.

## Origin

issue: https://github.com/NickyDaB/CAST/issues/16

## Approach
1. ufm event logs are sent to the logstash node as a `log-mellanox-event` event
2. the logstash parses through incoming events and looks for the `eventlog` program
3. that triggers the `MELLANOXMSG` pattern
4. that parses the message and extracts the values
5. from those values we use event correlator and construct a CSM RAS event
6. ras event is generated and stored on the csmdb connected to the logstash node.

## How to Test
There is an event triggering in ufm every five minutes. You can look for that in the csmdb. 

Example: 
ufm logs:
```
Nov 27 16:23:09 c650ufm03 eventlog[182483]: CRITICAL - 2018-11-27 16:23:09.423 [665916] [627] CRITICAL [Maintenance] Grid [Grid]: Monitoring History partition /opt/ufm/history is not mounted
Nov 27 16:28:09 c650ufm03 eventlog[182483]: CRITICAL - 2018-11-27 16:28:09.426 [665933] [627] CRITICAL [Maintenance] Grid [Grid]: Monitoring History partition /opt/ufm/history is not mounted

```

Or you can go pull a fan from a switch in the lab to trigger an event, and see it show up in the database.

## Screenshots
some examples of ras events in the database created via the ufm/ras integration. 


```
csmdb=# SELECT * FROM csm_ras_event_action;
 rec_id |        msg_id         | msg_id_seq |         time_stamp         |     master_time_stamp      | location_name | count |                     message                     | kvcsv |                                                                                                 raw_data                                                                                                | archive_history_time 
--------+-----------------------+------------+----------------------------+----------------------------+---------------+-------+-------------------------------------------------+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------
     56 | ufm.Maintenance.627   |        726 | 2018-11-27 15:52:05.659    | 2018-11-27 15:52:44.26032  | c650ufm03     |     1 | Monitoring History partition is not mounted     |       | [Grid]: Monitoring History partition /opt/ufm/history is not mounted                                                                                                                                     | 
     57 | ufm.Maintenance.627   |        726 | 2018-11-27 15:57:30.576    | 2018-11-27 15:58:09.186567 | c650ufm03     |     1 | Monitoring History partition is not mounted     |       | [Grid]: Monitoring History partition /opt/ufm/history is not mounted                                                                                                                                     | 
     58 | ufm.Maintenance.627   |        726 | 2018-11-27 16:02:30.58     | 2018-11-27 16:03:09.199727 | c650ufm03     |     1 | Monitoring History partition is not mounted     |       | [Grid]: Monitoring History partition /opt/ufm/history is not mounted                                                                                                                                     | 
(58 rows)
```