### PR TITLE
CSM documentation update for SSD wear bucket

### DIFF
--- a/docs/source/cast-big-data/python-guide.rst
+++ b/docs/source/cast-big-data/python-guide.rst
@@ -341,7 +341,7 @@ The core objective of this script is to repair issues with the transactional ind
 exposed in the transitory steps of the CSM Big Data development. As such, this script should only 
 be run in clusters which were running pre ``1.5.0`` level code.
 
-.. code-black:: bash
+.. code-block:: bash
 
     usage: csmTransactionRebuild.py [-h] [-d db] [-u user] [-o output]
 

--- a/docs/source/csmd/csmd_config.rst
+++ b/docs/source/csmd/csmd_config.rst
@@ -613,6 +613,10 @@ effect on other daemon roles.
                     {
                         "execution_interval":"00:10:00",
                         "item_list": ["gpu", "environmental"]
+                    },
+                    {
+                        "execution_interval":"24:00:00",
+                        "item_list": ["ssd"]
                     }
                 ]
         }
@@ -630,6 +634,8 @@ effect on other daemon roles.
         | ``gpu``           | A set of GPU stats and counters.             |
         +-------------------+----------------------------------------------+
         | ``environmental`` | A set of CPU and machine stats and counters. |
+        +-------------------+----------------------------------------------+
+        | ``ssd``           | A set of SSD wear stats and counters.        |
         +-------------------+----------------------------------------------+
         
 .. _CSMD_jittermitigation_Block:


### PR DESCRIPTION
Two small documentation updates:
- Fixed a markup typo I noticed:
`python-guide.rst:344: WARNING: Unknown directive type "code-black".`
- Added documentation for the ssd bucket to the csmd_config data_collection section.