### PR TITLE
prevent client lib race condition: socket tear-down and pending send/recv

### DIFF
--- a/csmi/src/common/src/csm_api_common.c
+++ b/csmi/src/common/src/csm_api_common.c
@@ -109,7 +109,7 @@ int csm_init_lib_vers(int64_t version_id)
   csmi_set_init_msgId(init_msgId);
 
   ep->_on_disconnect = on_disconnect;
-  
+
   initialized = 1;
 
   csmutil_logging(trace, "csm_init_lib initialized (init_msg_id=%d)", init_msgId);

--- a/csmnet/src/C/csm_network_local.c
+++ b/csmnet/src/C/csm_network_local.c
@@ -1062,7 +1062,7 @@ ssize_t FillReceiveBuffer( csm_net_unix_t *aEP, csmi_cmd_t cmd, const int partia
 }
 
 static
-csm_net_msg_t * csm_net_unix_RecvMain( 
+csm_net_msg_t * csm_net_unix_RecvMain(
     csm_net_unix_t *aEP, 
     int aBlocking, 
     csmi_cmd_t cmd,
@@ -1420,6 +1420,7 @@ void * thread_callback_loop( void * aIn )
           ep->_connected = 0;
           ep->_cb_keep_running = 0;
           rc = ep->_on_disconnect( msg );
+          break;
         }
       }
       continue;
@@ -1433,6 +1434,7 @@ void * thread_callback_loop( void * aIn )
         ep->_connected = 0;
         ep->_cb_keep_running = 0;
         rc = ep->_on_disconnect( msg );
+        break;
       }
     }
     else


### PR DESCRIPTION
PR solved race condition and deadlock possibility when client lib tears down the link to the CSMD in case of either disconnect msg from daemon or other connection problems.

The approach is to extend the usage of an existing mutex that was supposed to prevent init and term of the lib to interfere. This mutex is now used to make sure termination waits until a recv/send returns and vice versa. It also prevents a recv/send from getting processed while the link data structures get cleaned up.
I believe, a possible deadlock during disconnect existed for a long time, it's just that the probability seemed very low to hit it. The problem was that multiple code paths were possible to enter the disconnect. However, if the main thread performs the disconnect (with the lock aquired) it also terminates the callback thread. If the callback thread attempted to disconnect too, it would wait for the mutex and thus prevents the pthread_join() to complete. With additional use of the mutex it got exposed more and should be fixed with this PR now.

Testing requires to run many iterations of some client cmd (can be error-inject or any other, even if errors are returned like when requesting node attributes of a non-existing node).
While the requests are running, force the local csmd into disconnected mode (e.g. shutting down aggregator for a compute node; disconnect the master of a utility daemon).

The expected result is
* the client output should show errors regarding disconnect of the daemon
* Returning the daemon to regular operation should resume the request iterations.
* the client that got hit by the disconnect should fail but not hang
