### PR TITLE
csmdb_update: archive_history_db_default_thread_count set to 10

### DIFF
--- a/csmdb/sql/csm_db_history_archive.py
+++ b/csmdb/sql/csm_db_history_archive.py
@@ -34,7 +34,7 @@ DEFAULT_TARGET='''/var/log/ibm/csm/archive'''
 DEFAULT_COUNT=1000
 DEFAULT_DATABASE="csmdb"
 DEFAULT_USER="postgres"
-DEFAULT_THREAD_POOL=2
+DEFAULT_THREAD_POOL=10
 
 # Additional Formatting style
 line1 = "---------------------------------------------------------------------------------------------------------"


### PR DESCRIPTION
# Pull Request Title
csmdb_update: archive_history_db_default_thread_count set to 10
## Purpose
optimize DB connection size for archiving history tables.
