### PR TITLE
Fix for Issue #535. Moved source location in filebeats output.

### DIFF
--- a/csm_big_data/transition-scripts/metric-transaction_140-150.py
+++ b/csm_big_data/transition-scripts/metric-transaction_140-150.py
@@ -1,0 +1,68 @@
+#!/bin/python
+
+import os
+import sys
+import glob
+import json
+import argparse
+
+def processLogFile(logfile, outputfile):
+    ''' A function for processing log files and replacing them with the new structure.
+        @timestamp => timestamp
+        source => data.source
+
+        :param logfile: The old format logfile to perform a fix operation on.
+        :param outputfile: An output file to store the fix results on.
+    '''
+
+    for line in logfile:
+        data=json.loads(line)
+        
+        # Move the source field to the data.source field.
+        if 'data' in data :
+            if 'source' in data :
+                data['data']['source']=data.pop('source',None)
+        
+        # Move the @timestamp field to the timestamp field. 
+        timestamp=data.pop('@timestamp',None)
+        if timestamp is not None:
+            data['timestamp'] = timestamp
+    
+        outputfile.write("{0}\n".format(json.dumps(data, ensure_ascii=False,separators=(',', ':'))))
+     
+def main(args):
+    
+    parser = argparse.ArgumentParser(
+        description='''A tool for converting 1.4.0 CSM BDS logs to 1.5.0 CSM BDS logs.''')
+
+    parser.add_argument( '-f', '--files', metavar='file-glob', dest='fileglob', default=None,
+        required=True,
+        help='A file glob containing the bds logs to run the fix operations on.')
+    parser.add_argument( '--overwrite', action='store_true',
+        help='If set the script will overwrite the old files. Default writes new file *.fixed')
+
+    args = parser.parse_args()
+
+    
+    # Open all of the files matching the glob and run the fix.
+    for name in glob.glob(args.fileglob):
+        print("Now Processing: {0}".format(name))
+        outputname="{0}.fixed".format(name)
+
+        if name.endswith("fixed"):
+            print("Detected 'fixed' file, skipping")
+            continue
+
+        with open(name, 'r') as logfile, open(outputname, 'w') as outputfile:
+            processLogFile(logfile, outputfile)
+
+        if args.overwrite:
+            os.rename(outputname, name)
+            outputname=name
+
+        print("Processed {0}, results written to {1}".format(name, outputname))
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+
+

--- a/docs/source/cast-big-data/python-guide.rst
+++ b/docs/source/cast-big-data/python-guide.rst
@@ -323,6 +323,45 @@ This script performs 3 key operations:
 
 3. Opens a socket to a target logstash instance and writes the payload.
 
+
+Transition scripts
+------------------
+
+.. note:: The following scripts are **NOT** shipped in the RPMs.
+
+Sometimes between major versions fields may be renamed in the Big Data Store (this is generally
+only performed in the event of a major bug). When CSM performs such a change a `transition-script`
+will be provided on the GitHub repository in the ``csm_big_data/transition-scripts`` directory.
+
+metric-transaction_140-150.py
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Performs the transition from the `1.4.0` metric and transaction logs to `1.5.0`.
+
+.. code-block:: bash
+
+    # ./metric-transaction_140-150.py -h
+    usage: metric-transaction_140-150.py [-h] -f file-glob [--overwrite]
+    
+    A tool for converting 1.4.0 CSM BDS logs to 1.5.0 CSM BDS logs.
+    
+    optional arguments:
+      -h, --help            show this help message and exit
+      -f file-glob, --files file-glob
+                            A file glob containing the bds logs to run the fix
+                            operations on.
+      --overwrite           If set the script will overwrite the old files.
+                            Default writes new file *.fixed.
+
+The following commands will migrate the old logs to the new format:
+
+.. code-block:: bash
+
+    ./metric-transaction_140-150.py -f '/var/log/ibm/csm/csm_transaction.log*' --overwrite
+    ./metric-transaction_140-150.py -f '/var/log/ibm/csm/csm_allocation_metrics.log*' --overwrite
+
+.. note:: If performing this transition, the old data may need to be purged from BDS (in the case 
+    of the metrics log especially).
 .. _Elastic Tests: https://github.com/IBM/CAST/tree/master/csm_big_data/Python/elastic_tests
 .. _Elasticsearch API: https://pypi.org/project/elasticsearch/
 .. _Installing Packages: https://packaging.python.org/tutorials/installing-packages/#source-distributions-vs-wheels

--- a/utilities/include/logging.h
+++ b/utilities/include/logging.h
@@ -108,7 +108,7 @@ namespace utility
     "\",\"traceid\":" << traceid << ",\"uid\":" << uid << TIMESTAMP_NOW() <<",\"data\":" << data << "}"
 
 #define ALLOCATION(type, source, data) BOOST_LOG(utility::allocation_logger) << "{\"type\":\"" << type << \
-"\",\"source\":\"" << source << "\"" TIMESTAMP_NOW() <<",\"data\":" << data << "}"
+"\""  TIMESTAMP_NOW() <<",\"data\":" << data << ",\"source\":\"" << source << "\"}"
 
 #define setLoggingLevel(subcomponent, setlevel) \
     utility::minlevel[utility::bluecoral_subcomponents::subcomponent] = utility::bluecoral_sevs::setlevel


### PR DESCRIPTION
Fixes an issue where the CSM log collides with the filebeats source field described in Issue #535. The fix moves the `source` field to the `data.source` field.

Wrote a python script to transition existing logs from the old schema to the new one, this script does require the old data to be removed or moved in the BDS.

@pdlun92 This needs a basic regression as the logging mechanism has a slight change.