### PR TITLE
Activelist Warning Rework

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationAgentUpdateState.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationAgentUpdateState.cc
@@ -555,41 +555,25 @@ int AllocationAgentUpdateState::RegisterAllocation( int64_t allocationId, const 
     int errorCode = 0;
     std::string allocationString(username);
     allocationString.append(";").append(std::to_string(allocationId)).append("\n");
-    
-    int openFlag = O_WRONLY | O_CLOEXEC;
-    
-    if ( shared )
-        openFlag |= O_APPEND;
-    else
-        openFlag |= O_TRUNC;
 
-    // Open the file descriptor.
-    errno=0;
-    int fileDescriptor = open(CSM_ACTIVELIST, openFlag );
-    errorCode = errno;
-
-    // Attempt to write the descriptor.
-    if( fileDescriptor >= 0 )
+    std::ofstream activelistStream(CSM_ACTIVELIST);
+    try
     {
-        errno=0;
-        write( fileDescriptor, allocationString.c_str(), allocationString.size() );
-        errorCode = errno;
-
-        errno=0;
-        close( fileDescriptor );
-    }
+        activelistStream << allocationString;
     
-    // If the error code is not zero report a warning.
-    if ( errorCode != 0 )
-    {
-        LOG( csmapi, warning ) <<  "Allocation ID: "
+        // Close the stream so it can be swapped.
+        activelistStream.close();
+
+    } catch (const std::ifstream::failure& e){
+        LOG( csmapi, error ) <<  "Allocation ID: "
             << std::to_string(allocationId) << 
-            "; Message: Unable to register allocation with daemon; errno string: "
-            << strerror(errorCode);
+            "; Message: Unable to register allocation with daemon; Extended Message: "
+            << e.what();
+        errorCode = 1;
     }
 
     LOG( csmapi, trace ) << STATE_NAME ":RegisterAllocation; Exit";
-
+    
     return errorCode;
 }
 
@@ -629,6 +613,7 @@ int AllocationAgentUpdateState::RemoveAllocation( int64_t allocationId )
             
             // Swap the temporary list with the official one.
             if ( !std::remove(CSM_ACTIVELIST) ) 
+                std::rename(CSM_ACTIVELIST_SWAP, CSM_ACTIVELIST);
                 LOG( csmapi, warning ) <<  "Allocation ID: " << std::to_string(allocationId)
                     << "; Message: Activelist couldn't be removed;";
 

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationAgentUpdateState.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationAgentUpdateState.cc
@@ -612,11 +612,7 @@ int AllocationAgentUpdateState::RemoveAllocation( int64_t allocationId )
             activelistSwapStream.close();
             
             // Swap the temporary list with the official one.
-            if ( !std::remove(CSM_ACTIVELIST) ) 
-                std::rename(CSM_ACTIVELIST_SWAP, CSM_ACTIVELIST);
-                LOG( csmapi, warning ) <<  "Allocation ID: " << std::to_string(allocationId)
-                    << "; Message: Activelist couldn't be removed;";
-
+            std::remove(CSM_ACTIVELIST);
             if ( !std::rename(CSM_ACTIVELIST_SWAP, CSM_ACTIVELIST) )
                 LOG( csmapi, warning ) <<  "Allocation ID: " << std::to_string(allocationId)
                 << "; Message: Activelist couldn't be swapped;";

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationAgentUpdateState.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationAgentUpdateState.cc
@@ -613,7 +613,7 @@ int AllocationAgentUpdateState::RemoveAllocation( int64_t allocationId )
             
             // Swap the temporary list with the official one.
             std::remove(CSM_ACTIVELIST);
-            if ( !std::rename(CSM_ACTIVELIST_SWAP, CSM_ACTIVELIST) )
+            if ( std::rename(CSM_ACTIVELIST_SWAP, CSM_ACTIVELIST) )
                 LOG( csmapi, warning ) <<  "Allocation ID: " << std::to_string(allocationId)
                 << "; Message: Activelist couldn't be swapped;";
         }


### PR DESCRIPTION
Removing the entry from the activelist no longer triggers warning messages on allocation delete.