### PR TITLE
Tolerate bailout on removefiles tool

### DIFF
--- a/bb/tools/removefiles.cc
+++ b/bb/tools/removefiles.cc
@@ -91,7 +91,6 @@ int main(int argc, char *argv[])
     catch(ExceptionBailout& e)
     {
         LOG(bb,always) << "ExceptionBailout";
-        exitrc = -1;
     }
     catch (exception& e)
     {


### PR DESCRIPTION
RemoveFiles is sometimes called in FVT during cleanup processing without a valid filelist, causing the test suite to incorrectly abort.