### PR TITLE
CSM / UFM Integration - Feature Improvement

### DIFF
--- a/csm_big_data/logstash/patterns/events.yml
+++ b/csm_big_data/logstash/patterns/events.yml
@@ -48,15 +48,14 @@ data_sources:                                  # Mandatory, Map with the keys co
   event_data:    "message" 
   category_key:  "program_name" 
   categories:
-   eventlog:
-     - tag:        "UFM_391"
-       pattern:    "."
+    eventlog:
+     - tag:        "UFM_LOCATION"
+       pattern:    "%{MELLANOX_INFO}"
        ras_msg_id: "ufm.%{event_type}.%{event_id}"
-       action:     ".send_ras;" 
+       action:     "post_ras(ras_msg_id,%{hostname},%{timestamp},%{message});"
+
      - tag:        "UFM_GENERIC"
        pattern:    "."
        ras_msg_id: "ufm.%{event_type}.%{event_id}"
-       action:     ".send_ras;" 
-
-
+       action:     ".send_ras;"
 ...

--- a/csm_big_data/logstash/patterns/events.yml
+++ b/csm_big_data/logstash/patterns/events.yml
@@ -49,6 +49,10 @@ data_sources:                                  # Mandatory, Map with the keys co
   category_key:  "program_name" 
   categories:
    eventlog:
+    - tag:        "UFM_391"
+       pattern:    "."
+       ras_msg_id: "ufm.%{event_type}.%{event_id}"
+       action:     ".send_ras;" 
      - tag:        "UFM_GENERIC"
        pattern:    "."
        ras_msg_id: "ufm.%{event_type}.%{event_id}"

--- a/csm_big_data/logstash/patterns/events.yml
+++ b/csm_big_data/logstash/patterns/events.yml
@@ -49,7 +49,7 @@ data_sources:                                  # Mandatory, Map with the keys co
   category_key:  "program_name" 
   categories:
    eventlog:
-    - tag:        "UFM_391"
+     - tag:        "UFM_391"
        pattern:    "."
        ras_msg_id: "ufm.%{event_type}.%{event_id}"
        action:     ".send_ras;" 

--- a/csm_big_data/logstash/patterns/mellanox_grok.conf
+++ b/csm_big_data/logstash/patterns/mellanox_grok.conf
@@ -1,18 +1,16 @@
 MELLANOXTIME %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{TIME}
 
-MELLANOXCORE %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category}
+# MELLANOXCORE %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category}
 
-MELLANOX_INFO_full_location_path \[%{GREEDYDATA:scope} / %{GREEDYDATA:device}\: %{HOSTNAME:hostname} / %{GREEDYDATA:module} / %{GREEDYDATA:port}\]
+MELLANOX_INFO_full_location_path \[%{GREEDYDATA:scope} / %{GREEDYDATA:device}\: %{HOSTNAME:hostname} .*/ %{GREEDYDATA:module} / %{GREEDYDATA:port}\]
 
 MELLANOX_INFO_device \[dev_id: %{WORD:dev_id}\]:
 
 MELLANOX_INFO %{MELLANOX_INFO_full_location_path} %{MELLANOX_INFO_device} %{GREEDYDATA:message}
 
-# MELLANOXMSG_391 %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} [default(62) / Switch: %{HOSTNAME:switch_host} / FAN 4 / NA] [dev_id: 248a070300fd6100]: %{GREEDYDATA:message}
-
 MELLANOXMSG %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} %{GREEDYDATA:message}
 
-# MELLANOXMSG %{MELLANOXCORE} %{MELLANOX_INFO}
+# MELLANOXMSG_location %{MELLANOXCORE} %{MELLANOX_INFO}
 
 GUID [0-9a-f]{16}
 

--- a/csm_big_data/logstash/patterns/mellanox_grok.conf
+++ b/csm_big_data/logstash/patterns/mellanox_grok.conf
@@ -1,5 +1,7 @@
 MELLANOXTIME %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{TIME}
 
+MELLANOXMSG_391 %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} [default(62) / Switch: %{HOSTNAME:switch_host} / FAN 4 / NA] [dev_id: 248a070300fd6100]: %{GREEDYDATA:message}
+
 MELLANOXMSG %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} %{GREEDYDATA:message}
 
 GUID [0-9a-f]{16}
@@ -10,6 +12,8 @@ SOURCE_LINK \[Source .*TO Dest:.*\]:
 328 %{SOURCE_LINK} Link (is up|went down)?: %{GUID} \((Switch|Computer): %{HOSTNAME:s_host}( {HOSTNAME})?\) : %{NUMBER:s_port} - %{GUID} \((Switch|Computer): %{HOSTNAME:d_host}( %{HOSTNAME})?\) : %{NUMBER:d_port}
 
 329 %{328}
+
+# 391 %{GREEDYDATA}
 # ++++++++++++++++++++++++++++++++++++++++
 
 

--- a/csm_big_data/logstash/patterns/mellanox_grok.conf
+++ b/csm_big_data/logstash/patterns/mellanox_grok.conf
@@ -1,6 +1,12 @@
 MELLANOXTIME %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{TIME}
 
-MELLANOXMSG_391 %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} [default(62) / Switch: %{HOSTNAME:switch_host} / FAN 4 / NA] [dev_id: 248a070300fd6100]: %{GREEDYDATA:message}
+MELLANOXCORE %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category}
+
+MELLANOX_INFO_device \[dev_id: %{WORD:dev_id}\]:
+
+MELLANOX_INFO \[%{GREEDYDATA:MELLANOX_INFO_full_location_path}\] %{MELLANOX_INFO_device} %{GREEDYDATA:message}
+
+# MELLANOXMSG_391 %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} [default(62) / Switch: %{HOSTNAME:switch_host} / FAN 4 / NA] [dev_id: 248a070300fd6100]: %{GREEDYDATA:message}
 
 MELLANOXMSG %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} %{GREEDYDATA:message}
 

--- a/csm_big_data/logstash/patterns/mellanox_grok.conf
+++ b/csm_big_data/logstash/patterns/mellanox_grok.conf
@@ -2,13 +2,17 @@ MELLANOXTIME %{YEAR}-%{MONTHNUM}-%{MONTHDAY} %{TIME}
 
 MELLANOXCORE %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category}
 
+MELLANOX_INFO_full_location_path \[%{GREEDYDATA:scope} / %{GREEDYDATA:device}\: %{HOSTNAME:hostname} / %{GREEDYDATA:module} / %{GREEDYDATA:port}\]
+
 MELLANOX_INFO_device \[dev_id: %{WORD:dev_id}\]:
 
-MELLANOX_INFO \[%{GREEDYDATA:MELLANOX_INFO_full_location_path}\] %{MELLANOX_INFO_device} %{GREEDYDATA:message}
+MELLANOX_INFO %{MELLANOX_INFO_full_location_path} %{MELLANOX_INFO_device} %{GREEDYDATA:message}
 
 # MELLANOXMSG_391 %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} [default(62) / Switch: %{HOSTNAME:switch_host} / FAN 4 / NA] [dev_id: 248a070300fd6100]: %{GREEDYDATA:message}
 
 MELLANOXMSG %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} %{GREEDYDATA:message}
+
+# MELLANOXMSG %{MELLANOXCORE} %{MELLANOX_INFO}
 
 GUID [0-9a-f]{16}
 


### PR DESCRIPTION
# Include location on CSM RAS event generation

## Purpose
Currently all CSM RAS events generated from UFM events are created with a `location_name` of the originating UFM box. Yet some of the events, even though technically generated from the UFM box, are logically generated from other hardware devices. Example: A fan is pulled from switch: `abc123`.  In this example it would be nice if the CSM RAS event reported the  `location_name` to be the switch's hostname of `abc123` and not `ufmbox-01`. 

This pull request extracts the true location name (for appropriate UFM events) and updates that field for CSM RAS events. 

## Approach
We detected more patterns in UFM events. There is a core UFM message that is consistent across all UFM event messages. 

It consists of a timestamp, log counter, event id, severity level, event type, and category. 

```
%{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} 
```

After this it is possible for two more patterns to exist before the event message. 
- a location path
- a device id
- event message

if those patterns don't exist, then there is only an event message

Our approach, we first see if there is a location path pattern. If there is we extract that info and pass the hostname along to the CSM RAS event. If we do not detect the pattern, we default to our older behavior of RAS event generation and create the generic event as we did before this pull request. 


## Screenshots

Important path of the mellanox grok. Here we introduce the new patterns to look for.
```
MELLANOX_INFO_full_location_path \[%{GREEDYDATA:scope} / %{GREEDYDATA:device}\: %{HOSTNAME:hostname} .*/ %{GREEDYDATA:module} / %{GREEDYDATA:port}\]

MELLANOX_INFO_device \[dev_id: %{WORD:dev_id}\]:

MELLANOX_INFO %{MELLANOX_INFO_full_location_path} %{MELLANOX_INFO_device} %{GREEDYDATA:message}

MELLANOXMSG %{MELLANOXTIME:timestamp} \[%{NUMBER:log_counter}\] \[%{NUMBER:event_id}\] %{WORD:severity} \[%{WORD:event_type}\] %{WORD:category} %{GREEDYDATA:message}
```


Important part of `events.yml`. Here you can see that we test for the new location pattern first, and if there is no match found, then we default to the generic ufm event. 
```
 log-mellanox-event:
  ras_location:  "hostname"
  ras_timestamp: "timestamp"
  event_data:    "message" 
  category_key:  "program_name" 
  categories:
    eventlog:
     - tag:        "UFM_LOCATION"
       pattern:    "%{MELLANOX_INFO}"
       ras_msg_id: "ufm.%{event_type}.%{event_id}"
       action:     "post_ras(ras_msg_id,%{hostname},%{timestamp},%{message});"

     - tag:        "UFM_GENERIC"
       pattern:    "."
       ras_msg_id: "ufm.%{event_type}.%{event_id}"
       action:     ".send_ras;"
```


Below you can see the new benefits of the new code in action: 

```
SELECT * FROM csm_ras_event_action;

 rec_id |           msg_id            | msg_id_seq |         time_stamp         |     master_time_stamp      |    location_name    | count |                     message                     | kvcsv |                                                       raw_data                                                       | archive_history_time 
--------+-----------------------------+------------+----------------------------+----------------------------+---------------------+-------+-------------------------------------------------+-------+----------------------------------------------------------------------------------------------------------------------+----------------------
 44     | ufm.Fabric_Notification.393 |        586 | 2019-01-22 16:34:37.422    | 2019-01-22 16:37:39.537584 | c650f05ib-leaf04-UM |     1 | Switch Module Added                             |       | Module FAN 8 was added to switch c650f05ib-leaf04-UM                                                                 | 
 45     | ufm.Maintenance.604         |        719 | 2019-01-22 16:34:37.423    | 2019-01-22 16:37:39.543358 | c650ufm03           |     1 | Report Succeeded                                |       | [Grid]: Fabric Analysis Report succeeded   
```

Here. There are two events. 393 which is an event that has a location. as a fan is pulled from a specific switch. there other 604, has the default ufm box location as it is a UFM event that is grid/fabric related and therefore does not have a physical location and defaults to the generic pattern we set up in the events.yml file.

## Origin and more information
original issue: https://github.com/IBM/CAST/issues/450

## Reviewer Duties:
- [x] @mew2057 - Check in relation to sanity checks for `csm event correlator` and in relation to fields correctly moving into BDS.  
- [x] @besawn  - check in regards to CSM RAS system
- [x] @pdlun92 - check in regards to FVT
- [ ] @lasch - check in regards to outside and fresh view. see if anything stands out to you as bizarre 
- [x] @fpizzano  - check in regard to feature implementation