### PR TITLE
Packaging updates related to ibm-csm-tools rpm

### DIFF
--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -33,3 +33,7 @@ set( CPACK_RPM_csm-core_POST_INSTALL_SCRIPT_FILE
 set(CPACK_RPM_csm-core_PACKAGE_REQUIRES "nvme-cli")
 
 set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv")
+
+# ibm-csm-tools rpm settings
+set(CPACK_RPM_csm-tools_PACKAGE_ARCHITECTURE "noarch")
+set(CPACK_RPM_csm-tools_PACKAGE_REQUIRES "numpy")

--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -19,20 +19,20 @@
 # Note: when shipping libraries to a new directory location via cmake "install ...", 
 # the new directory must be added to the CMAKE_INSTALL_RPATH in scripts/setupRPATH.cmake
 
-# Change the CSM rpms that do not contain compiled binaries to noarch
-SET(CPACK_RPM_csm-db_PACKAGE_ARCHITECTURE "noarch")
-SET(CPACK_RPM_csm-hcdiag_PACKAGE_ARCHITECTURE "noarch")
-
-
+# ibm-csm-core rpm settings
+set(CPACK_RPM_csm-core_PACKAGE_REQUIRES "nvme-cli")
 set( CPACK_RPM_csm-core_POST_UNINSTALL_SCRIPT_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/csmd/rpmscripts/csmd.post.uninstall")
 
 set( CPACK_RPM_csm-core_POST_INSTALL_SCRIPT_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/csmd/rpmscripts/csmd.post.install")
 
-set(CPACK_RPM_csm-core_PACKAGE_REQUIRES "nvme-cli")
-
+# ibm-csm-db rpm settings
+set(CPACK_RPM_csm-db_PACKAGE_ARCHITECTURE "noarch")
 set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv")
+
+# ibm-csm-hcdiag rpm settings
+set(CPACK_RPM_csm-hcdiag_PACKAGE_ARCHITECTURE "noarch")
 
 # ibm-csm-tools rpm settings
 set(CPACK_RPM_csm-tools_PACKAGE_ARCHITECTURE "noarch")

--- a/csmutil/csm_log_utility/CMakeLists.txt
+++ b/csmutil/csm_log_utility/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmutil/csm_log_utility/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -24,6 +24,5 @@ file(GLOB INSTALL_SCRIPTS
 )
 
 install(FILES ${INSTALL_SCRIPTS} COMPONENT csm-tools DESTINATION csm/tools)
-set(CPACK_RPM_csm-tools_PACKAGE_REQUIRES "numpy == 1.7.1")
-SET(CPACK_RPM_csm-tools_PACKAGE_ARCHITECTURE "noarch")
 
+# CPACK_RPM settings for the csm-tools rpm are managed in csmd/setupRPM.cmake 

--- a/csmutil/csm_log_utility/Logs/CMakeLists.txt
+++ b/csmutil/csm_log_utility/Logs/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmutil/csm_log_utility/Logs/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -30,6 +30,6 @@ file(GLOB INSTALL_U_Logs
 )
 
 install(FILES ${INSTALL_A_Logs} COMPONENT csm-tools DESTINATION csm/tools/Logs/Aggregator)
-install(FILES ${INSTALL_C_Logs} COMPONENT csm-core DESTINATION csm/tools/Logs/Compute)
-install(FILES ${INSTALL_M_Logs} COMPONENT csm-core DESTINATION csm/tools/Logs/Master)
-install(FILES ${INSTALL_U_Logs} COMPONENT csm-core DESTINATION csm/tools/Logs/Utility)
+install(FILES ${INSTALL_C_Logs} COMPONENT csm-tools DESTINATION csm/tools/Logs/Compute)
+install(FILES ${INSTALL_M_Logs} COMPONENT csm-tools DESTINATION csm/tools/Logs/Master)
+install(FILES ${INSTALL_U_Logs} COMPONENT csm-tools DESTINATION csm/tools/Logs/Utility)


### PR DESCRIPTION
### Made the ibm-csm-tools rpm noarch instead of ppc64le
```
# Before:
# ls ibm-csm-tools*
ibm-csm-tools-1.6.0-2141.ppc64le.rpm

# After:
# ls ibm-csm-tools*
ibm-csm-tools-1.6.0-2146.noarch.rpm
```
### Fixed the ibm-csm-tools rpm dependency on numpy
```
# Before:
# rpm -qpR ibm-csm-tools* | grep numpy

# After:
# rpm -qpR ibm-csm-tools* | grep numpy
numpy

# rpm -ivh ibm-csm-tools-1.6.0-2143.noarch.rpm 
error: Failed dependencies:
	numpy is needed by ibm-csm-tools-1.6.0-2143.noarch

# yum install -y -q numpy

# rpm -ivh ibm-csm-tools-1.6.0-2143.noarch.rpm 
Preparing...                          ################################# [100%]
Updating / installing...
   1:ibm-csm-tools-1.6.0-2143         ################################# [100%]

```
### Moved some misplaced files from ibm-csm-core to ibm-csm-tools
```
# Before:
# rpm -qpl ibm-csm-core-* | grep ReadMe.md
/opt/ibm/csm/tools/Logs/Compute/ReadMe.md
/opt/ibm/csm/tools/Logs/Master/ReadMe.md
/opt/ibm/csm/tools/Logs/Utility/ReadMe.md

# rpm -qpl ibm-csm-tools-* | grep ReadMe.md
/opt/ibm/csm/tools/Logs/Aggregator/ReadMe.md
/opt/ibm/csm/tools/ReadMe.md

# After:
# rpm -qpl ibm-csm-core-* | grep ReadMe.md

# rpm -qpl ibm-csm-tools* | grep ReadMe.md
/opt/ibm/csm/tools/Logs/Aggregator/ReadMe.md
/opt/ibm/csm/tools/Logs/Compute/ReadMe.md
/opt/ibm/csm/tools/Logs/Master/ReadMe.md
/opt/ibm/csm/tools/Logs/Utility/ReadMe.md
/opt/ibm/csm/tools/ReadMe.md
```
