### PR TITLE
Updated tracing in CSM buckets

### DIFF
--- a/csmd/src/inv/include/inv_ssd_inventory.h
+++ b/csmd/src/inv/include/inv_ssd_inventory.h
@@ -23,7 +23,7 @@
 
 // Returns true if successful, false if an error occurred 
 // If successful, ssd_count will contain the number of entries populated in the ssd_inventory array
-bool GetSsdInventory(csm_ssd_inventory_t ssd_inventory[CSM_SSD_MAX_DEVICES], uint32_t& ssd_count);
+bool GetSsdInventory(csm_ssd_inventory_t ssd_inventory[CSM_SSD_MAX_DEVICES], uint32_t& ssd_count, const bool& verbose=true);
 
 // Returns true if successful, false if an error occurred 
 // If successful: wear_lifespan_used, wear_percent_spares_remaining, wear_total_bytes_written, and wear_total_bytes_read


### PR DESCRIPTION
## Summary
- Modified SSD inventory collection to support verbose and quiet levels of trace as requested by the caller.
- Updated the trace messages created during processing of CSM buckets.

## Example messages
With the default trace levels enabled, one trace entry will be created for each bucket item that is processed successfully.
```
[COMPUTE]2019-02-20 12:25:13.001705     csmenv::info     | CSM_ENVIRONMENTAL gpu: GPU data collection was successful.
[COMPUTE]2019-02-20 12:25:13.009847     csmenv::info     | CSM_ENVIRONMENTAL environmental: node environmental data collection was successful.
[COMPUTE]2019-02-20 12:25:13.014682     csmenv::info     | CSM_ENVIRONMENTAL ssd: SSD wear collection was successful.
```


