### PR TITLE
Prefer Pre-Incrementing rather than Post-Incrementing

### DIFF
--- a/bb/src/BBLV_Metadata.cc
+++ b/bb/src/BBLV_Metadata.cc
@@ -50,7 +50,7 @@ int BBLV_Metadata::update_xbbServerAddData(txp::Msg* pMsg, const uint64_t pJobId
                 for(auto& elements: boost::make_iterator_range(bfs::directory_iterator(job), {}))
                 {
                     LOG(bb,info) << "elements: " << elements;
-                    count++;
+                    ++count;
                 }
                 LOG(bb,info) << "xbbServer: JobId " << pJobId << " is already registered and currently has " << count << " associated job step(s)";
             }


### PR DESCRIPTION
Change count++ to ++count to save the additional storage from using the post-increment.

For example consider the following:
```
class Integer {

  public:

  // Sample implementation of pre-incrementing.
  Integer & operator++() {
    myInt += 1;
    return *this;
  }
  // Sample implementation of post-incrementing.
  const Integer operator++(int) {
    Integer temporary = *this;
    ++*this;
    return temporary;
  }

  private:

  int myInt;
};
```

The additional copy (temporary) in post-incrementing step is unnecessary.

