### PR TITLE
IRQ Daemon Fix

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
@@ -1062,7 +1062,7 @@ int CGroup::IRQRebalance( const std::string CPUs, bool startIRQBalance )
             // Build a verbose error for the user.
             if ( errorCode != 0 )
             {
-                LOG(csmapi, warning) << "Could not write: \"" << CPUs << "\" to " << affinityList;
+                LOG(csmapi, trace) << "Could not write: \"" << CPUs << "\" to " << affinityList;
             }
         }
     }

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
@@ -28,6 +28,8 @@
 #include "logging.h"   ///< CSM logging.
 #include "cgroup.h" 
 #include "csm_handler_exception.h"
+#include "Agent.h"
+
 #include "csmi/include/csm_api_macros.h" // csm_get_enum_from_stringget_enum_from_string
 
 
@@ -1016,24 +1018,24 @@ int CGroup::IRQRebalance( const std::string CPUs )
 {
     LOG(csmapi, trace) << "CGroup::IRQRebalance Enter";
     // stop irqbalance
-    /*
+    
     char* scriptArgs[] = { (char*)"/bin/systemctl", (char*)"stop", (char*)"irqbalance", NULL };
 
     errno = 0;
-    int exit = execv(*scriptArgs, scriptArgs);
-    if ( exit != -1 )
-    {
-        LOG(csmapi, debug) << "CGroup::IRQRebalance: IRQ Balance Completed successfully";
-    }
-    else
-    {
-        exit = errno;
-        LOG(csmapi, error) << "CGroup::IRQRebalance: IRQ Balance Failed; Error Code: " << std::to_string(exit)
-            << "; Error Message: " << strerror(exit);
-        errno=0;
-
-    }
-    */
+    ForkAndExec(scriptArgs);
+    //int exit = execv(*scriptArgs, scriptArgs);
+    //if ( exit != -1 )
+    //{
+    //    LOG(csmapi, debug) << "CGroup::IRQRebalance: IRQ Balance Completed successfully";
+    //}
+    //else
+    //{
+    //    exit = errno;
+    //    LOG(csmapi, error) << "CGroup::IRQRebalance: IRQ Balance Failed; Error Code: " << std::to_string(exit)
+    //        << "; Error Message: " << strerror(exit);
+    //    errno=0;
+    //}
+   
     
     #define IRQ_PATH "/proc/irq/"
     const char* CPUList = CPUs.c_str();

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
@@ -245,10 +245,13 @@ private:
      * @brief Applies the IRQ affinity using the irqbalance daemon in oneshot mode.
      *
      * @param[in] bannedCPUs A list of banned CPUs as hex strings, sets env `IRQBALANCE_BANNED_CPUS`.
+     * @param[in] startIRQBalance If set true the IRQBalance daemon will be started, if set false
+     *  it will stop the IRQBalance Daemon.
+     *
      *
      * @return 0 on success, errno on failure.
      */
-    static int IRQRebalance(const std::string bannedCPUs);
+    static int IRQRebalance(const std::string bannedCPUs, bool startIRQBalance);
 
     /** @brief Write the supplied value to the specified parameter for the controller.
      *


### PR DESCRIPTION
Stopping the IRQ daemon was crashing CSM silently. Replaced the old exec with a nohupped operation to stop the daemon. 

Should now successfully stop the IRQBalance Daemon when `jitter_mitigation.irq_affinity` is set to true.