### PR TITLE
candidate fix for csm client-crash issue

### DIFF
--- a/csmnet/src/C/csm_network_internal_api_c.h
+++ b/csmnet/src/C/csm_network_internal_api_c.h
@@ -55,6 +55,7 @@ typedef struct {
     struct sockaddr_un _OtherAddr; // for client sockets this holds the connected addr
 
     char * _DataBuffer;
+    pthread_mutex_t _Lock;
     csm_dgram_buffer_state_t _BufferState;
 
 } csm_net_unix_t;

--- a/csmnet/src/C/csm_network_local.c
+++ b/csmnet/src/C/csm_network_local.c
@@ -450,6 +450,10 @@ csm_net_endpoint_t * csm_net_unix_Init( const int aIsServer )
   return ret;
 }
 
+
+ssize_t csm_net_unix_Send_unlocked( csm_net_unix_t *aEP,
+                                    csm_net_msg_t *aMsg );
+
 /** @brief destruction of the local endpoint
  *
  * Closes and cleans up the local endpoint structures, state, and files
@@ -997,7 +1001,7 @@ ssize_t FillReceiveBuffer( csm_net_unix_t *aEP, csmi_cmd_t cmd, const int partia
         errno = 0;
         rlen = recvmsg( aEP->_Socket, &msg, 0 );
         stored_errno = errno;
-        
+
         switch( stored_errno )
         {
             case EINTR:
@@ -1429,7 +1433,13 @@ int handle_internal_msg( csm_net_unix_t *ep, csm_net_msg_t const *aMsg )
 void * thread_callback_loop( void * aIn )
 {
   csm_net_endpoint_t *ep = (csm_net_endpoint_t*)aIn;
+  if( ep == NULL )
+    return NULL;
+
   csm_net_unix_t *cb = ep->_cb;
+  if( cb == NULL )
+    return NULL;
+
   int rc = 0;
   int recvRetries = 2;
 


### PR DESCRIPTION
This introduces a candidate fix for a potential race condition.

The race condition can happen when the client is communicating with the CSM daemon and that daemon is forced into disconnected mode. (e.g. aggregators of a compute node become unreachable, or master node goes down so utility and aggregator become disconnected).

The approach is a mutex around send/recv operations and the socket shutdown/cleanup so that a socket that's in active recv/send can no longer run into wiped/freed data structures that got cleaned by the shutdown sequence.

I have not been able to reproduce that crash with or without this fix yet. It seems that this crash is a rare event since the unprotected code sections existed for quite a while.