### PR TITLE
Csm api logging tools

### DIFF
--- a/csmutil/csm_log_utility/API_Statistics.py
+++ b/csmutil/csm_log_utility/API_Statistics.py
@@ -49,9 +49,9 @@ else:
 # python api_statistics.py <Start Date> <Start Time> <End Date> <End Time>  - looks from Start Date/Time to End Date/Time
 
 if(args.start_arg):
-    start_datetime = datetime.strptime(start_arg, '%Y-%m-%d %H:%M:%S.%f')
+    start_datetime = datetime.strptime(args.start_arg, '%Y-%m-%d %H:%M:%S.%f')
 if(args.end_arg):
-    end_datetime = datetime.strptime(range_arg, '%Y-%m-%d %H:%M:%S.%f')
+    end_datetime = datetime.strptime(args.end_arg, '%Y-%m-%d %H:%M:%S.%f')
 
 
 # if len(sys.argv) == 1:

--- a/csmutil/csm_log_utility/API_Statistics.py
+++ b/csmutil/csm_log_utility/API_Statistics.py
@@ -106,7 +106,7 @@ def handle_file(filename):
         start = time.time()
         # pass
         print 'Utility: ' + filename
-        compute_CSM_Utility_stats(filename,start_datetime,end_datetime)
+        compute_CSM_Utility_stats(filename,start_datetime,end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
 
 

--- a/csmutil/csm_log_utility/API_Statistics.py
+++ b/csmutil/csm_log_utility/API_Statistics.py
@@ -29,11 +29,11 @@ logs_path = ""
 parser = argparse.ArgumentParser(
     description='''A tool for parsing daemon logs for API statistics.''')
 parser.add_argument( '-p', metavar='path', dest='directory_path', default=None,
-    help='The directory path to where the logs are located.')
+    help='The directory path to where the logs are located. Defaults to: \'/var/log/ibm/csm\'')
 parser.add_argument( '-s', metavar='start', dest='start_arg', default=None,
-    help='looks from Start Date/Time to end of log file.')
+    help='start of search range. Defaults to: \'1000-01-01 00:00:00.0000\'')
 parser.add_argument( '-e', metavar='end', dest='end_arg', default=None,
-    help='looks from Start Date/Time to End Date/Time.')
+    help='end of search range. Defaults to: \'9999-01-01 00:00:00.0000\'')
 args = parser.parse_args()
 
 #Default log location for CSM logs, unless a user supplies a path

--- a/csmutil/csm_log_utility/API_Statistics.py
+++ b/csmutil/csm_log_utility/API_Statistics.py
@@ -88,24 +88,19 @@ sys.path.insert(0, logs_path)
 
 def handle_file(filename):
     if "compute" in filename and ".log" in filename:
-        print 'Compute: ' + filename
         start = time.time()
         compute_CSM_Compute_stats(filename,start_datetime,end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
     elif "aggregator" in filename and ".log" in filename:
-        print 'Aggregate: ' + filename
         start = time.time()
         compute_CSM_Aggregator_stats(filename,start_datetime, end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
     elif "master" in filename and ".log" in filename:
-        print 'Master: ' + filename
         start = time.time()
         compute_CSM_Master_stats(filename,start_datetime,end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
     elif "utility" in filename and ".log" in filename:
         start = time.time()
-        # pass
-        print 'Utility: ' + filename
         compute_CSM_Utility_stats(filename,start_datetime,end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
 

--- a/csmutil/csm_log_utility/API_Statistics.py
+++ b/csmutil/csm_log_utility/API_Statistics.py
@@ -22,6 +22,9 @@ from Utility_Stat import compute_CSM_Utility_stats
 time_format = '%Y-%m-%d %H:%M:%S.%f'
 start_datetime = datetime.strptime('1000-01-01' + ' ' + '00:00:00.0000', time_format)
 end_datetime   = datetime.strptime('9999-01-01' + ' ' + '00:00:00.0000', time_format)
+# How to order the output.
+order_by = 0;
+reverse_order = False;
 
 
 logs_path = ""
@@ -34,6 +37,10 @@ parser.add_argument( '-s', metavar='start', dest='start_arg', default=None,
     help='start of search range. Defaults to: \'1000-01-01 00:00:00.0000\'')
 parser.add_argument( '-e', metavar='end', dest='end_arg', default=None,
     help='end of search range. Defaults to: \'9999-01-01 00:00:00.0000\'')
+parser.add_argument( '-o', metavar='order', dest='order_arg', default=0,
+    help='order the results by a field. Defaults to alphabetical by API name. Valid values: 0 = alphabetical, 1 = Frequency, 2 = Mean, 3 = Max, 4 = Min, 5 = Std')
+parser.add_argument( '-r', metavar='reverse', dest='reverse_arg', default=0,
+    help='reverse the order of the data. Defaults to 0. Set to 1 to turn on.')
 args = parser.parse_args()
 
 #Default log location for CSM logs, unless a user supplies a path
@@ -52,6 +59,12 @@ if(args.start_arg):
     start_datetime = datetime.strptime(args.start_arg, '%Y-%m-%d %H:%M:%S.%f')
 if(args.end_arg):
     end_datetime = datetime.strptime(args.end_arg, '%Y-%m-%d %H:%M:%S.%f')
+if(args.order_arg):
+    order_by = int(args.order_arg)
+    if(order_by > 5 or order_by < 0):
+        order_by = 0
+if(int(args.reverse_arg) == 1):
+    reverse_order = True
 
 
 # if len(sys.argv) == 1:
@@ -87,7 +100,7 @@ def handle_file(filename):
     elif "master" in filename and ".log" in filename:
         print 'Master: ' + filename
         start = time.time()
-        compute_CSM_Master_stats(filename,start_datetime,end_datetime)
+        compute_CSM_Master_stats(filename,start_datetime,end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
     elif "utility" in filename and ".log" in filename:
         start = time.time()

--- a/csmutil/csm_log_utility/API_Statistics.py
+++ b/csmutil/csm_log_utility/API_Statistics.py
@@ -90,12 +90,12 @@ def handle_file(filename):
     if "compute" in filename and ".log" in filename:
         print 'Compute: ' + filename
         start = time.time()
-        compute_CSM_Compute_stats(filename,start_datetime,end_datetime)
+        compute_CSM_Compute_stats(filename,start_datetime,end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
     elif "aggregator" in filename and ".log" in filename:
         print 'Aggregate: ' + filename
         start = time.time()
-        compute_CSM_Aggregator_stats(filename,start_datetime, end_datetime)
+        compute_CSM_Aggregator_stats(filename,start_datetime, end_datetime, order_by, reverse_order)
         print 'Run Time: ' + str(time.time() - start) + '\n'
     elif "master" in filename and ".log" in filename:
         print 'Master: ' + filename

--- a/csmutil/csm_log_utility/Helper_Files/Aggregator_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Aggregator_Stat.py
@@ -19,7 +19,7 @@ time_format = '%Y-%m-%d %H:%M:%S.%f'
 print_padding = 115
 total_errors = 0
 
-def compute_CSM_Aggregator_stats(filename, start_datetime, end_datetime):
+def compute_CSM_Aggregator_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
     opened_file = Pre_Process(filename) #open(filename, 'r')                   
     dictionary = dict()                 # Dictionary key uses Api operation ID
     Api_Statistics = dict()             # Api_Statistics key uses Api name
@@ -45,7 +45,7 @@ def compute_CSM_Aggregator_stats(filename, start_datetime, end_datetime):
                     Api_Statistics['responses'].append(responses)
             else:
                 break
-    end_stats = calculate_statistics(filename, Api_Statistics)
+    end_stats = calculate_statistics(filename, Api_Statistics, order_by, reverse_order)
     report_file.write(end_stats)
     report_file.close()
 
@@ -60,7 +60,7 @@ def collision_error(Api_Id, start_api, end_api):
     global total_errors 
     total_errors += 1
 
-def calculate_statistics(filename, Api_Statistics):
+def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
     print ("Aggregator Log").center(print_padding, '+')
     print filename.center(print_padding, '-')
     file_opened = open(filename, 'r')
@@ -70,22 +70,31 @@ def calculate_statistics(filename, Api_Statistics):
     file_time = ("File Start: {0} and File End: {1}".format(file_start, file_end)).center(print_padding, '-')
     print '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std")
     total_calls = 0
+
+    # Dictionary to hold all apis after calculating full stats.
+    dic_API_Stats = {}
+
     stats = ("Aggregator Log").center(print_padding, '+') + '\n' + filename.center(print_padding, '-') +'\n' + file_time + '\n' + '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std") + '\n'
     if not Api_Statistics['responses']:
         pass
     else:
         for key in Api_Statistics.keys():
-            stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(
-                key, 
-                len(Api_Statistics[key]),
-                np.mean(Api_Statistics[key]),
-                np.median(Api_Statistics[key]),
-                min(Api_Statistics[key]),
-                max(Api_Statistics[key]),
-                np.std(Api_Statistics[key]))
+            #apis with stats
+            dic_API_Stats[key] = [key]
+            dic_API_Stats[key].append(len(Api_Statistics[key]))
+            dic_API_Stats[key].append(np.mean(Api_Statistics[key]))
+            dic_API_Stats[key].append(np.median(Api_Statistics[key]))
+            dic_API_Stats[key].append(min(Api_Statistics[key]))
+            dic_API_Stats[key].append(max(Api_Statistics[key]))
+            dic_API_Stats[key].append(np.std(Api_Statistics[key]))
+
             total_calls = total_calls + len(Api_Statistics[key])
+
+        for key, value in sorted(dic_API_Stats.iteritems(), key=lambda (k,v): (v[order_by],k), reverse = reverse_order):
+            stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(value[0], value[1], value[2], value [3], value [4], value [5], value[6])
             print stat_line
             stats = stats + '\n' + stat_line
+            
     print "Total Calls:  " + str(total_calls)
     print "Total Errors: " + str(total_errors) + '\n'  
     return stats + '\n' + "Total Calls:  " + str(total_calls) + '\n' + "Total Errors: " + str(total_errors) + '\n' 

--- a/csmutil/csm_log_utility/Helper_Files/Aggregator_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Aggregator_Stat.py
@@ -20,11 +20,12 @@ print_padding = 115
 total_errors = 0
 
 def compute_CSM_Aggregator_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
+    print 'Aggregate: ' + filename
     opened_file = Pre_Process(filename) #open(filename, 'r')                   
     dictionary = dict()                 # Dictionary key uses Api operation ID
     Api_Statistics = dict()             # Api_Statistics key uses Api name
     Api_Statistics['responses'] = []
-    report_file_path = './Reports/Aggregator_Reports/Report_'+ filename[18:] +'.txt'
+    report_file_path = './Reports/Aggregator_Reports/'+ filename +'.txt'
     if not os.path.exists(os.path.dirname(report_file_path)):
         try:
             os.makedirs(os.path.dirname(report_file_path))
@@ -94,7 +95,7 @@ def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
             stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(value[0], value[1], value[2], value [3], value [4], value [5], value[6])
             print stat_line
             stats = stats + '\n' + stat_line
-            
+
     print "Total Calls:  " + str(total_calls)
     print "Total Errors: " + str(total_errors) + '\n'  
     return stats + '\n' + "Total Calls:  " + str(total_calls) + '\n' + "Total Errors: " + str(total_errors) + '\n' 

--- a/csmutil/csm_log_utility/Helper_Files/Compute_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Compute_Stat.py
@@ -20,7 +20,7 @@ time_format = '%Y-%m-%d %H:%M:%S.%f'
 print_padding = 115
 total_errors = 0
 
-def compute_CSM_Compute_stats(filename, start_datetime, end_datetime):
+def compute_CSM_Compute_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
     opened_file = Pre_Process(filename) #open((filename), 'r')                   
     dictionary = dict()                 # Dictionary key uses Api operation ID
     Api_Statistics = dict()             # Api_Statistics key uses Api name
@@ -76,7 +76,7 @@ def compute_CSM_Compute_stats(filename, start_datetime, end_datetime):
                                 Api_Statistics[end_line[5]] = [run_time]
             else:
                 break
-    end_stats = calculate_statistics(filename, Api_Statistics)
+    end_stats = calculate_statistics(filename, Api_Statistics, order_by, reverse_order)
     report_file.write(end_stats)
     report_file.close()
 
@@ -90,7 +90,7 @@ def collision_error(Api_Id, start_api, end_api):
     total_errors += 1
     return error
 
-def calculate_statistics(filename, Api_Statistics):
+def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
     print ("Compute Log").center(print_padding, '+')
     print filename.center(print_padding, '-')
     file_opened = open(filename, 'r')
@@ -102,19 +102,28 @@ def calculate_statistics(filename, Api_Statistics):
     print '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std")
     # print Api_Statistics.keys()
     total_calls = 0
+
+    # Dictionary to hold all apis after calculating full stats.
+    dic_API_Stats = {}
+
     stats = ("Compute Log").center(print_padding, '+') + '\n' + filename.center(print_padding, '-') + '\n' + file_time  + '\n' + '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std") + '\n'
     for key in Api_Statistics.keys():
-        stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(
-            key, 
-            len(Api_Statistics[key]),
-            np.mean(Api_Statistics[key]),
-            np.median(Api_Statistics[key]),
-            min(Api_Statistics[key]),
-            max(Api_Statistics[key]),
-            np.std(Api_Statistics[key]))
+        #apis with stats
+        dic_API_Stats[key] = [key]
+        dic_API_Stats[key].append(len(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.mean(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.median(Api_Statistics[key]))
+        dic_API_Stats[key].append(min(Api_Statistics[key]))
+        dic_API_Stats[key].append(max(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.std(Api_Statistics[key]))
+
         total_calls = total_calls + len(Api_Statistics[key])
+
+     for key, value in sorted(dic_API_Stats.iteritems(), key=lambda (k,v): (v[order_by],k), reverse = reverse_order):
+        stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(value[0], value[1], value[2], value [3], value [4], value [5], value[6])
         print stat_line
         stats = stats + '\n' + stat_line
+
     print "Total Calls:  " + str(total_calls)
     print "Total Errors: " + str(total_errors) + '\n'  
     return stats + '\n' + "Total Calls:  " + str(total_calls) + '\n' + "Total Errors: " + str(total_errors) + '\n' 

--- a/csmutil/csm_log_utility/Helper_Files/Compute_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Compute_Stat.py
@@ -21,10 +21,11 @@ print_padding = 115
 total_errors = 0
 
 def compute_CSM_Compute_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
+    print 'Compute: ' + filename
     opened_file = Pre_Process(filename) #open((filename), 'r')                   
     dictionary = dict()                 # Dictionary key uses Api operation ID
     Api_Statistics = dict()             # Api_Statistics key uses Api name
-    report_file_path = './Reports/Compute_Reports/Report_'+ filename[15:] +'.txt'
+    report_file_path = './Reports/Compute_Reports/'+ filename +'.txt'
     if not os.path.exists(os.path.dirname(report_file_path)):
         try:
             os.makedirs(os.path.dirname(report_file_path))

--- a/csmutil/csm_log_utility/Helper_Files/Compute_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Compute_Stat.py
@@ -119,7 +119,7 @@ def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
 
         total_calls = total_calls + len(Api_Statistics[key])
 
-     for key, value in sorted(dic_API_Stats.iteritems(), key=lambda (k,v): (v[order_by],k), reverse = reverse_order):
+    for key, value in sorted(dic_API_Stats.iteritems(), key=lambda (k,v): (v[order_by],k), reverse = reverse_order):
         stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(value[0], value[1], value[2], value [3], value [4], value [5], value[6])
         print stat_line
         stats = stats + '\n' + stat_line

--- a/csmutil/csm_log_utility/Helper_Files/Master_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Master_Stat.py
@@ -117,7 +117,7 @@ def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
     
     total_calls = 0
 
-    # Dictionary to hold all apis with full stats.
+    # Dictionary to hold all apis after calculating full stats.
     dic_API_Stats = {}
 
     stats = ("Master Log").center(print_padding, '+') + '\n' + filename.center(print_padding, '-') + '\n' + file_time +'\n' + '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std") + '\n'

--- a/csmutil/csm_log_utility/Helper_Files/Master_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Master_Stat.py
@@ -24,10 +24,11 @@ total_errors = 0
 
 
 def compute_CSM_Master_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
+    print 'Master: ' + filename
     opened_file = Pre_Process(filename) #open(filename, 'r') 
     dictionary = dict()         # Dictionary key uses Api operation ID
     Api_Statistics = dict()     # Api_Statistics key uses Api name
-    report_file_path = './Reports/Master_Reports/Report_'+ filename[14:] +'.txt'
+    report_file_path = './Reports/Master_Reports/'+ filename +'.txt'
     if not os.path.exists(os.path.dirname(report_file_path)):
         try:
             os.makedirs(os.path.dirname(report_file_path))
@@ -113,6 +114,7 @@ def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
     file_start = file_lines[0].split("csm")[0].strip()
     file_end   = file_lines[-1].split("csm")[0].strip()
     file_time = ("File Start: {0} and File End: {1}".format(file_start, file_end)).center(print_padding, '-')
+    print(file_time)
     print '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std")
     
     total_calls = 0

--- a/csmutil/csm_log_utility/Helper_Files/Master_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Master_Stat.py
@@ -23,7 +23,7 @@ total_errors = 0
 
 
 
-def compute_CSM_Master_stats(filename, start_datetime, end_datetime):
+def compute_CSM_Master_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
     opened_file = Pre_Process(filename) #open(filename, 'r') 
     dictionary = dict()         # Dictionary key uses Api operation ID
     Api_Statistics = dict()     # Api_Statistics key uses Api name
@@ -85,7 +85,7 @@ def compute_CSM_Master_stats(filename, start_datetime, end_datetime):
                                 Api_Statistics[end_line[5]] = [run_time]
             else:
                 break
-    end_stats = calculate_statistics(filename, Api_Statistics)
+    end_stats = calculate_statistics(filename, Api_Statistics, order_by, reverse_order)
     report_file.write(end_stats)
     report_file.close()
 
@@ -105,7 +105,7 @@ def collision_error(Api_Id, start_api, end_api):
     total_errors += 1
     return error
 
-def calculate_statistics(filename, Api_Statistics):
+def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
     print ("Master Log").center(print_padding, '+')
     print filename.center(print_padding, '-')
     file_opened = open(filename, 'r')
@@ -114,21 +114,30 @@ def calculate_statistics(filename, Api_Statistics):
     file_end   = file_lines[-1].split("csm")[0].strip()
     file_time = ("File Start: {0} and File End: {1}".format(file_start, file_end)).center(print_padding, '-')
     print '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std")
-    # print Api_Statistics.keys()
+    
     total_calls = 0
+
+    # Dictionary to hold all apis with full stats.
+    dic_API_Stats = {}
+
     stats = ("Master Log").center(print_padding, '+') + '\n' + filename.center(print_padding, '-') + '\n' + file_time +'\n' + '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std") + '\n'
     for key in Api_Statistics.keys():
-        stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(
-            key, 
-            len(Api_Statistics[key]),
-            np.mean(Api_Statistics[key]),
-            np.median(Api_Statistics[key]),
-            min(Api_Statistics[key]),
-            max(Api_Statistics[key]),
-            np.std(Api_Statistics[key]))
+        #apis with stats
+        dic_API_Stats[key] = [key]
+        dic_API_Stats[key].append(len(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.mean(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.median(Api_Statistics[key]))
+        dic_API_Stats[key].append(min(Api_Statistics[key]))
+        dic_API_Stats[key].append(max(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.std(Api_Statistics[key]))
+
         total_calls = total_calls + len(Api_Statistics[key])
+    
+    for key, value in sorted(dic_API_Stats.iteritems(), key=lambda (k,v): (v[order_by],k), reverse = reverse_order):
+        stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(value[0], value[1], value[2], value [3], value [4], value [5], value[6])
         print stat_line
         stats = stats + '\n' + stat_line
+
     print "Total Calls:  " + str(total_calls)
     print "Total Errors: " + str(total_errors) + '\n'  
     return stats + '\n' + "Total Calls:  " + str(total_calls) + '\n' + "Total Errors: " + str(total_errors) + '\n' 

--- a/csmutil/csm_log_utility/Helper_Files/Utility_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Utility_Stat.py
@@ -20,10 +20,11 @@ print_padding = 115
 total_errors = 0
 
 def compute_CSM_Utility_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
+    print 'Utility: ' + filename
     opened_file = Pre_Process(filename) #open(filename, 'r')                   
     dictionary = dict()                 # Dictionary key uses Api operation ID
     Api_Statistics = dict()             # Api_Statistics key uses Api name
-    report_file_path = './Reports/Utility_Reports/Report_'+ filename[15:] +'.txt'
+    report_file_path = './Reports/Utility_Reports/'+ filename +'.txt'
     if not os.path.exists(os.path.dirname(report_file_path)):
         try:
             os.makedirs(os.path.dirname(report_file_path))

--- a/csmutil/csm_log_utility/Helper_Files/Utility_Stat.py
+++ b/csmutil/csm_log_utility/Helper_Files/Utility_Stat.py
@@ -19,7 +19,7 @@ time_format = '%Y-%m-%d %H:%M:%S.%f'
 print_padding = 115
 total_errors = 0
 
-def compute_CSM_Utility_stats(filename, start_datetime, end_datetime):
+def compute_CSM_Utility_stats(filename, start_datetime, end_datetime, order_by, reverse_order):
     opened_file = Pre_Process(filename) #open(filename, 'r')                   
     dictionary = dict()                 # Dictionary key uses Api operation ID
     Api_Statistics = dict()             # Api_Statistics key uses Api name
@@ -59,7 +59,7 @@ def compute_CSM_Utility_stats(filename, start_datetime, end_datetime):
                                 Api_Statistics[start_api] = [run_time]
             else:
                 break
-    end_stats = calculate_statistics(filename, Api_Statistics)
+    end_stats = calculate_statistics(filename, Api_Statistics, order_by, reverse_order)
     report_file.write(end_stats)
     report_file.close()
 
@@ -73,7 +73,7 @@ def collision_error(Api_Id, start_api, end_api):
     total_errors += 1
     return error
 
-def calculate_statistics(filename, Api_Statistics):
+def calculate_statistics(filename, Api_Statistics, order_by, reverse_order):
     print ("Utility Log").center(print_padding, '+')
     print filename.center(print_padding, '-')
     file_opened = open(filename, 'r')
@@ -83,23 +83,33 @@ def calculate_statistics(filename, Api_Statistics):
     file_time = ("File Start: {0} and File End: {1}".format(file_start, file_end)).center(print_padding, '-')
     print(file_time)
     print '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std")
-    # print Api_Statistics.keys()
+    
     total_calls = 0
+
+    # Dictionary to hold all apis after calculating full stats.
+    dic_API_Stats = {}
+
     stats = ("Utility Log").center(print_padding, '+') + '\n' + filename.center(print_padding, '-') + '\n' + file_time +'\n' + '{:50s} {:10s}  {:8s}  {:8s}  {:8s}  {:8s}  {:8s}'.format('Api Function', "Frequency", "Mean", "Median", "Min", "Max", "Std") + '\n'
     for key in Api_Statistics.keys():
-        stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(
-            key, 
-            len(Api_Statistics[key]),
-            np.mean(Api_Statistics[key]),
-            np.median(Api_Statistics[key]),
-            min(Api_Statistics[key]),
-            max(Api_Statistics[key]),
-            np.std(Api_Statistics[key]))
+        #apis with stats
+        dic_API_Stats[key] = [key]
+        dic_API_Stats[key].append(len(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.mean(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.median(Api_Statistics[key]))
+        dic_API_Stats[key].append(min(Api_Statistics[key]))
+        dic_API_Stats[key].append(max(Api_Statistics[key]))
+        dic_API_Stats[key].append(np.std(Api_Statistics[key]))
+
         total_calls = total_calls + len(Api_Statistics[key])
+
+    for key, value in sorted(dic_API_Stats.iteritems(), key=lambda (k,v): (v[order_by],k), reverse = reverse_order):
+        stat_line = '{:50s} {:10d}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}  {:3.6f}'.format(value[0], value[1], value[2], value [3], value [4], value [5], value[6])
         print stat_line
         stats = stats + '\n' + stat_line
+        
     print "Total Calls:  " + str(total_calls)
     print "Total Errors: " + str(total_errors) + '\n'  
+
     return stats + '\n' + "Total Calls:  " + str(total_calls) + '\n' + "Total Errors: " + str(total_errors) + '\n' 
 
 def Pre_Process(filename):


### PR DESCRIPTION
# upgrades to CSM API logging tools

## Purpose
- fix time search span issue
- new options to order and filter results

## Known issue
- multi threading causes out of order prints in the terminal window
- not that big of an issue because we also write data to individual report files for each log.
- by doing that you can view each piece of data nice and pretty
- these can be found in the report directory 

## to test
- run with `-h` to see all the options
- test all the options, see if get expected results

## Screenshots

default:

```
[root@c650f03p41 tools]# python API_Statistics.py -p /u/nbuonar/csm_test_logs/
Search from:  1000-01-01 00:00:00 to 9999-01-01 00:00:00
['/u/nbuonar/csm_test_logs//csm_master.log']
Master: /u/nbuonar/csm_test_logs//csm_master.log
+++++++++++++++++++++++++++++++++++++++++++++++++++++Master Log++++++++++++++++++++++++++++++++++++++++++++++++++++
--------------------------------------/u/nbuonar/csm_test_logs//csm_master.log-------------------------------------
Api Function                                       Frequency   Mean      Median    Min       Max       Std     
csm_allocation_create                                   31356  3.676569  1.075274  0.046917  368.997716  10.889477
csm_allocation_delete                                   30517  20.975742  26.667443  0.000569  606.577267  20.905661
csm_allocation_query                                   753760  0.189049  0.052771  0.000192  34.967717  1.371676
csm_allocation_query_active_all                         55159  0.013027  0.012512  0.000593  5.473623  0.024489
csm_allocation_query_details                            30429  5.559708  5.181977  0.000299  38.138260  1.554801
csm_allocation_step_begin                               71119  0.013446  0.005687  0.000693  2.898997  0.037653
csm_allocation_step_end                                 70586  0.008485  0.004428  0.001349  2.072873  0.020801
csm_allocation_step_query                                  53  0.020747  0.003277  0.001616  0.448491  0.066675
csm_bb_vg_create                                           30  0.017211  0.016855  0.011011  0.023667  0.003034
csm_jsrun_cmd                                              26  0.334397  0.193788  0.008559  1.105818  0.349893
csm_node_attributes_query                             1416204  0.000772  0.000646  0.000398  7.157922  0.007590
csm_node_attributes_query_history                           2  0.026112  0.026112  0.005603  0.046622  0.020509
csm_node_attributes_update                              32321  0.030945  0.001870  0.000848  1.284394  0.125259
csm_node_query_state_history                             1094  0.007135  0.005073  0.002749  0.481446  0.020326
csm_node_resources_query_all                            35346  0.239251  0.224177  0.186501  10.551058  0.076131
csm_ras_event_query                                        10  0.092842  0.073729  0.002362  0.270096  0.089136
csm_ras_msg_type_query                                      5  0.006571  0.003427  0.001025  0.023056  0.008315
Total Calls:  2528017
Total Errors: 96

Run Time: 240.581523895
```

with sort on frequency and reversed:
```
[root@c650f03p41 tools]# 
[root@c650f03p41 tools]# 
[root@c650f03p41 tools]# python API_Statistics.py -p /u/nbuonar/csm_test_logs/ -o 1 -r 1
Search from:  1000-01-01 00:00:00 to 9999-01-01 00:00:00
['/u/nbuonar/csm_test_logs//csm_master.log']
Master: /u/nbuonar/csm_test_logs//csm_master.log
+++++++++++++++++++++++++++++++++++++++++++++++++++++Master Log++++++++++++++++++++++++++++++++++++++++++++++++++++
--------------------------------------/u/nbuonar/csm_test_logs//csm_master.log-------------------------------------
Api Function                                       Frequency   Mean      Median    Min       Max       Std     
csm_node_attributes_query                             1416204  0.000772  0.000646  0.000398  7.157922  0.007590
csm_allocation_query                                   753760  0.189049  0.052771  0.000192  34.967717  1.371676
csm_allocation_step_begin                               71119  0.013446  0.005687  0.000693  2.898997  0.037653
csm_allocation_step_end                                 70586  0.008485  0.004428  0.001349  2.072873  0.020801
csm_allocation_query_active_all                         55159  0.013027  0.012512  0.000593  5.473623  0.024489
csm_node_resources_query_all                            35346  0.239251  0.224177  0.186501  10.551058  0.076131
csm_node_attributes_update                              32321  0.030945  0.001870  0.000848  1.284394  0.125259
csm_allocation_create                                   31356  3.676569  1.075274  0.046917  368.997716  10.889477
csm_allocation_delete                                   30517  20.975742  26.667443  0.000569  606.577267  20.905661
csm_allocation_query_details                            30429  5.559708  5.181977  0.000299  38.138260  1.554801
csm_node_query_state_history                             1094  0.007135  0.005073  0.002749  0.481446  0.020326
csm_allocation_step_query                                  53  0.020747  0.003277  0.001616  0.448491  0.066675
csm_bb_vg_create                                           30  0.017211  0.016855  0.011011  0.023667  0.003034
csm_jsrun_cmd                                              26  0.334397  0.193788  0.008559  1.105818  0.349893
csm_ras_event_query                                        10  0.092842  0.073729  0.002362  0.270096  0.089136
csm_ras_msg_type_query                                      5  0.006571  0.003427  0.001025  0.023056  0.008315
csm_node_attributes_query_history                           2  0.026112  0.026112  0.005603  0.046622  0.020509
Total Calls:  2528017
Total Errors: 96

Run Time: 237.426492929

[root@c650f03p41 tools]#
```