### PR TITLE
Fixing bug with SMT mode in allocation update state.

### DIFF
--- a/csmdb/sql/csm_create_triggers.sql
+++ b/csmdb/sql/csm_create_triggers.sql
@@ -823,7 +823,7 @@ BEGIN
         o_state, o_isolated_cores,
         o_primary_job_id, o_secondary_job_id, o_user_flags,
         o_system_flags, o_num_nodes, o_user_name,
-        o_shared, o_num_gpus, o_num_processors,
+        o_num_gpus, o_num_processors,
         o_projected_memory, o_runtime, o_smt_mode
     FROM csm_allocation a
     WHERE allocation_id = i_allocationid;


### PR DESCRIPTION
Fixing a bug in the SQL statement for the update state Stored Procedure.

The shared column was leftover from a previous iteration of the procedure.