### PR TITLE
Fixing a bug in allocation delete in error reporting

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationDelete.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationDelete.cc
@@ -385,7 +385,7 @@ csm::db::DBReqContent* CSMIAllocationDelete_Master::DeleteRowStatement(
     }
     
 
-    if (allocation && allocation->primary_job_id > 0)
+    if (allocation && allocation->primary_job_id > 0 && !ctx->GetDBErrorCode() )
     {
         const int paramCount = 13;
         std::string stmt = "SELECT fn_csm_allocation_history_dump( "

--- a/csmdb/sql/csm_create_triggers.sql
+++ b/csmdb/sql/csm_create_triggers.sql
@@ -482,6 +482,8 @@ RETURNS timestamp AS $$
 DECLARE 
    a "csm_allocation"%ROWTYPE;
    s "csm_step"%ROWTYPE;
+   INVALID_STATE       CONSTANT integer := 1;
+   INVALID_ALLOCATION  CONSTANT integer := 2;
 
 BEGIN
     o_end_time = endtime;
@@ -584,7 +586,8 @@ BEGIN
         DELETE FROM csm_allocation WHERE allocation_id=allocationid;
 
     ELSE
-        RAISE EXCEPTION using message = 'allocation_id does not exist.';
+        RAISE EXCEPTION 'allocation_id does not exist.'
+            USING HINT = INVALID_ALLOCATION;
     END IF;
     --EXCEPTION
     --    WHEN others THEN


### PR DESCRIPTION
Error reporting was always being reported as CSMERR_DB for the primary jobid path. This should be fixed now.