### PR TITLE
Adding SSD wear collection to CSM

### DIFF
--- a/csmconf/csm_compute.cfg
+++ b/csmconf/csm_compute.cfg
@@ -54,10 +54,10 @@
 
         "jitter_mitigation" :
         {
-            "system_map"     : "F03C0",
-            "system_smt"     : 0,
-            "irq_affinity"   : true,
-            "socket_order"   : "00"
+            "system_smt"         : 0,
+            "irq_affinity"       : false,
+            "core_isolation_max" : 4,
+            "socket_order"       : "00"
         },
 
         "data_collection" :
@@ -67,6 +67,10 @@
                     {
                         "execution_interval":"00:10:00",
                         "item_list": ["gpu", "environmental"]                        
+                    },
+                    {
+                        "execution_interval":"24:00:00",
+                        "item_list": ["ssd"]
                     }
                 ]
         }

--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -2,7 +2,7 @@
 #
 #    csmd/setupRPM.cmake
 #
-#  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -30,3 +30,4 @@ set( CPACK_RPM_csm-core_POST_UNINSTALL_SCRIPT_FILE
 set( CPACK_RPM_csm-core_POST_INSTALL_SCRIPT_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/csmd/rpmscripts/csmd.post.install")
 
+set(CPACK_RPM_csm-core_PACKAGE_REQUIRES "nvme-cli >= 1.4-3")

--- a/csmd/src/daemon/include/bucket_item_type_definitions.h
+++ b/csmd/src/daemon/include/bucket_item_type_definitions.h
@@ -2,7 +2,7 @@
 
     csmd/src/daemon/include/bucket_item_type_definitions.h
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -19,3 +19,4 @@ bucket_item(GPU)
 bucket_item(NETWORK)
 bucket_item(DEFAULT)
 bucket_item(ENVIRONMENTAL)
+bucket_item(SSD)

--- a/csmd/src/daemon/include/csm_event_routing.h
+++ b/csmd/src/daemon/include/csm_event_routing.h
@@ -2,7 +2,7 @@
 
     csmd/src/daemon/include/csm_event_routing.h
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -104,6 +104,7 @@
 
 // Internal Inventory Functions
 #include "src/csmi_request_handler/InvGetNodeInventory.h"
+#include "src/csmi_request_handler/InvSsdWearUpdate.h"
 
 namespace csm {
 namespace daemon {

--- a/csmd/src/daemon/src/CMakeLists.txt
+++ b/csmd/src/daemon/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmd/src/daemon/src/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -122,6 +122,7 @@ file(GLOB CSM_DAEMON_SRC
   csmi_request_handler/csm_infrastructure_test_utility.cc
   csmi_request_handler/csmi_agg_mtc_handler.cc
   csmi_request_handler/InvGetNodeInventory.cc
+  csmi_request_handler/InvSsdWearUpdate.cc
   csmi_request_handler/csm_ctrl_cmd_handler.cc
   csmi_request_handler/csm_daemon_clock.cc
   csmi_request_handler/csm_environmental_handler.cc

--- a/csmd/src/daemon/src/csm_event_routing_master.cc
+++ b/csmd/src/daemon/src/csm_event_routing_master.cc
@@ -101,6 +101,7 @@ void EventRoutingMaster::RegisterHandlers()
    // Internal node inventory functions
    Register<InvGetNodeInventory>(CSM_CMD_INV_get_node_inventory);
    AddInitEventHandler( createInstance_sptr<INV_MASTER_HANDLER>() );
+   Register<InvSsdWearUpdate>(CSM_CMD_ssd_wear_update);
 
    // Environmental data handling
    Register<CSM_ENVDATA_HANDLER>( CSM_environmental_data );

--- a/csmd/src/daemon/src/csmi_request_handler/InvGetNodeInventory.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/InvGetNodeInventory.cc
@@ -489,11 +489,10 @@ bool InvGetNodeInventory::CreateSqlStmt(const std::string& arguments, const uint
         CSMLOGp(csmd, info, SSD_INV) << "   pci_bus_id:                    " << inventory.ssd[i].pci_bus_id;
         CSMLOGp(csmd, info, SSD_INV) << "   fw_ver:                        " << inventory.ssd[i].fw_ver;
         CSMLOGp(csmd, info, SSD_INV) << "   size:                          " << inventory.ssd[i].size;
-        // TODO: Add these to inventory collection 
-        //CSMLOGp(csmd, info, SSD_INV) << "   wear_lifespan_used:            " << inventory.ssd[i].wear_lifespan_used;
-        //CSMLOGp(csmd, info, SSD_INV) << "   wear_total_bytes_written:      " << inventory.ssd[i].wear_total_bytes_written;
-        //CSMLOGp(csmd, info, SSD_INV) << "   wear_total_bytes_read:         " << inventory.ssd[i].wear_total_bytes_read;
-        //CSMLOGp(csmd, info, SSD_INV) << "   wear_percent_spares_remaining: " << inventory.ssd[i].wear_percent_spares_remaining;
+        CSMLOGp(csmd, info, SSD_INV) << "   wear_lifespan_used:            " << inventory.ssd[i].wear_lifespan_used;
+        CSMLOGp(csmd, info, SSD_INV) << "   wear_total_bytes_written:      " << inventory.ssd[i].wear_total_bytes_written;
+        CSMLOGp(csmd, info, SSD_INV) << "   wear_total_bytes_read:         " << inventory.ssd[i].wear_total_bytes_read;
+        CSMLOGp(csmd, info, SSD_INV) << "   wear_percent_spares_remaining: " << inventory.ssd[i].wear_percent_spares_remaining;
         
         // Build the list of ssd serial numbers in the current inventory
         if ( !ssd_serials_out.str().empty() )
@@ -509,9 +508,10 @@ bool InvGetNodeInventory::CreateSqlStmt(const std::string& arguments, const uint
         stmt_out << "fw_ver='" << inventory.ssd[i].fw_ver << "', ";
         stmt_out << "update_time='" << inventory.node.collection_time << "', ";
         stmt_out << "size=" << inventory.ssd[i].size << ", ";
-        // Defaulting wear_lifespan_used to 0 for PRPQ
-        // TODO: Replace this with real data
-        stmt_out << "wear_lifespan_used=0 ";
+        stmt_out << "wear_lifespan_used=" << inventory.ssd[i].wear_lifespan_used << ", ";
+        stmt_out << "wear_total_bytes_written=" << inventory.ssd[i].wear_total_bytes_written << ", ";
+        stmt_out << "wear_total_bytes_read=" << inventory.ssd[i].wear_total_bytes_read << ", ";
+        stmt_out << "wear_percent_spares_remaining=" << inventory.ssd[i].wear_percent_spares_remaining << " ";
         stmt_out << " WHERE node_name IN (SELECT t.node_name FROM csm_node_temp t WHERE ";
         stmt_out << "t.collection_time!='" << inventory.node.collection_time << "') "; 
         stmt_out << "AND serial_number='" << inventory.ssd[i].serial_number << "';" << endl;
@@ -524,16 +524,17 @@ bool InvGetNodeInventory::CreateSqlStmt(const std::string& arguments, const uint
         values_out.str("");
         values_out.clear();
         
-        keys_out << "(node_name, ";           values_out << "'" << inventory.node.node_name << "', ";
-        keys_out << "serial_number, ";        values_out << "'" << inventory.ssd[i].serial_number << "', ";
-        keys_out << "update_time, ";          values_out << "'" << inventory.node.collection_time << "', ";
-        keys_out << "device_name, ";          values_out << "'" << inventory.ssd[i].device_name << "', ";
-        keys_out << "pci_bus_id, ";           values_out << "'" << inventory.ssd[i].pci_bus_id  << "', ";
-        keys_out << "fw_ver, ";               values_out << "'" << inventory.ssd[i].fw_ver  << "', ";
-        keys_out << "size, ";                 values_out << inventory.ssd[i].size << ", ";
-        // Defaulting wear_lifespan_used to 0 for PRPQ
-        // TODO: Replace this with real data
-        keys_out << "wear_lifespan_used) ";   values_out << 0;
+        keys_out << "(node_name, ";                     values_out << "'" << inventory.node.node_name << "', ";
+        keys_out << "serial_number, ";                  values_out << "'" << inventory.ssd[i].serial_number << "', ";
+        keys_out << "update_time, ";                    values_out << "'" << inventory.node.collection_time << "', ";
+        keys_out << "device_name, ";                    values_out << "'" << inventory.ssd[i].device_name << "', ";
+        keys_out << "pci_bus_id, ";                     values_out << "'" << inventory.ssd[i].pci_bus_id  << "', ";
+        keys_out << "fw_ver, ";                         values_out << "'" << inventory.ssd[i].fw_ver  << "', ";
+        keys_out << "size, ";                           values_out << inventory.ssd[i].size << ", ";
+        keys_out << "wear_lifespan_used, ";             values_out << inventory.ssd[i].wear_lifespan_used << ", ";
+        keys_out << "wear_total_bytes_written, ";       values_out << inventory.ssd[i].wear_total_bytes_written << ", ";
+        keys_out << "wear_total_bytes_read, ";          values_out << inventory.ssd[i].wear_total_bytes_read << ", ";
+        keys_out << "wear_percent_spares_remaining)";   values_out << inventory.ssd[i].wear_percent_spares_remaining;
         
         // Now build the statement
         stmt_out << "INSERT INTO " << SSD_TABLE_NAME << " " << keys_out.str();

--- a/csmd/src/daemon/src/csmi_request_handler/InvSsdWearUpdate.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/InvSsdWearUpdate.cc
@@ -1,0 +1,235 @@
+/*================================================================================
+   
+    csmd/src/daemon/src/csmi_request_handler/InvSsdWearUpdate.cc
+
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+ 
+================================================================================*/
+
+#include "InvSsdWearUpdate.h"
+#include "include/csm_event_type_definitions.h"
+
+#ifndef logprefix
+#define logprefix "SSD_WEAR"
+#define logprefix_local
+#endif
+#include "csm_pretty_log.h"
+
+#include "csmd/src/inv/include/inv_ssd_wear_serialization.h"
+#include "csmi/include/csm_api_consts.h"
+
+#include <sstream>
+
+using std::string;
+using std::to_string;
+using std::endl;
+
+void InvSsdWearUpdate::Process(const csm::daemon::CoreEvent &aEvent, std::vector<csm::daemon::CoreEvent*>& postEventList)
+{
+   // set up the context
+   EventContextDBBase_sptr ctx;
+   csm::daemon::EventContext_sptr gen_ctx = aEvent.GetEventContext();
+   if( ! gen_ctx )
+   {
+      ctx = std::make_shared<EventContextDBBase>(this, INITIAL_STATE, CopyEvent(aEvent));
+      if( ! ctx )
+         throw csm::daemon::Exception("ERROR: Context type cannot be created.");
+   }
+   else
+   {
+      ctx = std::dynamic_pointer_cast<EventContextDBBase> (aEvent.GetEventContext() );
+      if( ! ctx )
+         throw csm::daemon::Exception("ERROR: Context type cannot be dyn-casted to EventContextDBBase.");
+   }
+
+   LOG(csmd, debug) << _cmdName << "::Process: mystages = " << ctx->GetAuxiliaryId() << "....";
+   if (ctx->GetAuxiliaryId() == INITIAL_STATE)
+   {
+      if ( !isNetworkEvent(aEvent) )
+      {
+         LOG(csmd, error) << _cmdName << "::Process: Expecting a NetworkEvent";
+         return;
+      }
+      
+      csm::network::Message msg = GetNetworkMessage(aEvent);
+      ctx->SetAuxiliaryId(SEND_DB);
+   }
+
+   switch ( ctx->GetAuxiliaryId() )
+   {
+      case SEND_DB:
+      {
+         LOG(csmd, debug) << _cmdName << "::Process: at SEND_DB";
+         bool create_db_success(false);
+
+         ctx->SetAuxiliaryId(RCV_DB);
+         create_db_success = CreateDbRequest(ctx, *(ctx->GetReqEvent()), postEventList); 
+         if ( create_db_success == false )
+         {
+            ctx->SetAuxiliaryId(DONE);
+            LOG(csmd, debug) << _cmdName << "::Process: at DONE";
+            CSMLOG(csmd, info) << "EVENT COMPLETE";
+         }
+
+         break;
+      }
+          
+      case RCV_DB:
+      {
+         if ( !isDBRespEvent(aEvent) )
+         {
+            LOG(csmd, error) << _cmdName << "::Process: Expecting a DBRespEvent";
+            break;
+         }
+         LOG(csmd, debug) << _cmdName << "::Process at RCV_DB";
+
+         int errcode;
+         std::string errmsg;
+         if ( !InspectDBResult(aEvent, errcode, errmsg) )
+         {
+            LOG(csmd, error) << _cmdName << "::Process: DB errcode=" << errcode << " " << errmsg;
+         }
+         else
+         {
+            LOG(csmd, debug) << _cmdName << "::Process: RCV_DB complete.";
+         }
+         CSMLOG(csmd, info) << "EVENT COMPLETE";
+        
+         ctx->SetAuxiliaryId(DONE);
+         break;
+      }
+
+      default:
+      {
+         LOG(csmd, error) << _cmdName << "::Process: handler entered with context in invalid state: " << ctx->GetAuxiliaryId();
+         break;
+      }
+   }
+}
+
+bool InvSsdWearUpdate::CreateDbRequest(const EventContextDBBase_sptr& ctx, const csm::daemon::CoreEvent& aEvent, 
+   std::vector<csm::daemon::CoreEvent*>& postEventList)
+{
+   CSMLOG(csmd, debug) << "Enter " << __PRETTY_FUNCTION__;
+   csm::daemon::NetworkEvent *ev = (csm::daemon::NetworkEvent *)&aEvent;
+   csm::network::MessageAndAddress req_content = ev->GetContent();
+    
+   if ( HasValidDBConn() == false )
+   {
+      CSMLOG(csmd, error) << "CreateDbRequest: No valid DB connections available.";
+      return false;
+   }
+
+   // Try to unpack the csm_ssd_wear_t update
+   csm_ssd_wear_t ssd_wear;
+   uint32_t bytes_unpacked;
+
+   bytes_unpacked = ssd_wear_unpack(req_content._Msg.GetData(), ssd_wear);
+
+   if ( bytes_unpacked == 0 ) 
+   {
+      CSMLOG(csmd, error) << "CreateDbRequest: failed to unpack ssd wear update message.";
+      return false;
+   }
+   else
+   {
+      const string node_name(ssd_wear.node_name);
+         
+      CSMLOG(csmd, info) << "NEW EVENT: Received ssd wear update from " << node_name << ", discovered_ssds=" << ssd_wear.discovered_ssds;
+      
+      if (ssd_wear.discovered_ssds < 1)
+      {
+         // No wear data to update 
+         return false;
+      }   
+
+      static const string SSD_TABLE_NAME("csm_ssd");
+      std::ostringstream stmt_out;
+      uint32_t param(0);         // Count of SQL parameters    
+     
+      for ( uint32_t i = 0; i < ssd_wear.discovered_ssds; i++ )
+      {
+         const string SSD_WEAR = "SSD_WEAR: " + node_name + "-ssd" + to_string(i) + " sn:" + string(ssd_wear.ssd[i].serial_number);
+         CSMLOGp(csmd, info, SSD_WEAR) << "wear_lifespan_used: " << ssd_wear.ssd[i].wear_lifespan_used
+                                       << " wear_percent_spares_remaining: " << ssd_wear.ssd[i].wear_percent_spares_remaining;
+         CSMLOGp(csmd, info, SSD_WEAR) << "wear_total_bytes_written: " << ssd_wear.ssd[i].wear_total_bytes_written
+                                       << " wear_total_bytes_read: " << ssd_wear.ssd[i].wear_total_bytes_read;
+         
+         // With the current architecture, only one SSD is expected per compute node
+         // The DB prepared statement syntax also limits the DB Req to a single SQL statement
+         // Attempting to update more than one row in this DB Req results in the following error:
+         // DB errcode=25 cannot insert multiple commands into a prepared statement
+         // Given the current requirements, assume only one SSD per update, but truncate the update here
+         // with an appropriate warning message in case future systems contain multiple SSDs
+         // A different approach will be needed to support multiple updates if they are required in the future.
+         if (i == 0)
+         {
+            // Build the update statement 
+            stmt_out << "UPDATE " << SSD_TABLE_NAME << " SET ";
+            stmt_out << "wear_lifespan_used="            << "$" << ++param << "::integer, ";
+            stmt_out << "wear_total_bytes_written="      << "$" << ++param << "::bigint, ";
+            stmt_out << "wear_total_bytes_read="         << "$" << ++param << "::bigint, ";
+            stmt_out << "wear_percent_spares_remaining=" << "$" << ++param << "::integer";
+            stmt_out << " WHERE node_name="              << "$" << ++param << "::text "; 
+            stmt_out << "AND serial_number="             << "$" << ++param << "::text;" << endl;
+         }
+         else
+         {
+            CSMLOGp(csmd, warning, SSD_WEAR) << "discarding update to unexpected SSD!"; 
+         }
+      }
+      
+      std::string sql_stmt = stmt_out.str();
+      CSMLOG(csmd, debug) << "sql_stmt=" << sql_stmt;
+   
+      // Create the DB request 
+      csm::db::DBReqContent db_content(sql_stmt, param);
+
+      // Add SQL params
+      for ( uint32_t i = 0; i < ssd_wear.discovered_ssds; i++ )
+      {  
+         // Limit DB Req to one SSD update
+         // See discussion in previous loop above 
+         if (i == 0)
+         {
+            db_content.AddNumericParam<int32_t>(ssd_wear.ssd[i].wear_lifespan_used);
+            db_content.AddNumericParam<int64_t>(ssd_wear.ssd[i].wear_total_bytes_written);
+            db_content.AddNumericParam<int64_t>(ssd_wear.ssd[i].wear_total_bytes_read);
+            db_content.AddNumericParam<int32_t>(ssd_wear.ssd[i].wear_percent_spares_remaining);
+            db_content.AddTextParam(ssd_wear.node_name);
+            db_content.AddTextParam(ssd_wear.ssd[i].serial_number);
+         }
+      }
+        
+      csm::daemon::DBReqEvent* dbevent = new csm::daemon::DBReqEvent(db_content, csm::daemon::EVENT_TYPE_DB_Request, ctx);
+      postEventList.push_back(dbevent);
+    
+      return true;
+   }
+}
+
+bool InvSsdWearUpdate::CreateSqlStmt(const std::string& arguments, const uint32_t len,
+                std::string &stmt, int &errcode, std::string &errmsg, bool compareDataForPrivateCheckRes)
+{
+   // This function is not in use, but is required by csmi_db_base
+   CSMLOG(csmd, warning) << "Entering " << __PRETTY_FUNCTION__ << " unexpectedly!";
+   return false; 
+}
+
+// will return csmi defined error code
+int InvSsdWearUpdate::CreateByteArray(std::vector<csm::db::DBTuple *>&tuples,
+                                          char **buf, uint32_t &bufLen, bool compareDataForPrivateCheckRes)
+{
+   // This function is not in use, but is required by csmi_db_base
+   CSMLOG(csmd, warning) << "Entering " << __PRETTY_FUNCTION__ << " unexpectedly!";
+    
+   int errcode = CSMI_SUCCESS;
+   return errcode;
+}

--- a/csmd/src/daemon/src/csmi_request_handler/InvSsdWearUpdate.h
+++ b/csmd/src/daemon/src/csmi_request_handler/InvSsdWearUpdate.h
@@ -1,0 +1,47 @@
+/*================================================================================
+   
+    csmd/src/daemon/src/csmi_request_handler/InvSsdWearUpdate.h
+
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+ 
+================================================================================*/
+#ifndef __INV_SSD_WEAR_UPDATE_H__
+#define __INV_SSD_WEAR_UPDATE_H__
+
+#include "csmi_db_base.h"
+
+class InvSsdWearUpdate : public CSMI_DB_BASE {
+
+public:
+   InvSsdWearUpdate(csm::daemon::HandlerOptions& options) : CSMI_DB_BASE(CSM_CMD_ssd_wear_update,options)
+   {
+   };
+
+   void Process(const csm::daemon::CoreEvent &aEvent, std::vector<csm::daemon::CoreEvent*>& postEventList);
+ 
+private:
+
+   /**
+    * Parses the original network event received and adds a DB Request to the postEventList 
+    * Returns true is successful; event will be added to the postEventList
+    * Returns false if unsuccessful or no updates needed; no event added to the postEventList
+    */
+   bool CreateDbRequest(const EventContextDBBase_sptr& ctx, const csm::daemon::CoreEvent& aEvent, std::vector<csm::daemon::CoreEvent*>& postEventList);
+
+   bool CreateSqlStmt(const std::string& arguments, const uint32_t len,
+                std::string &stmt, int &errcode, std::string &errmsg, bool compareDataForPrivateCheckRes=false);
+
+   // return the error code defined in csmi/src/common/include/csmi_cmd_error.h
+   int CreateByteArray(std::vector<csm::db::DBTuple *>&tuples, 
+                                  char **buf, uint32_t &bufLen, bool compareDataForPrivateCheckRes=false);
+};
+
+#endif
+

--- a/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.cc
@@ -12,9 +12,12 @@
     restricted by GSA ADP Schedule Contract with IBM Corp.
 
 ================================================================================*/
+#include "csm_daemon_config.h"
 #include "csm_environmental_handler.h"
 #include "logging.h"
 #include "csmd/src/inv/include/inv_dcgm_access.h"
+#include "csmd/src/inv/include/inv_ssd_inventory.h"
+#include "csmd/src/inv/include/inv_ssd_wear_serialization.h"
 
 #include <iostream>
 #include <iomanip>
@@ -91,7 +94,8 @@ void CSM_ENVIRONMENTAL::Process( const csm::daemon::CoreEvent &aEvent,
           }
           case csm::daemon::SSD:
           {
-            LOG(csmenv, info) << "Collecting SSD Wear data.";
+            LOG(csmenv, debug) << "Collecting SSD Wear data.";
+            BuildSsdWearUpdate(postEventList);
             break;
           }
           case csm::daemon::NETWORK:
@@ -138,4 +142,66 @@ void CSM_ENVIRONMENTAL::Process( const csm::daemon::CoreEvent &aEvent,
     }
   }
   
+}
+
+bool CSM_ENVIRONMENTAL::BuildSsdWearUpdate(std::vector<csm::daemon::CoreEvent*>& postEventList)
+{
+  bool ssd_success(false);
+  csm_ssd_wear_t ssd_wear;
+
+  std::string node_name("");
+  try
+  {
+    node_name = csm::daemon::Configuration::Instance()->GetHostname();
+  }
+  catch (csm::daemon::Exception &e)
+  {
+    LOG(csmenv, error) << "SSD_WEAR: Caught exception when trying GetHostname()";
+  }
+
+  if (!node_name.empty())
+  {
+    LOG(csmenv, debug) << "SSD_WEAR: ssd_wear.node_name = " << node_name;
+    strncpy(ssd_wear.node_name, node_name.c_str(), CSM_NODE_NAME_MAX);
+    ssd_wear.node_name[CSM_NODE_NAME_MAX - 1] = '\0';
+  }
+  else
+  {
+    ssd_wear.node_name[0] = '\0';
+    LOG(csmenv, error) << "SSD_WEAR: Error: could not determine ssd_wear.node_name!";
+    return false;
+  }
+
+  ssd_success = GetSsdInventory(ssd_wear.ssd, ssd_wear.discovered_ssds); 
+  if ( ssd_success )
+  {
+    LOG(csmenv, info) << "SSD_WEAR: Successfully collected ssd wear data.";
+  
+    string payload_str("");
+    uint32_t bytes_packed(0);
+    bytes_packed = ssd_wear_pack(ssd_wear, payload_str);
+
+    if ( bytes_packed == 0 || payload_str.size() == 0 )
+    {
+      LOG(csmenv, error) << "SSD_WEAR: Failed to pack ssd wear update.";
+      return false;
+    }
+
+    LOG(csmenv, debug) << "SSD_WEAR: CSM_CMD_ssd_wear_update payload_str.size() = " << payload_str.size();
+
+    csm::network::Message ssd_msg;
+    ssd_msg.Init(CSM_CMD_ssd_wear_update, 0, CSM_PRIORITY_DEFAULT,
+      0, 3253, 1351, geteuid(), getegid(),
+      payload_str );
+
+    csm::network::MessageAndAddress ssd_msg_and_addr( ssd_msg, _AbstractMaster);
+
+    postEventList.push_back( CreateNetworkEvent( ssd_msg_and_addr ) );
+  }
+  else
+  {
+    LOG(csmenv, warning) << "SSD_WEAR: Failed to collect ssd wear data.";
+  }
+
+  return ssd_success;
 }

--- a/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.cc
@@ -2,7 +2,7 @@
 
     csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.cc
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -87,6 +87,11 @@ void CSM_ENVIRONMENTAL::Process( const csm::daemon::CoreEvent &aEvent,
           {
             LOG(csmenv, debug) << "Collecting node environmental data.";
             envData.CollectEnvironmentalData();
+            break;
+          }
+          case csm::daemon::SSD:
+          {
+            LOG(csmenv, info) << "Collecting SSD Wear data.";
             break;
           }
           case csm::daemon::NETWORK:

--- a/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csm_environmental_handler.h
@@ -73,6 +73,7 @@ private:
 
   CSM_Environmental_Data * Environmental_data;
 
+  bool BuildSsdWearUpdate(std::vector<csm::daemon::CoreEvent*>& postEventList);
 };
 
 class CSM_ENVIRONMENTAL_UTILITY : public CSM_ENVIRONMENTAL

--- a/csmd/src/inv/include/inv_ssd_inventory.h
+++ b/csmd/src/inv/include/inv_ssd_inventory.h
@@ -2,7 +2,7 @@
    
     csmd/src/inv/include/inv_ssd_inventory.h
 
-  © Copyright IBM Corporation 2017. All Rights Reserved
+  © Copyright IBM Corporation 2017-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -17,10 +17,19 @@
 
 #include <stdint.h>       // Provides int32_t
 
+#include <string>
+
 #include "csmi/src/inv/include/inv_types.h"
 
 // Returns true if successful, false if an error occurred 
 // If successful, ssd_count will contain the number of entries populated in the ssd_inventory array
 bool GetSsdInventory(csm_ssd_inventory_t ssd_inventory[CSM_SSD_MAX_DEVICES], uint32_t& ssd_count);
+
+// Returns true if successful, false if an error occurred 
+// If successful: wear_lifespan_used, wear_percent_spares_remaining, wear_total_bytes_written, and wear_total_bytes_read
+// will contain valid values.
+// If unsuccessful: all fields will be set to -1
+bool GetSsdWear(const std::string &devicename, int32_t &wear_lifespan_used, int32_t &wear_percent_spares_remaining,
+                int64_t &wear_total_bytes_written, int64_t &wear_total_bytes_read);
 
 #endif

--- a/csmd/src/inv/include/inv_ssd_wear_serialization.h
+++ b/csmd/src/inv/include/inv_ssd_wear_serialization.h
@@ -1,0 +1,28 @@
+/*================================================================================
+    
+    csmd/src/inv/include/inv_ssd_wear_serialization.h    
+
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+ 
+================================================================================*/
+#ifndef _INV_SSD_WEAR_SERIALIZATION_H
+#define _INV_SSD_WEAR_SERIALIZATION_H
+
+#include "csmi/src/inv/include/inv_types.h"
+
+#include <string>
+
+using std::string;
+
+uint32_t ssd_wear_pack(const csm_ssd_wear_t& in_ssd_wear, string& out_payload_str);
+
+uint32_t ssd_wear_unpack(const string& in_payload_str, csm_ssd_wear_t& out_ssd_wear);
+
+#endif

--- a/csmd/src/inv/src/CMakeLists.txt
+++ b/csmd/src/inv/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 #   
 #    csmd/src/inv/src/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -33,4 +33,5 @@ set(CSM_INVENTORY_SRC
   ${CSMD_INV_SRC_DIR}/inv_aggregator_handler.cc
   ${CSMD_INV_SRC_DIR}/inv_master_handler.cc
   ${CSMD_INV_SRC_DIR}/inv_dcgm_access.cc
+  ${CSMD_INV_SRC_DIR}/inv_ssd_wear_serialization.cc
 )

--- a/csmd/src/inv/src/inv_ssd_inventory.cc
+++ b/csmd/src/inv/src/inv_ssd_inventory.cc
@@ -183,10 +183,15 @@ bool GetSsdInventory(csm_ssd_inventory_t ssd_inventory[CSM_SSD_MAX_DEVICES], uin
     GetSsdWear(devicename, ssd_inventory[i].wear_lifespan_used, ssd_inventory[i].wear_percent_spares_remaining, 
                ssd_inventory[i].wear_total_bytes_written, ssd_inventory[i].wear_total_bytes_read);
 
+    LOG(csmd, info) << "wear_lifespan_used: " << ssd_inventory[i].wear_lifespan_used
+                    << " wear_percent_spares_remaining: " << ssd_inventory[i].wear_percent_spares_remaining;
+    LOG(csmd, info) << "wear_total_bytes_written: " << ssd_inventory[i].wear_total_bytes_written
+                    << " wear_total_bytes_read: " << ssd_inventory[i].wear_total_bytes_read;
+
     ssd_itr++;
     ssd_count++;
   } 
- 
+
   if (ssdlist.size() > CSM_SSD_MAX_DEVICES)
   {
     LOG(csmd, warning) << "ssd_inventory truncated to " << ssd_count << " entries, " << ssdlist.size() << " ssds discovered.";

--- a/csmd/src/inv/src/inv_ssd_wear_serialization.cc
+++ b/csmd/src/inv/src/inv_ssd_wear_serialization.cc
@@ -1,0 +1,113 @@
+/*================================================================================
+    
+    csmd/src/inv/src/inv_ssd_wear_serialization.cc 
+
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+
+    This program is licensed under the terms of the Eclipse Public License
+    v1.0 as published by the Eclipse Foundation and available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+    restricted by GSA ADP Schedule Contract with IBM Corp.
+ 
+================================================================================*/
+#include "inv_ssd_wear_serialization.h"
+#include "logging.h"
+
+#include <string>
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+using std::string;
+
+uint32_t ssd_wear_pack(const csm_ssd_wear_t& in_ssd_wear, string& out_payload_str)
+{
+  // Pack the node name 
+  out_payload_str.append( (char*) &in_ssd_wear.node_name, sizeof(in_ssd_wear.node_name) );
+  
+  // Pack the ssd portion of the inventory 
+  if ( in_ssd_wear.discovered_ssds > CSM_SSD_MAX_DEVICES )
+  {
+    LOG(csmd, error) << "in_ssd_wear.discovered_ssds (" << in_ssd_wear.discovered_ssds << ") " 
+                     << "> CSM_SSD_MAX_DEVICES (" << CSM_SSD_MAX_DEVICES << ")";
+
+    out_payload_str.clear();
+    LOG(csmd, debug) << "out_payload_str.length() = " << out_payload_str.length();
+    return out_payload_str.length();
+  }
+ 
+  // Pack the count of discovered_ssds 
+  out_payload_str.append( (char*) &in_ssd_wear.discovered_ssds, sizeof(in_ssd_wear.discovered_ssds) );
+
+  // Only pack populated SSDs
+  for ( uint32_t i = 0; i < in_ssd_wear.discovered_ssds; i++ )
+  {
+    out_payload_str.append( (char*) &(in_ssd_wear.ssd[i]), sizeof(in_ssd_wear.ssd[i]) );
+  }
+  
+  LOG(csmd, debug) << "out_payload_str.length() = " << out_payload_str.length();
+
+  return out_payload_str.length();
+}
+
+uint32_t ssd_wear_unpack(const string& in_payload_str, csm_ssd_wear_t& out_ssd_wear)
+{
+  uint32_t offset(0);  
+
+  // Clear the current structure
+  memset( &out_ssd_wear, 0, sizeof(out_ssd_wear) );
+
+  // Unpack the node name
+  if ( in_payload_str.size() >= sizeof(out_ssd_wear.node_name) )
+  {
+    memcpy( &out_ssd_wear.node_name, &(in_payload_str.c_str()[offset]), sizeof(out_ssd_wear.node_name) );
+    offset += sizeof(out_ssd_wear.node_name);
+  }
+  else
+  {
+    LOG(csmd, error) << "in_payload_str.size() (" << in_payload_str.size() << ") " 
+                     << "< sizeof(out_ssd_wear.node_name) (" << sizeof(out_ssd_wear.node_name) << ")";
+  }
+  
+  // Unpack the count of discovered_ssds 
+  if ( in_payload_str.size() >= sizeof(out_ssd_wear.discovered_ssds) )
+  {
+    memcpy( &out_ssd_wear.discovered_ssds, &(in_payload_str.c_str()[offset]), sizeof(out_ssd_wear.discovered_ssds) );
+    offset += sizeof(out_ssd_wear.discovered_ssds);
+  }
+  else
+  {
+    LOG(csmd, error) << "in_payload_str.size() (" << in_payload_str.size() << ") " 
+                     << "< sizeof(out_ssd_wear.node_name) (" << sizeof(out_ssd_wear.node_name) << ")";
+  }
+  
+  // Unpack the ssd portion of the message 
+  if ( out_ssd_wear.discovered_ssds > CSM_SSD_MAX_DEVICES )
+  {
+    LOG(csmd, error) << "out_ssd_wear.discovered_ssds (" << out_ssd_wear.discovered_ssds << ") " 
+                     << "> CSM_SSD_MAX_DEVICES (" << CSM_SSD_MAX_DEVICES << "), truncating array to fit";
+
+    out_ssd_wear.discovered_ssds = CSM_SSD_MAX_DEVICES;
+  }
+
+  for ( uint32_t i = 0; i < out_ssd_wear.discovered_ssds; i++ )
+  {
+    if ( in_payload_str.size() >= (offset + sizeof(out_ssd_wear.ssd[i])) )
+    {
+      memcpy( &out_ssd_wear.ssd[i], &(in_payload_str.c_str()[offset]), sizeof(out_ssd_wear.ssd[i]) );
+      offset += sizeof(out_ssd_wear.ssd[i]);
+    }
+    else
+    {
+      LOG(csmd, error) << "in_payload_str.size() (" << in_payload_str.size() << ") " 
+                       << "< offset (" << offset << ") + sizeof(out_ssd_wear.ssd[i]) (" 
+                       << sizeof(out_ssd_wear.ssd[i]) << ")";
+    }
+  }
+
+  return offset;
+}
+

--- a/csmi/src/common/include/csmi_cmds_def.h
+++ b/csmi/src/common/include/csmi_cmds_def.h
@@ -2,7 +2,7 @@
 
     csmi/src/common/include/csmi_cmds_def.h
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -90,12 +90,14 @@ cmd(cluster_query_state)
 cmd(node_find_job)
 cmd(soft_failure_recovery)
 
+// Added in CSM v1.5.0
+cmd(ssd_wear_update)
+
 // new APIS should go here by adding the new API immediately above this line
 // and removing the first reserved_NN that appears after MAX_REGULAR
 cmd(MAX_REGULAR)
 
 // reserved cmd IDS
-cmd(reserved_65)
 cmd(reserved_66)
 cmd(reserved_67)
 cmd(reserved_68)

--- a/csmi/src/inv/include/inv_types.h
+++ b/csmi/src/inv/include/inv_types.h
@@ -2,7 +2,7 @@
 
     csmi/src/inv/include/inv_types.h
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -180,5 +180,22 @@ typedef struct csm_full_inventory_t
   {}
 
 } csm_full_inventory_t;
+
+typedef struct csm_ssd_wear_t
+{
+  char node_name[CSM_NODE_NAME_MAX];
+  uint32_t discovered_ssds;
+  csm_ssd_inventory_t ssd[CSM_SSD_MAX_DEVICES];
+
+  csm_ssd_wear_t()
+  {
+    // Initialize the whole struct with 0s first; guarantees any pad bytes are also initialized
+    memset(this, 0, sizeof(*this));
+
+    // Set any non-zero defaults here
+  }
+
+} csm_ssd_wear_t;
+
 
 #endif


### PR DESCRIPTION
This pull request contains several new features related to SSD wear collection.

**Summary**
CSM Compute daemons will now start collecting wear_lifespan_used, wear_percent_spares_remaining, wear_total_bytes_written, and wear_total_bytes_read in the csm_ssd table.
These fields will be collected as part of inventory collection whenever a CSM compute daemon starts.
They will also be recollected periodically as part of the "ssd" bucket, which has a configurable frequency in the csm_compute.cfg file.

**Dependancies**
The nvme-cli rpm must be installed on any nodes where SSD wear is intended to be collected.

The ssd configuration section must be added to the "data_collection.buckets" section of the csm_compute.cfg to enable periodic recollection:

```
        "data_collection" :
        {
            "buckets":
                [
                    {
                        "execution_interval":"00:10:00",
                        "item_list": ["gpu", "environmental"]
                    },
                    {
                        "execution_interval":"24:00:00",
                        "item_list": ["ssd"]
                    }
                ]
        }
```

**Tests with sample output:**
**Test 1: Normal operation during initial inventory collection:**

From csm_master.log:
```
2019-02-13 13:14:59.200314       csmd::info     | INV_MASTER: Received new inventory from c650f99p18
2019-02-13 13:14:59.207027       csmd::info     |  SSD_INV: c650f99p18-ssd0 :  - serial_number:                 S3RVNA0K400110
2019-02-13 13:14:59.207065       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    device_name:                   PCIe3 1.6TB NVMe Flash Adapter II x8
2019-02-13 13:14:59.207103       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    pci_bus_id:                    0030:01:00.0
2019-02-13 13:14:59.207140       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    fw_ver:                        MN12MN12
2019-02-13 13:14:59.207177       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    size:                          1600321314816
2019-02-13 13:14:59.207215       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    wear_lifespan_used:            0
2019-02-13 13:14:59.207252       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    wear_total_bytes_written:      4013269504000
2019-02-13 13:14:59.207290       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    wear_total_bytes_read:         4819166720000
2019-02-13 13:14:59.207327       csmd::info     |  SSD_INV: c650f99p18-ssd0 :    wear_percent_spares_remaining: 100
```

From csm_node_attributes_query_details:
```
/opt/ibm/csm/bin/csm_node_attributes_query_details -n c650f99p18
  ssds:
    - serial_number:                 S3RVNA0K400110
      update_time:                   2019-02-13 13:14:59.209468
      device_name:                   PCIe3 1.6TB NVMe Flash Adapter II x8
      fw_ver:                        MN12MN12
      pci_bus_id:                    0030:01:00.0
      size:                          1600321314816
      wear_lifespan_used:            0.000000
      wear_total_bytes_read:         4819166720000
      wear_total_bytes_written:      4013269504000
      wear_percent_spares_remaining: 100.000000
```


**Test 2: Normal operation after being recollected via the "ssd" bucket:**

From csm_master.log:
```
2019-02-13 15:03:30.142250       csmd::info     | SSD_WEAR: NEW EVENT: Received ssd wear update from c650f99p18, discovered_ssds=1
2019-02-13 15:03:30.142322       csmd::info     | SSD_WEAR: c650f99p18-ssd0 sn:S3RVNA0K400110: wear_lifespan_used: 0 wear_percent_spares_remaining: 100
2019-02-13 15:03:30.142384       csmd::info     | SSD_WEAR: c650f99p18-ssd0 sn:S3RVNA0K400110: wear_total_bytes_written: 4013792256000 wear_total_bytes_read: 4819166720000
2019-02-13 15:03:30.167269       csmd::info     | SSD_WEAR: EVENT COMPLETE
```

From csm_node_attributes_query_details:
```
/opt/ibm/csm/bin/csm_node_attributes_query_details -n c650f99p18
  ssds:
    - serial_number:                 S3RVNA0K400110
      update_time:                   2019-02-13 15:03:30.156245
      device_name:                   PCIe3 1.6TB NVMe Flash Adapter II x8
      fw_ver:                        MN12MN12
      pci_bus_id:                    0030:01:00.0
      size:                          1600321314816
      wear_lifespan_used:            0.000000
      wear_total_bytes_read:         4819166720000
      wear_total_bytes_written:      4013792256000
      wear_percent_spares_remaining: 100.000000
```

**Test 3: Error: nvme-cli rpm is not installed on the compute node.**

From csm_compute.log:
`[COMPUTE]2019-02-13 13:15:49.865311       csmd::error    | GetSsdWear(): sh: /usr/sbin/nvme: No such file or directory`

From csm_node_attributes_query_details:
```
/opt/ibm/csm/bin/csm_node_attributes_query_details -n c650f99p26
  ssds:
    - serial_number:                 S3RVNA0K400104_FAKE
      update_time:                   2019-02-13 13:14:59.042719
      device_name:                   PCIe3 1.6TB NVMe Flash Adapter II x8
      fw_ver:                        MN12MN12
      pci_bus_id:                    0030:01:00.0
      size:                          1600321314816
      wear_lifespan_used:            -1.000000
      wear_total_bytes_read:         -1
      wear_total_bytes_written:      -1
      wear_percent_spares_remaining: -1.000000
```
