### PR TITLE
Soft Failure Bug Fixes

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIRasEventCreate.cc
@@ -421,7 +421,13 @@ csm::db::DBReqContent CSMIRasEventCreate::getRasCreateDbReq(RasEvent &rasEvent)
         sql_stmt << "$" << ++param << "::compute_node_states";     // SQL param: set_state
         sql_stmt <<  " where node_name=";
         sql_stmt << "$" << ++param << "::text";                    // SQL param: location_name
-        sql_stmt <<  " AND state IN ('" << CSM_NODE_STATE_DISCOVERED << "','" << CSM_NODE_STATE_IN_SERVICE << "') ) ";
+        sql_stmt <<  " AND state IN ('" << CSM_NODE_STATE_DISCOVERED << "','" << CSM_NODE_STATE_IN_SERVICE;
+        
+        // Allow hard failure transitions from soft failure.
+        if (set_state == CSM_NODE_STATE_HARD_FAILURE)
+            sql_stmt << "','" << CSM_NODE_STATE_SOFT_FAILURE;
+
+        sql_stmt <<"') ) ";
     }
     else if (set_state == "")
     {

--- a/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecovery.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecovery.cc
@@ -237,7 +237,7 @@ csm::db::DBReqContent* CSMISoftFailureRecovery_Master::FixRepairedNodes(
     {
         const int paramCount = 1; 
         std::string stmt = "UPDATE csm_node SET state='IN_SERVICE' "
-            "WHERE node_name=ANY($1::text[]);";
+            "WHERE node_name=ANY($1::text[]) AND state='SOFT_FAILURE';";
 
         dbReq = new csm::db::DBReqContent( stmt, paramCount );
         dbReq->AddTextParam(nodeStr.c_str());

--- a/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecovery.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecovery.cc
@@ -109,7 +109,7 @@ bool CSMISoftFailureRecovery_Master::CreatePayload(
         *dbPayload = dbReq;
         
         MCAST_PROPS_PAYLOAD* payload = new MCAST_PROPS_PAYLOAD( CMD_ID, context, false, false, 
-             CSM_RAS_MSG_ID_ALLOCATION_TIMEOUT); // TODO Replace msg id
+             ""); // TODO Replace msg id
          ctx->SetDataDestructor( []( void* data ){ delete (MCAST_PROPS_PAYLOAD*)data;});
          ctx->SetUserData( payload );
             
@@ -155,11 +155,16 @@ bool CSMISoftFailureRecovery_Master::ParseInfoQuery(
         if ( tuples[i] && tuples[i]->nfields > 0 )
         {
             recovery->compute_nodes[i] = strdup(tuples[i]->data[0]);
-            nodeList.append(recovery->compute_nodes[i]);
+            nodeList.append(recovery->compute_nodes[i]).append(",");
         }
         else
             recovery->compute_nodes[i] = strdup("");
     }
+
+    // Drop the comma.
+    if (nodeList.length() > 0)
+        nodeList.back()=' ';
+
 
     // Log the mcast information.
     LOG(csmapi,info) << ctx << mcastProps->GenerateIdentifierString()

--- a/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecovery.h
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMISoftFailureRecovery.h
@@ -78,11 +78,6 @@ public:
     static csm::db::DBReqContent* FixRepairedNodes( 
         csm::daemon::EventContextHandlerState_sptr& ctx,
         CSMIMcastSoftFailureRecovery* mcastProps);
-
-    static bool CreateHardFailures(
-        const std::vector<csm::db::DBTuple *>&tuples,
-        csm::db::DBReqContent **dbPayload,
-        csm::daemon::EventContextHandlerState_sptr& ctx);
 };
 
 class CSMISoftFailureRecovery_Agent : public CSMIStateful

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_handler_context.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_handler_context.cc
@@ -30,6 +30,7 @@ EventContextHandlerState::EventContextHandlerState(
         _PrivateCheck(false),
         _ExpectedNumResponses(0),
         _ReceivedNumResponses(0),
+        _MCASTNoTargetFail(true),
         _ErrorCode(CSMI_SUCCESS),
         _DBErrorCode(0),
         _NodeErrors({}),
@@ -57,6 +58,7 @@ EventContextHandlerState::EventContextHandlerState(const csm::daemon::EventConte
         _HasPrivateAccess(true),
         _ExpectedNumResponses(0),
         _ReceivedNumResponses(0),
+        _MCASTNoTargetFail(true),
         _ErrorCode(CSMI_SUCCESS),
         _ErrorMessage(""),
         _UserData(nullptr),
@@ -242,8 +244,20 @@ char* EventContextHandlerState::GetErrorSerialized(uint32_t* bufLen)
     if (error.errmsg) free(error.errmsg);
 
     return buffer;
-
 }
+
+void EventContextHandlerState::SetMCASTNoTargetSuccess()
+{
+    std::lock_guard<std::mutex> lock(_MCASTNoTargetFailMutex);
+    _MCASTNoTargetFail = false;
+}
+
+bool EventContextHandlerState::GetMCASTNoTargetFail()
+{
+    std::lock_guard<std::mutex> lock(_MCASTNoTargetFailMutex);
+    return _MCASTNoTargetFail;
+}
+
 
 
 void EventContextHandlerState::SetUserData( void* userData ) 

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_handler_context.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_handler_context.h
@@ -58,6 +58,9 @@ private:
     uint32_t      _ReceivedNumResponses;         ///< Number of responses received by the state.
     std::mutex    _ReceivedMutex;                ///< Mutex lock for the responses received.
 
+    bool          _MCASTNoTargetFail;            ///< Triggers a failure if a multicast has no targets.
+    std::mutex    _MCASTNoTargetFailMutex;       ///< Mutex lock for a multicast no target.
+
     // General Data.
     int           _ErrorCode;                    ///< Holds the error code for error events.
     std::mutex    _ErrorCodeMutex;               ///< A mutex lock for the error code.
@@ -237,6 +240,15 @@ public:
      * @return The serialized @ref csmi_err_t error object contained in this context object.
      */
     char* GetErrorSerialized(uint32_t* bufLen);
+
+    /** @brief  Sets the multicast to not return an error when the multicast fails.
+     */
+    void SetMCASTNoTargetSuccess();
+
+    /** @brief Retreives if the multicast should return an error when no targets were found.
+     * @return True multicast should return an error when no targets were found.
+     */
+    bool GetMCASTNoTargetFail();
 
     /** @brief Retrieves the user data, performing a static cast to the correct type.
      * 

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.cc
@@ -85,7 +85,8 @@ bool CSMIHandlerState::PushMCAST(
 {
     if( targets.size() == 0 )
     {
-        ctx->SetErrorCode(CSMERR_MULTI_GEN_ERROR);
+        // Set the error code if the NoTargetFail is set. This allows this MCAST to be used for non failure cases.
+        ctx->SetErrorCode(ctx->GetMCASTNoTargetFail() ? CSMERR_MULTI_GEN_ERROR : CSMI_NO_RESULTS );
         ctx->SetErrorMessage("Multicast had no targets!");
         return false;
     }
@@ -230,7 +231,14 @@ void CSMIHandlerState::DefaultHandleError(
     std::string prependString = ctx->GenerateUniqueID() + ";" ;
     ctx->PrependErrorMessage( prependString, ' ');
 
-    LOG(csmapi, error) <<  ctx->GetErrorMessage();
+    if(ctx->GetErrorCode() == CSMI_NO_RESULTS)
+    {
+        LOG(csmapi, error) <<  ctx->GetErrorMessage();
+    }
+    else
+    {
+        LOG(csmapi, info) <<  ctx->GetErrorMessage();
+    }
 
     ctx->SetAuxiliaryId( GetFinalState() );
 

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcast.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcast.h
@@ -59,6 +59,8 @@ protected:
     std::string _ErrorMsg;      /**< An aggration of error messages.*/
 
     std::priority_queue<int, std::vector<int>, ErrorCompare> _ErrHeap;  /**< A Heap to store errors received from the compute nodes. */
+    bool         _EventListRegistered; /**< Tracks whether the event  qeueue was registered. */
+    std::vector<csm::daemon::CoreEvent*> _PostEventList; /**< A Queue of events. */
     
 
 
@@ -79,7 +81,8 @@ public:
                 _Recovery(false),      _IsAlternate(false),
                 _EEReply(eeReply),     _RASPushed(false),
                 _Data(data),           _RASMsgId(rasMsgId),
-                _ErrorMsg(""),         _ErrHeap()
+                _ErrorMsg(""),         _ErrHeap(),
+                _EventListRegistered(false), _PostEventList()
     { 
         
         _ErrHeap.push(CSMERR_MULTI_GEN_ERROR);    
@@ -396,6 +399,29 @@ public:
      *  @return The most important error from the multicast.
      */
     inline int GetMainErrorCode() { return _ErrHeap.top(); }
+
+    inline void SetEventList(std::vector<csm::daemon::CoreEvent*>& postEventList)
+    {
+        _EventListRegistered = true;
+        _PostEventList = postEventList;
+    }
+
+    /** @brief Pushes an event to the event queue.
+     *  @param[in] reply The Core Event to enqueue.
+     *
+     *  @TODO Finish this
+     */
+    inline bool PushEvent(csm::daemon::CoreEvent* reply)
+    {
+        if(_EventListRegistered && reply)
+        {
+            _PostEventList.push_back(reply)
+            return true;
+        }
+        else
+            return false;
+
+    }
 };
 
 

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcast.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcast.h
@@ -59,8 +59,8 @@ protected:
     std::string _ErrorMsg;      /**< An aggration of error messages.*/
 
     std::priority_queue<int, std::vector<int>, ErrorCompare> _ErrHeap;  /**< A Heap to store errors received from the compute nodes. */
-    bool         _EventListRegistered; /**< Tracks whether the event  qeueue was registered. */
-    std::vector<csm::daemon::CoreEvent*> _PostEventList; /**< A Queue of events. */
+
+    std::vector<csm::daemon::CoreEvent*>* _PostEventList; /**< A Queue of events. */
     
 
 
@@ -82,7 +82,7 @@ public:
                 _EEReply(eeReply),     _RASPushed(false),
                 _Data(data),           _RASMsgId(rasMsgId),
                 _ErrorMsg(""),         _ErrHeap(),
-                _EventListRegistered(false), _PostEventList()
+                _PostEventList(nullptr)
     { 
         
         _ErrHeap.push(CSMERR_MULTI_GEN_ERROR);    
@@ -402,8 +402,7 @@ public:
 
     inline void SetEventList(std::vector<csm::daemon::CoreEvent*>& postEventList)
     {
-        _EventListRegistered = true;
-        _PostEventList = postEventList;
+        _PostEventList = &postEventList;
     }
 
     /** @brief Pushes an event to the event queue.
@@ -413,13 +412,16 @@ public:
      */
     inline bool PushEvent(csm::daemon::CoreEvent* reply)
     {
-        if(_EventListRegistered && reply)
+        if(_PostEventList && reply)
         {
-            _PostEventList.push_back(reply)
+            _PostEventList->push_back(reply);
             return true;
         }
         else
+        {
+            if (reply) delete reply;
             return false;
+        }
 
     }
 };

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastAllocation.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastAllocation.h
@@ -25,6 +25,7 @@
 #include "csmi/include/csmi_type_wm_funct.h"
 #include "csmi/include/csm_api_macros.h"
 #include "csmi/src/wm/include/csmi_wm_type_internal.h" 
+#define STRUCT_TYPE csmi_allocation_mcast_context_t
 //#include <map>
 
 // Build the error map table.
@@ -37,6 +38,9 @@ struct CSMIAllocErrorComparator
         {
             case CSMERR_ALLOC_BAD_FLAGS :
                 returnVal=5;
+                break;
+            case CSMERR_MULTI_GEN_ERROR:
+                returnVal=-1;
                 break;
             default:
                 break;
@@ -51,7 +55,6 @@ struct CSMIAllocErrorComparator
 };
 
 
-#define STRUCT_TYPE csmi_allocation_mcast_context_t
 
 
 /** @brief Frees the @ref _Data structure if not null.

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastBB.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastBB.cc
@@ -17,14 +17,14 @@
 #define STRUCT_TYPE csmi_bb_cmd_context_t
 
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast()
+CSMIMcast<STRUCT_TYPE,CSMIBBCMDComparator>::~CSMIMcast()
 {
     if(_Data) delete _Data;
     _Data = nullptr;
 }
 
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
+void CSMIMcast<STRUCT_TYPE,CSMIBBCMDComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
 {
     // Generate the leaner Burst Buffer payload.
     csmi_bb_cmd_payload_t *bbPayload = nullptr;
@@ -43,7 +43,7 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
 }
 
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString()
+std::string CSMIMcast<STRUCT_TYPE,CSMIBBCMDComparator>::GenerateIdentifierString()
 {
     std::string idString = "User ID: ";
     if ( _Data )

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastBB.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastBB.h
@@ -25,6 +25,29 @@
 #include "csmi/include/csmi_type_bb_funct.h"
 #define STRUCT_TYPE csmi_bb_cmd_context_t
 
+// Build the error map table.
+struct CSMIBBCMDComparator
+{
+    int map(int val) const
+    {
+        int returnVal=0;
+        switch (val)
+        {
+            case CSMERR_MULTI_GEN_ERROR:
+                returnVal=-1;
+                break;
+            default:
+                break;
+        }
+        return returnVal;
+    }
+
+    bool operator() (const int& a, const int& b) const
+    {
+        return map(a) < map(b);
+    }
+};
+
 /**
  * @brief Defines a context object for a Burst Buffer command multicast context.
  */
@@ -59,7 +82,7 @@ struct csmi_bb_cmd_context_t {
  * @tparam DataStruct The allocation create/delete/update multicast context.
  */
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
+CSMIMcast<STRUCT_TYPE,CSMIBBCMDComparator>::~CSMIMcast();
 
 /** @brief Builds a specialized payload to handle burst buffer command multicast payloads.
  *
@@ -69,7 +92,7 @@ CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
  * @param[out] bufferLength The length of the @p bufferLength payload.
  */
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
+void CSMIMcast<STRUCT_TYPE,CSMIBBCMDComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
 
 /**
  * @brief Generates a unique identifier for the multicast.
@@ -78,11 +101,11 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
  * @return A string containing the unique identifier for the multicast.
  */
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString();
+std::string CSMIMcast<STRUCT_TYPE,CSMIBBCMDComparator>::GenerateIdentifierString();
 
 /** @brief A typedef for @ref csmi_bb_context_t specializations of @ref CSMIMcast.
  */
-typedef CSMIMcast<STRUCT_TYPE> CSMIBBCMD;
+typedef CSMIMcast<STRUCT_TYPE,CSMIBBCMDComparator> CSMIBBCMD;
 
 namespace csm{
 namespace mcast{

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.cc
@@ -17,14 +17,14 @@
 #define STRUCT_TYPE csmi_jsrun_cmd_context_t
 
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast()
+CSMIMcast<STRUCT_TYPE,CSMIJSRUNCMDComparator>::~CSMIMcast()
 {
     if( _Data ) delete _Data;
     _Data = nullptr;
 }
 
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
+void CSMIMcast<STRUCT_TYPE,CSMIJSRUNCMDComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
 {
     // Generate the leaner JSRUN  payload.
     csmi_jsrun_cmd_payload_t *jsrunPayload = nullptr;
@@ -50,7 +50,7 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
 }
 
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString()
+std::string CSMIMcast<STRUCT_TYPE,CSMIJSRUNCMDComparator>::GenerateIdentifierString()
 {
     std::string idString = "User ID: ";
     if ( _Data )

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.h
@@ -25,6 +25,29 @@
 #include "csmi/include/csmi_type_wm_funct.h"
 #define STRUCT_TYPE csmi_jsrun_cmd_context_t
 
+// Build the error map table.
+struct CSMIJSRUNCMDComparator
+{
+    int map(int val) const
+    {
+        int returnVal=0;
+        switch (val)
+        {
+            case CSMERR_MULTI_GEN_ERROR:
+                returnVal=-1;
+                break;
+            default:
+                break;
+        }
+        return returnVal;
+    }
+
+    bool operator() (const int& a, const int& b) const
+    {
+        return map(a) < map(b);
+    }
+};
+
 /**
  * @brief Defines a context object for a JSRUN command multicast context.
  */
@@ -71,7 +94,7 @@ struct csmi_jsrun_cmd_context_t {
  * @tparam DataStruct The allocation create/delete/update multicast context.
  */
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
+CSMIMcast<STRUCT_TYPE,CSMIJSRUNCMDComparator>::~CSMIMcast();
 
 /** @brief Builds a specialized payload to handle burst buffer command multicast payloads.
  *
@@ -81,7 +104,7 @@ CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
  * @param[out] bufferLength The length of the @p bufferLength payload.
  */
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
+void CSMIMcast<STRUCT_TYPE,CSMIJSRUNCMDComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
 
 /**
  * @brief Generates a unique identifier for the multicast.
@@ -90,11 +113,11 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
  * @return A string containing the unique identifier for the multicast.
  */
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString();
+std::string CSMIMcast<STRUCT_TYPE,CSMIJSRUNCMDComparator>::GenerateIdentifierString();
 
 /** @brief A typedef for @ref csmi_bb_context_t specializations of @ref CSMIMcast.
  */
-typedef CSMIMcast<STRUCT_TYPE> CSMIJSRUNCMD;
+typedef CSMIMcast<STRUCT_TYPE,CSMIJSRUNCMDComparator> CSMIJSRUNCMD;
 
 namespace csm{
 namespace mcast{

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.cc
@@ -40,7 +40,7 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
 template<>
 std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString()
 {
-    std::string idString = "Soft Failure Recovery: ";
+    std::string idString = "Soft Failure Recovery";
     //if ( _Data )
     //    idString.append(std::to_string(_Data->allocation_id)).append( "; Primary Job Id: ")
     //        .append(std::to_string(_Data->primary_job_id)).append("; Secondary Job Id: ")

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.cc
@@ -16,14 +16,14 @@
 #define STRUCT_TYPE csmi_soft_failure_recovery_context_t
 
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast()
+CSMIMcast<STRUCT_TYPE,CSMISoftFailureComparator>::~CSMIMcast()
 {
     if(_Data) delete _Data;
     _Data = nullptr;
 }
 
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
+void CSMIMcast<STRUCT_TYPE,CSMISoftFailureComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
 {
     // Generate the payload
     csmi_soft_failure_recovery_payload_t * payload = nullptr;
@@ -38,7 +38,7 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
 }
 
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString()
+std::string CSMIMcast<STRUCT_TYPE,CSMISoftFailureComparator>::GenerateIdentifierString()
 {
     std::string idString = "Soft Failure Recovery";
     //if ( _Data )

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.h
@@ -25,9 +25,32 @@
 #include "csmi/include/csmi_type_wm_funct.h"
 #include "csmi/include/csm_api_macros.h"
 #include "csmi/src/wm/include/csmi_wm_type_internal.h" 
+#define STRUCT_TYPE csmi_soft_failure_recovery_context_t
 //#include <map>
 
-#define STRUCT_TYPE csmi_soft_failure_recovery_context_t
+// Build the error map table.
+struct CSMISoftFailureComparator
+{
+    int map(int val) const
+    {
+        int returnVal=0;
+        switch (val)
+        {
+            case CSMERR_MULTI_GEN_ERROR:
+                returnVal=-1;
+                break;
+            default:
+                break;
+        }
+        return returnVal;
+    }
+
+    bool operator() (const int& a, const int& b) const
+    {
+        return map(a) < map(b);
+    }
+};
+
 
 struct csmi_soft_failure_recovery_context_t {
     uint32_t num_nodes;
@@ -63,7 +86,7 @@ struct csmi_soft_failure_recovery_context_t {
  * @tparam DataStruct The allocation create/delete/update multicast context.
  */
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
+CSMIMcast<STRUCT_TYPE,CSMISoftFailureComparator>::~CSMIMcast();
 
 /** @brief Builds a specialized payload to handle allocation create/delete multicast payloads.
  *
@@ -73,7 +96,7 @@ CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
  * @param[out] bufferLength The length of the @p bufferLength payload.
  */
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
+void CSMIMcast<STRUCT_TYPE,CSMISoftFailureComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
 
 /**
  * @brief Generates a unique identifier string for the mcast object.
@@ -82,11 +105,11 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
  * @return A string containing the unique identifier for the multicast.
  */
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString();
+std::string CSMIMcast<STRUCT_TYPE,CSMISoftFailureComparator>::GenerateIdentifierString();
 
 /** @brief A typedef for @ref csmi_allocation_mcast_context_t specializations of @ref CSMIMcast.
  */
-typedef CSMIMcast<STRUCT_TYPE> CSMIMcastSoftFailureRecovery;
+typedef CSMIMcast<STRUCT_TYPE,CSMISoftFailureComparator> CSMIMcastSoftFailureRecovery;
 
 namespace csm{
 namespace mcast{

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.h
@@ -33,18 +33,12 @@ struct csmi_soft_failure_recovery_context_t {
     uint32_t num_nodes;
     uint32_t retry_count;
     char**   compute_nodes;
-    char*    hard_failure_nodes;
 
     csmi_soft_failure_recovery_context_t() : num_nodes(0), retry_count(0),
-        compute_nodes(nullptr), hard_failure_nodes(nullptr) {}
+        compute_nodes(nullptr){}
 
     ~csmi_soft_failure_recovery_context_t()
     {
-        if (hard_failure_nodes)
-        {
-            free(hard_failure_nodes);
-        }
-        hard_failure_nodes = nullptr;
 
         if ( compute_nodes != nullptr )
         {

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSpawner.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSpawner.h
@@ -83,6 +83,9 @@ protected:
         std::unique_lock<std::mutex>dataLock = 
             ctx->GetUserData<PayloadType*>(&mcastProps);
 
+        // Setup the post event list for registering other events.
+        mcastProps->SetEventList(postEventList);
+
         // Parse the request, if the parse was valid we're in the sucess state.
         success = InfoParser(ctx, tuples, mcastProps);
 

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastStep.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastStep.cc
@@ -16,17 +16,17 @@
 #define STRUCT_TYPE csmi_allocation_step_mcast_context_t
 
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast()
+CSMIMcast<STRUCT_TYPE,CSMIAllocStepComparator>::~CSMIMcast()
 {
     if( _Data )
     {
-        csm_free_struct_ptr( STRUCT_TYPE, _Data );
+        csm_free_struct_ptr( csmi_allocation_step_mcast_context_t, _Data );
         _Data = nullptr;
     }
 }
 
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
+void CSMIMcast<STRUCT_TYPE,CSMIAllocStepComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength)
 {
     // TODO improve this function for memory usage.
     if ( _Data )
@@ -46,7 +46,7 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
 }
 
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString()
+std::string CSMIMcast<STRUCT_TYPE,CSMIAllocStepComparator>::GenerateIdentifierString()
 {
     std::string idString = "Allocation ID: ";
     if ( _Data )

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastStep.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastStep.h
@@ -26,11 +26,34 @@
 
 #define STRUCT_TYPE csmi_allocation_step_mcast_context_t
 
+// Build the error map table.
+struct CSMIAllocStepComparator
+{
+    int map(int val) const
+    {
+        int returnVal=0;
+        switch (val)
+        {
+            case CSMERR_MULTI_GEN_ERROR:
+                returnVal=-1;
+                break;
+            default:
+                break;
+        }
+        return returnVal;
+    }
+
+    bool operator() (const int& a, const int& b) const
+    {
+        return map(a) < map(b);
+    }
+};
+
 /** @brief Frees the @ref _Data structure if not null.
  * @tparam DataStruct The step begin/end  multicast context.
  */
 template<>
-CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
+CSMIMcast<STRUCT_TYPE,CSMIAllocStepComparator>::~CSMIMcast();
 
 /** @brief Builds a specialized payload to handle step begin/end multicast payloads.
  * @todo finish this document.
@@ -43,7 +66,7 @@ CSMIMcast<STRUCT_TYPE>::~CSMIMcast();
  * @param[out] bufferLength The length of the @p bufferLength payload.
  */
 template<>
-void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
+void CSMIMcast<STRUCT_TYPE,CSMIAllocStepComparator>::BuildMcastPayload(char** buffer, uint32_t* bufferLength);
 
 /**
  * @brief Generates a unique identifier for the multicast.
@@ -52,11 +75,11 @@ void CSMIMcast<STRUCT_TYPE>::BuildMcastPayload(char** buffer, uint32_t* bufferLe
  * @return A string containing the unique identifier for the multicast.
  */
 template<>
-std::string CSMIMcast<STRUCT_TYPE>::GenerateIdentifierString();
+std::string CSMIMcast<STRUCT_TYPE,CSMIAllocStepComparator>::GenerateIdentifierString();
 
 /** @brief A typedef for @ref csmi_allocation_step_mcast_context_t specializations of @ref CSMIMcast.
  */
-typedef CSMIMcast<STRUCT_TYPE> CSMIStepMcast;
+typedef CSMIMcast<STRUCT_TYPE,CSMIAllocStepComparator> CSMIStepMcast;
 
 namespace csm{
 namespace mcast{

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_network_message_state.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_network_message_state.h
@@ -71,7 +71,7 @@ public:
         if (content._Msg.GetErr()) 
         {
             LOG(csmapi, error) << ctx << 
-                "NetworkMessageState: An error was detected while recieving a "
+                "NetworkMessageState: An error was detected while receiving a "
                 "Network Message.";
 
             // Unpack the error

--- a/csmi/include/csm_api_ras_keys.h
+++ b/csmi/include/csm_api_ras_keys.h
@@ -33,6 +33,7 @@ extern "C" {
 #define CSM_RAS_MSG_ID_CGROUP_CREATE_FAILURE   "csm.api.cgroup_create_failure"
 #define CSM_RAS_MSG_ID_CGROUP_DELETE_FAILURE   "csm.api.cgroup_delete_failure"
 #define CSM_RAS_MSG_ID_ALLOCATION_TIMEOUT      "csm.api.allocation_timeout"
+#define CSM_RAS_MSG_ID_RETRY_EXCEEDED          "csm.soft_failure_recovery.retries_exceeded"
 
 
 #define CSM_RAS_PROLOG_PROLOG_COLLISION        "csm.api.prolog_prolog_collision"

--- a/csmi/src/wm/cmd/soft_failure_recovery.c
+++ b/csmi/src/wm/cmd/soft_failure_recovery.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
     
     return_value = csm_soft_failure_recovery(&csm_obj, &input, &output);
 
-	if (return_value == CSMI_SUCCESS ) 
+	if (return_value == CSMI_SUCCESS )
     {
 	    printf("---\n# Soft Failure cleaned up.\n");
 
@@ -131,10 +131,17 @@ int main(int argc, char *argv[])
 	}
 	else 
     {
-		printf("# %s FAILED: returned: %d, errcode: %d errmsg: %s\n", argv[0], return_value, 
-            csm_api_object_errcode_get(csm_obj), csm_api_object_errmsg_get(csm_obj));
-        
-        csm_print_node_errors(csm_obj)
+        if(return_value == CSMI_NO_RESULTS)
+        {
+            printf("# No nodes currently in soft failure.\n");
+        }
+        else
+        {
+		    printf("# %s FAILED: returned: %d, errcode: %d errmsg: %s\n", argv[0], return_value, 
+                csm_api_object_errcode_get(csm_obj), csm_api_object_errmsg_get(csm_obj));
+            
+            csm_print_node_errors(csm_obj)
+        }
 	}
 
 	// it's the csmi library's responsibility to free internal space

--- a/docs/source/cast-big-data/kibana.rst
+++ b/docs/source/cast-big-data/kibana.rst
@@ -1,4 +1,5 @@
 .. _cast-kibana:
+
 Kibana
 ======
 

--- a/docs/source/csm/soft_failure.rst
+++ b/docs/source/csm/soft_failure.rst
@@ -61,6 +61,9 @@ CSM provides a command line script to trigger a `Soft Failure` recovery. Invocat
 The `-r` or `--retry` option sets a retry threshold if this threshold is exceeded or met by any nodes
 that failed to be placed into `In Service` the node will be moved to `Hard Failure`.
 
+.. attention:: Nodes that are in `Soft Failure` and owned by an allocation will *NOT* be processed by this
+    utility!
+
 Recovery Script
 ---------------
 


### PR DESCRIPTION
Fixes for some of the Soft Failure Bugs uncovered in test:
1. Transitioned to use RAS events to trigger hard failure.
2. Enhanced debug lines in error output (fixed commas, non errors don't present error messages).
3. Enabled Soft Failure to Hard Failure through RAS events.
4. Added mechanism to push events from multicast customization.

Test cases that need to be made:
1. Call soft failure recovery with no nodes in soft failure (`CSMI_NO_RESULTS`).
2. Call soft failure recovery with one node in soft failure (`CSMI_SUCCESS`).
3. Call soft failure recovery with multiple nodes in soft failure (`CSMI_SUCCESS`).
4. Call soft failure recovery with one node in soft failure in an allocation (`CSMI_NO_RESULTS`).
5. Call soft failure recovery with one node in soft failure in an allocation and one in soft failure without an allocation (`CSMI_SUCCESS`).
6. Call soft failure recovery with a node with a shut down daemon (`CSMERR_TIMEOUT`).


@besawn I added some logic to enable the `Soft Failure` -> `Hard Failure`.


