### PR TITLE
CSM RAS: fixed memory leak by removing completed event contexts from _contextMap

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
@@ -685,17 +685,22 @@ void CSMIRasEventCreate::Process( const csm::daemon::CoreEvent &aEvent,
                     else if (suppressed)
                     {
                         LOG(csmras, info) << "RAS EVENT SUPPRESSED " << rctx->_rasEvent->getLogString() << " state:" << node_state; 
+                        _contextMap.erase(ctx->GetAuxiliaryId());    // Finished processing this event, remove the rctx context
                     }
                     else
                     {
                         LOG(csmras, info) << "RAS EVENT DISABLED   " << rctx->_rasEvent->getLogString(); 
+                        _contextMap.erase(ctx->GetAuxiliaryId());    // Finished processing this event, remove the rctx context
                     }
                 }
 
                 if (rasRc._rc != CSMI_SUCCESS) {
                     csm::daemon::NetworkEvent *ev = (csm::daemon::NetworkEvent *)reqEvent;
                     csm::network::MessageAndAddress c = ev->GetContent();
+                    
                     LOG(csmras, error) << "RAS EVENT ERROR      " << rctx->_rasEvent->getLogString() << " errstr:" << rasRc._errstr; 
+                    _contextMap.erase(ctx->GetAuxiliaryId());    // Finished processing this event, remove the rctx context
+                    
                     if (! c._Msg.GetInt() )
                         returnErrorMsg(c.GetAddr(), c._Msg, rasRc._rc, rasRc._errstr, postEventList);
 
@@ -734,15 +739,14 @@ void CSMIRasEventCreate::Process( const csm::daemon::CoreEvent &aEvent,
             {
                 LOG(csmras, debug) << "RAS EVENT DB WR RESP " << rctx->_rasEvent->getLogString(); 
                 LOG(csmras, info) << "RAS EVENT COMPLETE   " << rctx->_rasEvent->getLogString(); 
+                _contextMap.erase(ctx->GetAuxiliaryId());    // Finished processing this event, remove the rctx context
             }
             else 
             {
-                LOG(csmras, warning) << "RAS EVENT unexpected branch taken, rctx->_state=" << rctx->_state; 
-
                 // TODO: detect and log db errors here...
-                // remove the rtx reference...
-                _contextMap.erase(ctx->GetAuxiliaryId());
-
+                
+                LOG(csmras, warning) << "RAS EVENT unexpected branch taken, rctx->_state=" << rctx->_state; 
+                _contextMap.erase(ctx->GetAuxiliaryId());    // Finished processing this event, remove the rctx context
             }
         }
     }


### PR DESCRIPTION
### Summary ###
This pull request contains the fix for issue #417.

The symptom of this issue is steadily increasing memory usage of the csmd master daemon over time as RAS events are created. The problem was first noticed due to large numbers of "bb.net.SSLconnectAttemptFailed" being created on a large system running CAST v1.3.0 versions of CSM and burstbuffer.

### Root cause ###
The CSM RAS Event Create handler involves multiple steps for handling each event. In order to maintain state about these events as they are processed, event context is stored for each event. The issue was caused by failing to remove this event context information after event processing is complete.

### Fix ###
Remove the event context information after processing is complete for each RAS event.

### Test ###
I have a test case available here:
/u/besawn/bash/csm_ras_memory_test.sh

This test exercises four different exit paths from the CSM RAS Event Create handler: normal good path, error path due to invalid msg_id, disabled event path due to policy setting, and suppressed event path due to the location of the event being in the OUT_OF_SERVICE state. The test case checks the csmd master daemon memory usage (RSS) before and after each batch of RAS events. The test also waits for ~5 minutes between each batch of RAS events to observe whether the RSS changes during the idle period. The test creates 10000 of each type of event above.

### Test results ###

For the test results below, I started the csmd master daemon, then ran the test case above twice. This shows the growth of the csmd master daemon memory usage over time as 80000 RAS events are created, comparing the behavior with and without the fix contained in this pull request. 
Note: for each row in the table, the event was repeated 10000 times before moving to the next row.

|                                | csmd master RSS with fix | csmd master RSS without fix |
|--------------------------|---------------------------------:|-------------------------------------:|
| Starting RSS           | 32768 | 33088 |
| Standard Event       | 35840 | 85568 |
| Invalid Message Id  | 36416 | 107648 |
| Disabled Event        | 36800 | 150208 |
| Suppressed Event   | 36736 | 193856 |
| Standard Event       | 36544 | 245440 |
| Invalid Message Id  | 36672| 267008 |
| Disabled Event        | 37504| 309120 |
| Suppressed Event   | 37504 | 350912 |

With the fix, RSS grows ~14% during the test.
Without the fix, RSS grows ~960% during the test.