### PR TITLE
CSM RAS: Added msg type definitions for common administrator ras events

### DIFF
--- a/csmdb/sql/csm_ras_type_data.csv
+++ b/csmdb/sql/csm_ras_type_data.csv
@@ -1,4 +1,10 @@
 #msg_id,severity,message,description,control_action,threshold_count,threshold_period,enabled,set_state,visible_to_users
+admin.common.soft_failure,FATAL,An administrative tool has detected an error on $(location_name): $(comment).,Set node state to SOFT_FAILURE due to error.,NONE,1,0,true,SOFT_FAILURE,true
+admin.common.hard_failure,FATAL,An administrative tool has detected an error on $(location_name): $(comment).,Set node state to HARD_FAILURE due to error.,NONE,1,0,true,HARD_FAILURE,true
+admin.common.prolog_soft_failure,FATAL,Prolog error detected on $(location_name): $(comment).,Set node state to SOFT_FAILURE due to a prolog error.,NONE,1,0,true,SOFT_FAILURE,true
+admin.common.prolog_hard_failure,FATAL,Prolog error detected on $(location_name): $(comment).,Set node state to HARD_FAILURE due to a prolog error.,NONE,1,0,true,HARD_FAILURE,true
+admin.common.epilog_soft_failure,FATAL,Epilog error detected on $(location_name): $(comment).,Set node state to SOFT_FAILURE due to an epilog error.,NONE,1,0,true,SOFT_FAILURE,true
+admin.common.epilog_hard_failure,FATAL,Epilog error detected on $(location_name): $(comment).,Set node state to HARD_FAILURE due to an epilog error. ,NONE,1,0,true,HARD_FAILURE,true
 bmc.Administrative.FQPSPSE0002M,FATAL,A session audit has occurred.,,NONE,1,0,true,,true
 bmc.CommunicationFailure/Timeout.FQPSPCA0057M,FATAL,Unable to set fan speed for Fan $(fan).,,NONE,1,0,true,,true
 bmc.CommunicationFailure/Timeout.FQPSPCA0058M,FATAL,Unable to read Fan $(fan) rotor $(rotor) speed.,,NONE,1,0,true,,true


### PR DESCRIPTION
This pull request contains ras msg type definitions intended for use by system administrators to place nodes into SOFT_FAILURE or HARD_FAILURE when administrator tools including prologs and epilogs detect a fatal error.

The new type definitions:
```
/opt/ibm/csm/bin/csm_ras_msg_type_query -m "admin.%"
---
Total_Records: 6
RECORD_1:
  msg_id:           admin.common.soft_failure
  control_action:   NONE
  description:      Set node state to SOFT_FAILURE due to error.
  enabled:          t
  message:          An administrative tool has detected an error on $(location_name): $(comment).
  set_state:        SOFT_FAILURE
  severity:         FATAL
  threshold_count:  1
  threshold_period: 0
  visible_to_users: t
RECORD_2:
  msg_id:           admin.common.hard_failure
  control_action:   NONE
  description:      Set node state to HARD_FAILURE due to error.
  enabled:          t
  message:          An administrative tool has detected an error on $(location_name): $(comment).
  set_state:        HARD_FAILURE
  severity:         FATAL
  threshold_count:  1
  threshold_period: 0
  visible_to_users: t
RECORD_3:
  msg_id:           admin.common.prolog_soft_failure
  control_action:   NONE
  description:      Set node state to SOFT_FAILURE due to a prolog error.
  enabled:          t
  message:          Prolog error detected on $(location_name): $(comment).
  set_state:        SOFT_FAILURE
  severity:         FATAL
  threshold_count:  1
  threshold_period: 0
  visible_to_users: t
RECORD_4:
  msg_id:           admin.common.prolog_hard_failure
  control_action:   NONE
  description:      Set node state to HARD_FAILURE due to a prolog error.
  enabled:          t
  message:          Prolog error detected on $(location_name): $(comment).
  set_state:        HARD_FAILURE
  severity:         FATAL
  threshold_count:  1
  threshold_period: 0
  visible_to_users: t
RECORD_5:
  msg_id:           admin.common.epilog_soft_failure
  control_action:   NONE
  description:      Set node state to SOFT_FAILURE due to an epilog error.
  enabled:          t
  message:          Epilog error detected on $(location_name): $(comment).
  set_state:        SOFT_FAILURE
  severity:         FATAL
  threshold_count:  1
  threshold_period: 0
  visible_to_users: t
RECORD_6:
  msg_id:           admin.common.epilog_hard_failure
  control_action:   NONE
  description:      Set node state to HARD_FAILURE due to an epilog error. 
  enabled:          t
  message:          Epilog error detected on $(location_name): $(comment).
  set_state:        HARD_FAILURE
  severity:         FATAL
  threshold_count:  1
  threshold_period: 0
  visible_to_users: t
...
```

And example events created using the msg types above:
```
  rec_id:            291
  msg_id:            admin.common.soft_failure
  severity:          FATAL
  time_stamp:        2018-12-07 17:32:53.191216
  master_time_stamp: 2018-12-07 17:32:53.193457
  location_name:     c650f99p36
  count:             1
  control_action:    NONE
  message:           An administrative tool has detected an error on c650f99p36: Allocation: 126 GPU error detected.
  raw_data:          
  kvcsv:             comment=Allocation: 126 GPU error detected

  rec_id:            295
  msg_id:            admin.common.hard_failure
  severity:          FATAL
  time_stamp:        2018-12-07 17:32:53.236353
  master_time_stamp: 2018-12-07 17:32:53.238588
  location_name:     c650f99p36
  count:             1
  control_action:    NONE
  message:           An administrative tool has detected an error on c650f99p36: Allocation: 130 GPU error detected.
  raw_data:          
  kvcsv:             comment=Allocation: 130 GPU error detected

  rec_id:            299
  msg_id:            admin.common.prolog_soft_failure
  severity:          FATAL
  time_stamp:        2018-12-07 17:32:53.280827
  master_time_stamp: 2018-12-07 17:32:53.283074
  location_name:     c650f99p36
  count:             1
  control_action:    NONE
  message:           Prolog error detected on c650f99p36: Allocation: 134 GPU error detected.
  raw_data:          
  kvcsv:             comment=Allocation: 134 GPU error detected

  rec_id:            303
  msg_id:            admin.common.prolog_hard_failure
  severity:          FATAL
  time_stamp:        2018-12-07 17:32:53.325073
  master_time_stamp: 2018-12-07 17:32:53.327269
  location_name:     c650f99p36
  count:             1
  control_action:    NONE
  message:           Prolog error detected on c650f99p36: Allocation: 138 GPU error detected.
  raw_data:          
  kvcsv:             comment=Allocation: 138 GPU error detected

  rec_id:            307
  msg_id:            admin.common.epilog_soft_failure
  severity:          FATAL
  time_stamp:        2018-12-07 17:32:53.369935
  master_time_stamp: 2018-12-07 17:32:53.372087
  location_name:     c650f99p36
  count:             1
  control_action:    NONE
  message:           Epilog error detected on c650f99p36: Allocation: 142 GPU error detected.
  raw_data:          
  kvcsv:             comment=Allocation: 142 GPU error detected


  rec_id:            311
  msg_id:            admin.common.epilog_hard_failure
  severity:          FATAL
  time_stamp:        2018-12-07 17:32:53.413939
  master_time_stamp: 2018-12-07 17:32:53.416204
  location_name:     c650f99p36
  count:             1
  control_action:    NONE
  message:           Epilog error detected on c650f99p36: Allocation: 146 GPU error detected.
  raw_data:          
  kvcsv:             comment=Allocation: 146 GPU error detected
```