### PR TITLE
Fixing error code for daemon being down.

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastAllocation.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastAllocation.h
@@ -39,6 +39,7 @@ struct CSMIAllocErrorComparator
             case CSMERR_ALLOC_BAD_FLAGS :
                 returnVal=5;
                 break;
+            case CSMERR_GENERIC:
             case CSMERR_MULTI_GEN_ERROR:
                 returnVal=-1;
                 break;

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastBB.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastBB.h
@@ -33,6 +33,7 @@ struct CSMIBBCMDComparator
         int returnVal=0;
         switch (val)
         {
+            case CSMERR_GENERIC:
             case CSMERR_MULTI_GEN_ERROR:
                 returnVal=-1;
                 break;

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.h
@@ -33,6 +33,7 @@ struct CSMIJSRUNCMDComparator
         int returnVal=0;
         switch (val)
         {
+            case CSMERR_GENERIC:
             case CSMERR_MULTI_GEN_ERROR:
                 returnVal=-1;
                 break;

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.h
@@ -36,6 +36,7 @@ struct CSMISoftFailureComparator
         int returnVal=0;
         switch (val)
         {
+            case CSMERR_GENERIC:
             case CSMERR_MULTI_GEN_ERROR:
                 returnVal=-1;
                 break;

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastStep.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastStep.h
@@ -34,6 +34,7 @@ struct CSMIAllocStepComparator
         int returnVal=0;
         switch (val)
         {
+            case CSMERR_GENERIC:
             case CSMERR_MULTI_GEN_ERROR:
                 returnVal=-1;
                 break;

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_network_message_state.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_network_message_state.h
@@ -80,6 +80,11 @@ public:
 
             this->ProcessError(ctx, error);
 
+            if ( ctx->GetErrorCode() >= csmi_cmd_err_t_MAX)
+            {
+                ctx->SetErrorCode(CSMERR_GENERIC);
+            }
+
             if ( ctx->GetErrorCode() == CSMERR_TIMEOUT )
             {
                 this->HandleTimeout(ctx, aEvent, postEventList);


### PR DESCRIPTION
Fixing bad network error codes to be transformed into `CSMERR_GENERIC` to prevent loss of error data.