### PR TITLE
Fixing responder error where error codes weren't set.

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_handler_state.cc
@@ -231,13 +231,17 @@ void CSMIHandlerState::DefaultHandleError(
     std::string prependString = ctx->GenerateUniqueID() + ";" ;
     ctx->PrependErrorMessage( prependString, ' ');
 
-    if(ctx->GetErrorCode() != CSMI_NO_RESULTS)
+    // Success should NEVER be sent back!
+    switch ( ctx->GetErrorCode() )
     {
-        LOG(csmapi, error) <<  ctx->GetErrorMessage();
-    }
-    else
-    {
-        LOG(csmapi, info) <<  ctx->GetErrorMessage();
+        case CSMI_NO_RESULTS:
+            LOG(csmapi, info) <<  ctx->GetErrorMessage();
+            break;
+        case CSMI_SUCCESS:
+            ctx->SetErrorCode(CSMERR_GENERIC);
+        default:
+            LOG(csmapi, error) <<  ctx->GetErrorMessage();
+            break;
     }
 
     ctx->SetAuxiliaryId( GetFinalState() );

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastResponder.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastResponder.h
@@ -503,6 +503,9 @@ protected:
                     //ctx->AppendErrorMessage(mcastProps->GenerateErrorListing());
                     LOG(csmapi, error) << ctx << STATE_NAME " Unable to build the response query.";
                     dataLock.unlock();
+                    
+                    // Set the Error Code.
+                    ctx->SetErrorCode(mcastProps->GetMainErrorCode());
                     CSMIHandlerState::DefaultHandleError(ctx, aEvent, postEventList, byAggregator);
                 }
             }
@@ -510,6 +513,8 @@ protected:
             {
                 LOG(csmapi, error) << ctx << STATE_NAME " Unable to build the response query.";
                 dataLock.unlock();
+
+                ctx->SetErrorCode(CSMERR_MEM_ERROR);
                 ctx->AppendErrorMessage(ERR_MSG_DIVIDE);
                 CSMIHandlerState::DefaultHandleError(ctx, aEvent, postEventList, byAggregator);
             }

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_mcast/CSMIMcastSoftFailureRecovery.cc
@@ -82,6 +82,8 @@ bool ParseResponseSoftFailure(
                 payload->error_code, 
                 payload->error_message);
             
+            if( payload->error_code )
+                mcastProps->PushError(payload->error_code);
 
             csm_free_struct_ptr(csmi_soft_failure_recovery_payload_t, payload);
         }


### PR DESCRIPTION
Fixing a bug uncovered in regression by @pdlun92 where the multicast was not returning a set error code.