### PR TITLE
an example of how to use xCAT restful python APIs and CSM python APIs to use an xCAT noderange

### DIFF
--- a/csmi/python_samples/node_attributes_query_with_xcat.py
+++ b/csmi/python_samples/node_attributes_query_with_xcat.py
@@ -1,0 +1,94 @@
+#!/bin/python
+# encoding: utf-8
+#================================================================================
+#
+#    node_attributes_query.py
+#
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+# import generic
+import sys
+import requests
+import json
+
+#add the python library to the path 
+sys.path.append('/opt/ibm/csm/lib')
+
+# import csm
+# eventually append the path as part of an rpm install 
+import lib_csm_py as csm
+import lib_csm_inv_py as inv
+from pprint import pprint
+
+# Get the node names from xcat
+
+XCATMN        = "127.0.0.1"
+username      = "wsuser"
+password = "cluster_rest"
+
+
+
+REST_ENDPOINT    = "https://" + XCATMN + "/xcatws"
+create_node      = REST_ENDPOINT + "/nodes/"
+get_all_nodes    = REST_ENDPOINT + "/nodes/"
+get_token = REST_ENDPOINT + "/tokens"
+
+get_node_range    = REST_ENDPOINT + "/nodes/n[1-3]/nodels"
+
+
+#
+# Send a request to get all nodes, passing in user and password
+#
+all_nodes = requests.get(get_node_range + "?userName=" + username + "&userPW=" + password, verify=False)
+
+# Display returned data
+print "List of all nodes extracted with userid and password:"
+print all_nodes.content
+
+
+# CSM API
+
+csm.init_lib()
+
+input = inv.node_attributes_query_input_t()
+#input.node_names = ["node_01", "n01"]
+#input.node_names_count = len(input.node_names)
+nodes=["node_01","n01"]
+input.set_node_names(nodes)
+#input.set_node_names(["node_01","n01"])
+input.limit=-1
+input.offset=-1
+
+rc,handler,output = inv.node_attributes_query(input)
+
+if(rc == csm.csmi_cmd_err_t.CSMI_SUCCESS):
+    for i in range (0, output.results_count):
+        node = output.get_results(i)
+        pprint(node.node_name)
+        pprint(node.collection_time)
+        pprint(node.update_time)
+        print(node.state)
+        print("node_state_value: " + str(node.state))
+        pprint(node.state)
+        pprint("node_state_value: " + str(node.state))
+        print(node.state)
+        print(node.node_name)
+        #print(csm.csm_get_string_from_enum(csm.csmi_node_state_t, node.state))
+else:
+    print("No matching records found.")
+	
+# csm_get_string_from_enum(csmi_node_state_t, output->results[i]->state)
+
+
+csm.api_object_destroy(handler)
+
+csm.term_lib()

--- a/docs/source/csm-apis/csm_python_guide.md
+++ b/docs/source/csm-apis/csm_python_guide.md
@@ -218,7 +218,7 @@ did not match C++ signature:
 
 ```
 
-When using the `set_` function to set an array for CSM. The python list should be encoded via `utf8`. A list encoded via `unicode` can not be properly set. 
+When using the `set_` function to set a `string` array for CSM. The python list should be encoded via `utf8`. A list encoded via `unicode` can not be properly set. 
 
 Example:
 ```Python

--- a/docs/source/csm-apis/csm_python_guide.md
+++ b/docs/source/csm-apis/csm_python_guide.md
@@ -10,6 +10,7 @@
 1. [Conclusion](#conclusion)
 1. [FAQ - Frequently Asked Questions](#faq---frequently-asked-questions)
    1. [How do I access and set arrays in the CSM Python library?](#how-do-i-access-and-set-arrays-in-the-csm-python-library)
+   1. [Why am I getting an error when I use "set_ARRAY()" with my python list?](#why-am-i-getting-an-error-when-i-use-set-array-with-my-python-list)
 
 ## About
 The CSM API Python Bindings library works similar to other C Python binding libraries. CSM APIs can be accessed in Python because they are bound to C via Boost. More technical details can be found here: https://wiki.python.org/moin/boost.python/GettingStarted but understanding all of this is not required to use CSM APIs in Python. This guide provides a central location for users looking to utilize CSM APIs via Python. If you believe this guide to be incomplete, then please make a pull request with your additional content. 
@@ -197,3 +198,31 @@ Once `nodes` has been defined, we can call: `set_node_names(nodes)`.
 Arrays in the CSM Python library must be set using this `set_` function. Following the pattern of `set_ARRAYNAME`. The `set_` function requires a single parameter of a populated array. (Here that is `nodes`.) The array names and fields of a CSM struct are the same as the C versions. Please look at CSM API documentation for a list of your struct and struct field names. 
 
 So in our example here, our struct has an array named `node_names`. To set it, we must call `input.set_node_names(nodes)`. `nodes` here represents the Python array we already created in the previous line. `input` represents the parent struct that contains this array. 
+
+### Why am I getting an error when I use "set_ARRAY()" with my python list?
+
+Common errors: 
+
+```
+TypeError: No registered converter was able to produce a C++ rvalue of type std::string from this Python object of type unicode
+```
+
+```
+Traceback (most recent call last):
+  File "node_attributes_query_with_xcat.py", line 95, in <module>
+    input.set_node_names(nodes_j)
+Boost.Python.ArgumentError: Python argument types in
+    node_attributes_query_input_t.set_node_names(node_attributes_query_input_t, dict)
+did not match C++ signature:
+    set_node_names(csm_node_attributes_query_input_t {lvalue}, boost::python::list {lvalue} e)
+
+```
+
+When using the `set_` function to set an array for CSM. The python list should be encoded via `utf8`. A list encoded via `unicode` can not be properly set. 
+
+Example:
+```Python
+nodes_j1 = [x.encode('utf8') for x in nodes_j]
+```
+
+


### PR DESCRIPTION
# an example of how to use xCAT restful python APIs and CSM python APIs to use an xCAT noderange

## Purpose
We want to be able to use an xCAT noderange or nodegroup with CSM APIs.

## Approach
This approach uses the python wrapper for CSM APIs. By writing a python script we can first call xCAT python restful APIs to get the nodes in a node range, then save that and pass it into the input of a CSM API, such as `node attributes query`. 

## Contents
This pull request includes :
- an example of how to use xCAT restful python APIs and CSM python APIs to use an xCAT noderange
- An update to the FAQ section of CSM python APIs read the docs to include a note about utf8 encoding. 

## How to Test
1. Nothing to new to test. This pull request add in an example python script of how to use an xCAT node range. not meant to be used in production.
2. Example works and has been tested.

## Origin:
original issue: https://github.com/IBM/CAST/issues/222

