### PR TITLE
Csm node query state history hard failure updates

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMINodeQueryStateHistory.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMINodeQueryStateHistory.cc
@@ -170,7 +170,7 @@ void CSMINodeQueryStateHistory::CreateOutputStruct(
 	o->history_time            = strdup(fields->data[i]);                                                        i++;
     o->state                   = (csmi_node_state_t)csm_get_enum_from_string(csmi_node_state_t,fields->data[i]); i++;
 	
-	if(o->state == CSM_NODE_SOFT_FAILURE){
+	if(o->state == CSM_NODE_SOFT_FAILURE || o->state == CSM_NODE_HARD_FAILURE){
 		o->alteration = CSM_NODE_ALTERATION_RAS_EVENT;
 		o->ras_rec_id = strdup(fields->data[i]); i++;
 		o->ras_msg_id = strdup(fields->data[i]); i++;

--- a/csmi/src/inv/cmd/node_query_state_history.c
+++ b/csmi/src/inv/cmd/node_query_state_history.c
@@ -237,9 +237,9 @@ int main(int argc, char *argv[])
 				for(i = 0; i < output->results_count; i++){
 					if(output->results[i]->state == CSM_NODE_SOFT_FAILURE)
 					{
-						printf("#  %s | %-15s| %-21s| %s, %s\n", output->results[i]->history_time, csm_get_string_from_enum(csmi_node_state_t, output->results[i]->state), csm_get_string_from_enum(csmi_node_alteration_t, output->results[i]->alteration), output->results[i]->ras_rec_id, output->results[i]->ras_msg_id);
+						printf("#  %-27s| %-15s| %-21s| %s, %s\n", output->results[i]->history_time, csm_get_string_from_enum(csmi_node_state_t, output->results[i]->state), csm_get_string_from_enum(csmi_node_alteration_t, output->results[i]->alteration), output->results[i]->ras_rec_id, output->results[i]->ras_msg_id);
 					}else{
-						printf("#  %s | %-15s| %-21s| \n", output->results[i]->history_time, csm_get_string_from_enum(csmi_node_state_t, output->results[i]->state), csm_get_string_from_enum(csmi_node_alteration_t, output->results[i]->alteration));
+						printf("#  %-27s| %-15s| %-21s| \n", output->results[i]->history_time, csm_get_string_from_enum(csmi_node_state_t, output->results[i]->state), csm_get_string_from_enum(csmi_node_alteration_t, output->results[i]->alteration));
 					}
 				}
 				puts("...");

--- a/csmi/src/inv/cmd/node_query_state_history.c
+++ b/csmi/src/inv/cmd/node_query_state_history.c
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
 				printf("#         history_time        |      state     |      alteration      | RAS_rec_id, RAS_msg_id \n");
 				printf("# ----------------------------+----------------+----------------------+------------------------\n");
 				for(i = 0; i < output->results_count; i++){
-					if(output->results[i]->state == CSM_NODE_SOFT_FAILURE)
+					if(output->results[i]->state == CSM_NODE_SOFT_FAILURE || output->results[i]->state == CSM_NODE_HARD_FAILURE )
 					{
 						printf("#  %-27s| %-15s| %-21s| %s, %s\n", output->results[i]->history_time, csm_get_string_from_enum(csmi_node_state_t, output->results[i]->state), csm_get_string_from_enum(csmi_node_alteration_t, output->results[i]->alteration), output->results[i]->ras_rec_id, output->results[i]->ras_msg_id);
 					}else{


### PR DESCRIPTION
addresses issue https://github.com/IBM/CAST/issues/449#event-2018959492 

also adds in padding to the time print if its less than 6 degrees of micro seconds. 