### PR TITLE
CSM FVT: Added csm_db_backup_script_v1.sh to basic db script bucket

### DIFF
--- a/csmtest/buckets/basic/db_script.sh
+++ b/csmtest/buckets/basic/db_script.sh
@@ -51,15 +51,26 @@ check_return_exit $? 0 "Test Case 1: Calling csm_db_script.sh -n fvttestdb"
 su -c "psql -d fvttestdb -c \"\q\"" postgres > ${TEMP_LOG} 2>&1
 check_return_exit $? 0 "Test Case 2: Checking fvttestdb exists"
 
-# Test Case 3: Calling csm_db_script.sh -d fvttestdb
+# Test Case 3: csm_db_backup_script - run script
+${DB_PATH}/csm_db_backup_script_v1.sh fvttestdb > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 3: csm_db_backup_script - run script"
+
+# Test Case 3: csm_db_backup_script - check for backup
+ls /var/lib/pgsql/backups/fvttestdb* > ${TEMP_LOG} 2>&1
+check_return_flag $? "Test Case 3: csm_db_backup_script - check for backup"
+
+# Test Case 4: Calling csm_db_script.sh -d fvttestdb
 echo "y" | ${DB_PATH}/csm_db_script.sh -d fvttestdb > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 3: Calling csm_db_script.sh -d fvttestdb"
+check_return_exit $? 0 "Test Case 4: Calling csm_db_script.sh -d fvttestdb"
 
-# Test Case 4: Checking fvttestdb was deleted
+# Test Case 5: Checking fvttestdb was deleted
 su -c "psql -d fvttestdb -c \"\q\"" postgres > ${TEMP_LOG} 2>&1
-check_return_exit $? 2 "Test Case 4: Checking fvttestdb was deleted"
+check_return_exit $? 2 "Test Case 5: Checking fvttestdb was deleted"
 
+# Cleanup
 rm -f ${TEMP_LOG}
+rm -f /var/lib/pgsql/backups/fvttestdb*
+
 echo "------------------------------------------------------------" >> ${LOG}
 echo "CSM DB Scripts Bucket PASSED" >> ${LOG}
 echo "------------------------------------------------------------" >> ${LOG}


### PR DESCRIPTION
Added a simple call and check for `csm_db_backup_script_v1.sh` to `CAST/csmtest/buckets/basic/db_script.sh`.  Going to fast track this pull request, since it is a minor change, but purpose of pull request is two-fold

1. Add coverage for `csm_db_backup_script_v1.sg` to CSM FVT regression
2. Changes to serve as reference for @williammorrison2 while he implements additions to regression for remaining CSM DB utility scripts