### PR TITLE
Issue #496: prospectors->inputs.

### DIFF
--- a/csm_big_data/beats/config/filebeat.yml
+++ b/csm_big_data/beats/config/filebeat.yml
@@ -1,4 +1,4 @@
-filebeat.prospectors:
+filebeat.inputs:
 - type: log
   enabled: true
   paths:

--- a/docs/source/cast-big-data/data-aggregators.rst
+++ b/docs/source/cast-big-data/data-aggregators.rst
@@ -731,7 +731,7 @@ given below:
 
 .. code-block:: YAML
 
-    filebeat.prospectors:
+    filebeat.inputs:
     - type: log 
       enabled: true
       paths:
@@ -918,7 +918,7 @@ given below:
 
 .. code-block:: YAML
 
-    filebeat.prospectors:
+    filebeat.inputs:
     - type: log
       enabled: true
       paths:


### PR DESCRIPTION
Simple rename for the filebeats file to handle deprecation of prospectors.

Doesn't need regression, doc and BDS changes only.