### PR TITLE
bbcmd copy will ignore blank lines in file list of transfers

### DIFF
--- a/bb/src/bbcmd.cc
+++ b/bb/src/bbcmd.cc
@@ -392,6 +392,7 @@ int bbcmd_copy(po::variables_map& vm)
             
             string src, dst, flags;
             
+            if (!strs.size() ) continue;
             if((strs.size() < 2) || (strs.size() > 3))
             {
                 rc = -1;


### PR DESCRIPTION
Handle blank lines in file list file

Tested with \n termination with blanks and/or tabs and neither.

Regression Tested against robot in sandbox.
