### PR TITLE
CSM FVT: Added new enable_ssl.sh tool and SSL test cases to infrastructure bucket

### DIFF
--- a/csmtest/buckets/error_injection/infrastructure.sh
+++ b/csmtest/buckets/error_injection/infrastructure.sh
@@ -324,7 +324,7 @@ echo "Test Case 24: Stop compute daemon, health check, compute unresponsive, RAS
 xdsh ${SINGLE_COMPUTE} "systemctl stop csmd-compute"
 sleep 1
 xdsh ${SINGLE_COMPUTE} "systemctl is-active csmd-compute" > /dev/null
-check_return_exit $? 1 "Test Case 24: Compute is active"
+check_return_exit $? 1 "Test Case 24: Compute is not active"
 ${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
 check_return_exit $? 0 "Test Case 24: Health Check"
 check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Utility Nodes:1" "COMPUTE: ${SINGLE_COMPUTE} (bounced=1; version=n/a; link=ANY)"
@@ -371,6 +371,93 @@ ${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
 check_return_exit $? 0 "Test Case 27: Health Check"
 check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Utility Nodes:1" "COMPUTE: ${SINGLE_COMPUTE} (bounced=0;" "Active: 1" "AGGREGATOR: ${AGGREGATOR_A} (bounced=1;"
 check_return_flag $? "Test Case 27: Validating Health Check output"
+
+# Restart Daemons - SSL section
+echo "------------------------------------------------------------" >> ${LOG}
+echo "Restarting Daemons..." >> ${LOG}
+echo "------------------------------------------------------------" >> ${LOG}
+shutdown_daemons
+
+echo "SSL Section" >> ${LOG}
+${FVT_PATH}/tools/enable_ssl.sh
+
+# Test Case 28: Start master daemon, health check, nothing but master
+echo "Test Case 28: Start master daemon, health check, nothing but master" >> ${LOG}
+systemctl start csmd-master
+sleep 1
+systemctl is-active csmd-master > /dev/null
+check_return_exit $? 0 "Test Case 28: Master is active"
+${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 28: Health Check"
+check_all_output "MASTER: ${MASTER}" "Aggregators:0" "Utility Nodes:0"
+check_return_flag $? "Test Case 28: Validating Health Check output"
+
+# Test Case 29: Start aggregator daemon, health check, aggregator daemon present
+echo "Test Case 29: Start aggregator daemon, health check, aggregator daemon present" >> ${LOG}
+xdsh ${AGGREGATOR_A} "systemctl start csmd-aggregator"
+sleep 1
+xdsh ${AGGREGATOR_A} "systemctl is-active csmd-aggregator" > /dev/null
+check_return_exit $? 0 "Test Case 29: Aggregator is active"
+${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 29: Health Check"
+check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Utility Nodes:0"
+check_return_flag $? "Test Case 29: Validating Health Check output"
+
+# Test Case 30: Start utility daemon, health check, utility and aggregator daemon present
+echo "Test Case 30: Start utility daemon, health check, utility and aggregator daemon present" >> ${LOG}
+xdsh utility "systemctl start csmd-utility"
+sleep 1
+xdsh utility "systemctl is-active csmd-utility" > /dev/null
+check_return_exit $? 0 "Test Case 30: Utility is active"
+${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 30: Health Check"
+check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Utility Nodes:1"
+check_return_flag $? "Test Case 30: Validating Health Check output"
+
+# Test Case 31: Start compute daemon, health check, compute is present 
+echo "Test Case 31: Start compute deamon, health check, compute is present" >> ${LOG}
+xdsh ${SINGLE_COMPUTE} "systemctl start csmd-compute"
+sleep 1
+xdsh ${SINGLE_COMPUTE} "systemctl is-active csmd-compute" > /dev/null
+check_return_exit $? 0 "Test Case 31: Compute is active"
+${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 31: Health Check"
+check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Utility Nodes:1" "COMPUTE: ${SINGLE_COMPUTE}"
+check_return_flag $? "Test Case 31: Validating Health Check output"
+
+# Test Case 32: Stop compute daemon, health check, compute unresponsive, RAS event for csm.status.down
+echo "Test Case 32: Stop compute daemon, health check, compute unresponsive, RAS event for csm.status.down" >> ${LOG}
+xdsh ${SINGLE_COMPUTE} "systemctl stop csmd-compute"
+sleep 1
+xdsh ${SINGLE_COMPUTE} "systemctl is-active csmd-compute" > /dev/null
+check_return_exit $? 1 "Test Case 32: Compute is not active"
+${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 32: Health Check"
+check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Utility Nodes:1" "COMPUTE: ${SINGLE_COMPUTE} (bounced=1; version=n/a; link=ANY)"
+check_return_flag $? "Test Case 32: Validating Health Check output"
+${CSM_PATH}/csm_ras_event_query -l ${SINGLE_COMPUTE} -m "csm.status.down" > ${TEMP_LOG} 2>&1
+check_all_output "Total_Records: 1"
+check_return_flag $? "Test Case 32: Validating csm_ras_event_query output"
+
+# Test Case 33: Stop utility daemon, health check, utility disconnected
+echo "Test Case 33: Stop utility daemon, health check, utility disconnected" >> ${LOG}
+xdsh utility "systemctl stop csmd-utility"
+sleep 1
+xdsh utility "systemctl is-active csmd-utility" > /dev/null
+check_return_exit $? 1 "Test Case 33: Utility is not active"
+${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 33: Health Check"
+check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Unresponsive Utility Nodes: 1" "COMPUTE: ${SINGLE_COMPUTE} (bounced=1; version=n/a; link=ANY)"
+
+# Test Case 34: Stop aggregator deamon, health check, aggregator disconnected
+echo "Test Case 34: Stop aggregator daemon, health check, aggregator disconnected"
+xdsh ${AGGREGATOR_A} "systemctl stop csmd-aggregator"
+sleep 1
+xdsh ${AGGREGATOR_A} "systemctl is-active csmd-aggregator" > /dev/null
+check_return_exit $? 1 "Test Case 34: Aggregator is not active"
+${CSM_PATH}/csm_infrastructure_health_check -v > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 34: Health Check"
+check_all_output "MASTER: ${MASTER}" "Aggregators:1" "Unresponsive Utility Nodes: 1" "Unresponsive Aggregators: 1"  
 
 # Clean up Temp Log
 rm -f ${TEMP_LOG}

--- a/csmtest/tools/enable_ssl.sh
+++ b/csmtest/tools/enable_ssl.sh
@@ -1,0 +1,77 @@
+#================================================================================
+#
+#    tools/complete_fvt.sh
+#
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+if [ -f "${BASH_SOURCE%/*}/../csm_test.cfg" ]
+then
+        . "${BASH_SOURCE%/*}/../csm_test.cfg"
+else
+        echo "Could not find csm_test.cfg file expected at "${BASH_SOURCE%/*}/../csm_test.cfg", exitting."
+        exit 1
+fi
+
+if [ -f "${BASH_SOURCE%/*}/../include/functions.sh" ]
+then
+        . "${BASH_SOURCE%/*}/../include/functions.sh"
+else
+        echo "Could not find functions file expected at /../../include/functions.sh, exitting."
+        exit 1
+fi
+
+# Create cert directory on remote nodes
+xdsh utility "mkdir /root/cert"
+xdsh ${AGGREGATOR_A} "mkdir /root/cert"
+xdsh ${AGGREGATOR_B} "mkdir /root/cert"
+xdsh ${COMPUTE_NODES} "mkdir /root/cert"
+
+# Distribute xCAT certificate authority, credential files
+xdcp utility /etc/xcat/cert/ca.pem /root/cert/
+xdcp utility /etc/xcat/cert/server-cred.pem /root/cert
+xdcp ${AGGREGATOR_A} /etc/xcat/cert/ca.pem /root/cert/
+xdcp ${AGGREGATOR_A} /etc/xcat/cert/server-cred.pem /root/cert
+xdcp ${AGGREGATOR_B} /etc/xcat/cert/ca.pem /root/cert/
+xdcp ${AGGREGATOR_B} /etc/xcat/cert/server-cred.pem /root/cert
+xdcp ${COMPUTE_NODES} /etc/xcat/cert/ca.pem /root/cert/
+xdcp ${COMPUTE_NODES} /etc/xcat/cert/server-cred.pem /root/cert
+
+# Modify CSM config files
+cd /etc/ibm/csm/
+sed -i -- "/ca_file/c\                \"ca_file\": \"/etc/xcat/cert/ca.pem\"," csm_master.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/etc/xcat/cert/server-cred.pem\"" csm_master.cfg
+sed -i -- "/ca_file/c\                \"ca_file\": \"/root/cert/ca.pem\"," csm_utility.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/root/cert/server-cred.pem\"" csm_utility.cfg
+sed -i -- "/ca_file/c\                \"ca_file\": \"/root/cert/ca.pem\"," csm_aggregator_A.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/root/cert/server-cred.pem\"" csm_aggregator_A.cfg
+sed -i -- "/ca_file/c\                \"ca_file\": \"/root/cert/ca.pem\"," csm_aggregator_B.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/root/cert/server-cred.pem\"" csm_aggregator_B.cfg
+sed -i -- "/ca_file/c\                \"ca_file\": \"/root/cert/ca.pem\"," csm_compute_A.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/root/cert/server-cred.pem\"" csm_compute_A.cfg
+sed -i -- "/ca_file/c\                \"ca_file\": \"/root/cert/ca.pem\"," csm_compute_B.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/root/cert/server-cred.pem\"" csm_compute_B.cfg
+sed -i -- "/ca_file/c\                \"ca_file\": \"/root/cert/ca.pem\"," csm_compute.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/root/cert/server-cred.pem\"" csm_compute.cfg
+sed -i -- "/ca_file/c\                \"ca_file\": \"/root/cert/ca.pem\"," csm_aggregator.cfg
+sed -i -- "/cred_pem/c\                \"cred_pem\": \"/root/cert/server-cred.pem\"" csm_aggregator.cfg
+
+# Distribute CSM config files 
+xdcp utility /etc/ibm/csm/csm_utility.cfg /etc/ibm/csm/csm_utility.cfg
+xdcp ${AGGREGATOR_A} /etc/ibm/csm/csm_aggregator_A.cfg /etc/ibm/csm/csm_aggregator.cfg
+xdcp ${AGGREGATOR_B} /etc/ibm/csm/csm_aggregator_B.cfg /etc/ibm/csm/csm_aggregator.cfg
+xdcp compute_A /etc/ibm/csm/csm_compute_A.cfg /etc/ibm/csm/csm_compute.cfg
+xdcp compute_B /etc/ibm/csm/csm_compute_B.cfg /etc/ibm/csm/csm_compute.cfg
+# If csm_compute_A/B.cfg does not exist, distribute in single aggregator config
+if [ ! -f /etc/ibm/csm/csm_compute_A.cfg ]
+then
+	xdcp csm_comp /etc/ibm/csm/csm_compute.cfg /etc/ibm/csm/csm_compute.cfg
+fi


### PR DESCRIPTION
New CSM FVT tool `enable_ssl.sh` will edit and distribute configuration files to FVT cluster to enable daemon-to-daemon SSL connections.  `enable_ssl.sh` is available for standalone use and incorporated in to new infrastructure error injection test cases to exercise the SSL daemon-to-daemon connection functionality.

New test cases are fairly straight forward:
- Bring up master, aggregator, utility, compute daemons in order. Query connections intermittently
- Tear down connections by stopping compute, utility, and aggregator daemons in order.  Query connections intermittently 

We can discuss adding additional test cases/conditions for passing test run, but I think this is good as a first pass
