### PR TITLE
Temporary fix for Issue #62 for CSM 1.5.0

### DIFF
--- a/csmd/src/daemon/etc/csmd-compute.service
+++ b/csmd/src/daemon/etc/csmd-compute.service
@@ -25,6 +25,7 @@ Before=csmrestd.service
 [Service]
 Type=simple
 LimitCORE=infinity
+LimitMEMLOCK=infinity
 LimitNOFILE=20480
 ExecStartPre=-/opt/ibm/csm/sbin/rotate-log-file.sh /etc/ibm/csm/csm_compute.cfg
 ExecStart=/opt/ibm/csm/sbin/csmd -f /etc/ibm/csm/csm_compute.cfg


### PR DESCRIPTION
Adds  LimitMEMLOCK=infinity to the compute service.
