### PR TITLE
Soft Failure Recovery Enhancements

### DIFF
--- a/csmconf/csm_api.cfg
+++ b/csmconf/csm_api.cfg
@@ -7,5 +7,6 @@
    "csm_allocation_step_begin" : 120,
    "csm_allocation_query" : 120,
    "csm_bb_cmd" : 120,
-   "csm_jsrun_cmd" : 60
+   "csm_jsrun_cmd" : 60,
+   "csm_soft_failure_recovery" : 240
 }

--- a/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecoveryAgentState.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecoveryAgentState.cc
@@ -70,7 +70,11 @@ bool SoftFailureRecoveryAgentState::HandleNetworkMessage(
         // Note if the cgroup fails we don't care about running the recovery script.
         // 1. Run the local recovery script.
         char* cmd_out = nullptr;
-        int errorCode = csm::daemon::helper::ExecuteSFRecovery(&cmd_out, csm_get_agent_timeout(CMD_ID)/1000);
+
+        LOG( csmapi, info ) <<  ctx << "Running soft failure recovery script.";
+        int errorCode = csm::daemon::helper::ExecuteSFRecovery(&cmd_out, (csm_get_agent_timeout(CMD_ID)/1000));
+        LOG( csmapi, info ) <<  ctx << "Soft failure recovery exited with error code: " << errorCode;
+
         if(errorCode)
         {
             std::string error = hostname + "[" + std::to_string(errorCode) + 

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/Agent.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/Agent.h
@@ -132,6 +132,7 @@ inline int SetSMTLevelCSM( int smtLevel )
 
 inline int ExecuteBB( char* command_args, char ** output, uid_t user_id, int timeout)
 {
+    timeout += 10;
     char* scriptArgs[] = { (char*)CSM_BB_CMD, command_args, NULL };
     int errCode = ForkAndExecCapture( scriptArgs, output, user_id, timeout );
     return errCode;
@@ -139,6 +140,7 @@ inline int ExecuteBB( char* command_args, char ** output, uid_t user_id, int tim
 
 inline int ExecuteSFRecovery( char ** output, int timeout)
 {
+    timeout += 10;
     char* scriptArgs[] = { (char*)CSM_SFR_CMD, NULL };
     int errCode = ForkAndExecCapture( scriptArgs, output, 0, timeout );
     return errCode;


### PR DESCRIPTION
Added a default timeout time, added utility to print around recovery script calls. 

Fixed a bug in timeouts for both soft failure recovery and bb_cmd. This bug was due to CSM not waiting long enough to process the recovery. Added a fudge time to resolve.