### PR TITLE
Fix dynamic_date_formats bug in elasticsearch templates

### DIFF
--- a/csm_big_data/elasticsearch/mappings/templates/cast-allocation.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-allocation.json
@@ -10,7 +10,7 @@
     "mappings": {
         "_doc" : {
 	    "dynamic_date_formats" : 
-		[ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"]
+		[ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"]
 	}
     }
 }

--- a/csm_big_data/elasticsearch/mappings/templates/cast-counters-gpfs.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-counters-gpfs.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
             }

--- a/csm_big_data/elasticsearch/mappings/templates/cast-counters-ufm.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-counters-ufm.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
             }

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-dimm-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-dimm-env.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-gpu-counters.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-gpu-counters.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
                 "data": {

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-gpu-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-gpu-env.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-node-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-node-env.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast-csm-processor-env.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-csm-processor-env.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast-db-csm.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-db-csm.json
@@ -13,7 +13,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" : {
                 "@version"   : { "type" : "text" },
                 "@timestamp" : { "type" : "date" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast-log-console.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast-log-console.json
@@ -7,7 +7,7 @@
     "mappings": {
         "_doc" : {
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"],
             "properties" :
             {
                 "hostname"     : { "type" : "text" },

--- a/csm_big_data/elasticsearch/mappings/templates/cast.json
+++ b/csm_big_data/elasticsearch/mappings/templates/cast.json
@@ -14,7 +14,7 @@
                 "type"       : { "type" : "text" } 
             },
 	        "dynamic_date_formats" : 
-		        [ "strict_date_optional_time|yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"]
+		        [ "strict_date_optional_time","yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z||yyyy-MM-dd HH:mm:ss.SSSSSS"]
         }
     }
 }


### PR DESCRIPTION
In dynamic_date_formats "strict_date_optional_time" needs to be a
separate comma-separated option, not or'ed with the date time patterns.

Fixes #547
