### PR TITLE
csmdb_updates for 1.6.0: including additional DB checks within some s…

### DIFF
--- a/csmdb/sql/CMakeLists.txt
+++ b/csmdb/sql/CMakeLists.txt
@@ -27,6 +27,7 @@ file(GLOB INSTALL_PROGRAMS
   "csm_db_backup_script_v1.sh"
   "csm_db_history_archive.py"
   "csm_db_history_delete.py"
+  "csm_db_utility_setup_script.sh"
 )
 
 # Files that should not be executable when shipped

--- a/csmdb/sql/csm_db_connections_script.sh
+++ b/csmdb/sql/csm_db_connections_script.sh
@@ -16,11 +16,9 @@
 
 #--------------------------------------------------------------------------------
 #   usage:              ./csm_db_connections_script.sh  <----- to kill db sessions
-#   current_version:    1.8
+#   current_version:    1.9
 #   create:             09-08-2017
-#   last modified:      02-15-2018
-#   Comments:           Execute this script as "postgres" user
-#                       (user who runs postmaster)
+#   last modified:      03-04-2018
 #--------------------------------------------------------------------------------
 
 export PGOPTIONS='--client-min-messages=warning'
@@ -93,7 +91,7 @@ echo "$now ($current_user) $1" >> $logfile
 echo "${line1_out}"
 echo "[Start ] Welcome to CSM datatbase connections script."
 echo "${line1_out}"
-echo "[Info  ] $logfile"
+echo "[Info  ] Log directory: $logfile"
 echo "${line1_out}"
 LogMsg "[Start ] Welcome to CSM datatbase connections script."
 LogMsg "${line2_log}"
@@ -253,25 +251,39 @@ function usage () {
 #fi
 }
 
+#----------------------------------------------------------------
+# Check the status of the PostgreSQl server
+#----------------------------------------------------------------
+
+systemctl status postgresql > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "[Error ] The PostgreSQL server: Is currently inactive and needs to be started"
+    echo "[Info  ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "[Error ] The PostgreSQL server: Is currently inactive and needs to be started"
+    LogMsg "[Info  ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "${line2_log}"
+    LogMsg "[End   ] Exiting csm_db_connections_script.sh script"
+    echo "${line1_out}"
+    echo "${line3_log}" >> $logfile
+    exit 0
+fi
+
 #--------------------------------------------------
 # Check if postgresql exists already and root user
 #--------------------------------------------------
-string1="$now1 ($current_user) [Info  ] DB Users:"
-    psql -U $db_username -t -c '\du' | cut -d \| -f 1 | grep -qw root
-        if [ $? -ne 0 ]; then
-            db_user_query=`psql -U $db_username -q -A -t -P format=wrapped <<EOF
-            \set ON_ERROR_STOP true
-            select string_agg(usename,' | ') from pg_user;
-EOF`
-            echo "$string1 $db_user_query" | sed "s/.\{60\}|/&\n$string1 /g" >> $logfile
-            echo "[Error ] Postgresql may not be configured correctly. Please check configuration settings."
-            LogMsg "[Error ] Postgresql may not be configured correctly. Please check configuration settings."
-            LogMsg "${line2_log}"
-            LogMsg "[End   ] Exiting csm_db_connections_script.sh script"
-            echo "${line1_out}"
-            echo "${line3_log}" >> $logfile
-            exit 0
-        fi
+root_query=`psql -qtA $db_username -c "SELECT usename FROM pg_catalog.pg_user where usename = 'root';" 2>&1`
+    if [ $? -ne 0 ]; then
+        echo "[Error ] $root_query"
+        echo "$root_query" |& awk '/^psql:.*$/{$1=""; gsub(/^[ \t]+|[ \t]+$/,""); print "'"$(date '+%Y-%m-%d %H:%M:%S') ($current_user) [Error ] DB Message: "'"$0}' >>"${logfile}"
+        echo "[Info  ] Postgresql may not be configured correctly. Please check configuration settings."
+        LogMsg "[Info  ] Postgresql may not be configured correctly. Please check configuration settings."
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_connections_script.sh script"
+        echo "${line1_out}"
+        echo "${line3_log}" >> $logfile
+        exit 0
+    fi
 
 #------------------------------------------------
 # Check if postgresql exists already and DB name

--- a/csmdb/sql/csm_db_ras_type_script.sh
+++ b/csmdb/sql/csm_db_ras_type_script.sh
@@ -16,9 +16,9 @@
 
 #--------------------------------------------------------------------------------
 #   usage:              ./csm_db_ras_type_script.sh
-#   current_version:    01.10
+#   current_version:    01.11
 #   create:             11-07-2017
-#   last modified:      02-15-2019
+#   last modified:      03-04-2019
 #--------------------------------------------------------------------------------
 
 export PGOPTIONS='--client-min-messages=warning'
@@ -77,7 +77,7 @@ LogMsg "[Start   ] Welcome to CSM database ras type automation script."
 LogMsg "${line2_log}"
 echo "[Start   ] Welcome to CSM database ras type automation script."
 echo "${line1_out}"
-echo "[Info    ] Log Dir: $logdir/$logname"
+echo "[Info    ] Log directory: $logdir/$logname"
 
 #----------------------------------------------
 # Usage Command Line Functions
@@ -237,26 +237,40 @@ if [ "$1" != "-l" ] && [ "$1" != "-r" ]; then
      exit 0
 fi
 
+#----------------------------------------------------------------
+# Check the status of the PostgreSQl server
+#----------------------------------------------------------------
+
+systemctl status postgresql > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "[Error   ] The PostgreSQL server: Is currently inactive and needs to be started"
+    echo "[Info    ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "[Error   ] The PostgreSQL server: Is currently inactive and needs to be started"
+    LogMsg "[Info    ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "${line2_log}"
+    LogMsg "[End     ] Exiting csm_db_ras_type_script.sh script"
+    echo "${line1_out}"
+    echo "${line3_log}" >> $logfile
+    exit 0
+fi
+
 #--------------------------------------------------
 # Check if postgresql exists already and root user
 #--------------------------------------------------
 
-string1="$now1 ($current_user) [Info    ] DB Users:"
-    psql -U $db_username -t -c '\du' | cut -d \| -f 1 | grep -qw root
-        if [ $? -ne 0 ]; then
-            db_user_query=`psql -U $db_username -q -A -t -P format=wrapped <<EOF
-            \set ON_ERROR_STOP true
-            select string_agg(usename,' | ') from pg_user;
-EOF`
-            echo "$string1 $db_user_query" | sed "s/.\{60\}|/&\n$string1 /g" >> $logfile
-            echo "[Error   ] Postgresql may not be configured correctly. Please check configuration settings."
-            LogMsg "[Error   ] Postgresql may not be configured correctly. Please check configuration settings."
-            LogMsg "${line2_log}"
-            LogMsg "[End     ] Exiting csm_db_ras_type_script.sh script"
-            echo "${line1_out}"
-            echo "${line3_log}" >> $logfile
-            exit 0
-        fi
+root_query=`psql -qtA $db_username -c "SELECT usename FROM pg_catalog.pg_user where usename = 'root';" 2>&1`
+    if [ $? -ne 0 ]; then
+        echo "[Error   ] $root_query"
+        echo "$root_query" |& awk '/^psql:.*$/{$1=""; gsub(/^[ \t]+|[ \t]+$/,""); print "'"$(date '+%Y-%m-%d %H:%M:%S') ($current_user) [Error   ] DB Message: "'"$0}' >>"${logfile}"
+        echo "[Info    ] Postgresql may not be configured correctly. Please check configuration settings."
+        LogMsg "[Info    ] Postgresql may not be configured correctly. Please check configuration settings."
+        LogMsg "${line2_log}"
+        LogMsg "[End     ] Exiting csm_db_ras_type_script.sh script"
+        echo "${line1_out}"
+        echo "${line3_log}" >> $logfile
+        exit 0
+    fi
 
 #-------------------------------------------------
 # Check if postgresql exists already and DB name

--- a/csmdb/sql/csm_db_script.sh
+++ b/csmdb/sql/csm_db_script.sh
@@ -15,9 +15,9 @@
 
 #--------------------------------------------------------------------------------
 #   usage:              ./csm_db_script.sh <----- to create the csm_db
-#   current_version:    10.16
+#   current_version:    10.17
 #   create:             12-14-2015
-#   last modified:      02-15-2019
+#   last modified:      03-04-2019
 #--------------------------------------------------------------------------------
 
 export PGOPTIONS='--client-min-messages=warning'
@@ -111,7 +111,7 @@ echo "${line1_out}"
 echo "[Start   ] Welcome to CSM database automation script."
 LogMsg "[Start   ] Welcome to CSM database automation script."
 LogMsg "${line2_log}"
-echo "[Info    ] Log Dir: $logfile"
+echo "[Info    ] Log directory: $logfile"
 
 #----------------------------------------------
 # Usage function (help menu options)
@@ -358,25 +358,39 @@ if [[ ($newdb == "yes") || ($force == "yes") ]]; then
     fi
 fi
 
+#----------------------------------------------------------------
+# Check the status of the PostgreSQl server
+#----------------------------------------------------------------
+
+systemctl status postgresql > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "[Error   ] The PostgreSQL server: Is currently inactive and needs to be started"
+    echo "[Info    ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "[Error   ] The PostgreSQL server: Is currently inactive and needs to be started"
+    LogMsg "[Info    ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "${line2_log}"
+    LogMsg "[End     ] Exiting csm_db_script.sh script"
+    echo "${line1_out}"
+    echo "${line3_log}" >> $logfile
+    exit 0
+fi
+
 #---------------------------------------------------------------------------------
 # Check if postgresql exists already and root user
 #---------------------------------------------------------------------------------
-string1="$now1 ($current_user) [Info    ] DB Users:"
-    psql -U $db_username -t -c '\du' | cut -d \| -f 1 | grep -qw root
-        if [ $? -ne 0 ]; then
-            db_user_query=`psql -U $db_username -q -A -t -P format=wrapped <<EOF
-            \set ON_ERROR_STOP true
-            select string_agg(usename,' | ') from pg_user;
-EOF`
-            echo "$string1 $db_user_query" | sed "s/.\{60\}|/&\n$string1 /g" >> $logfile
-            echo "[Error   ] Postgresql may not be configured correctly. Please check configuration settings."
-            LogMsg "[Error   ] Postgresql may not be configured correctly. Please check configuration settings."
-            LogMsg "${line2_log}"
-            LogMsg "[End     ] Exiting csm_db_script.sh script"
-            echo "${line1_out}"
-            echo "${line3_log}" >> $logfile
-            exit 0
-        fi
+root_query=`psql -qtA $db_username -c "SELECT usename FROM pg_catalog.pg_user where usename = 'root';" 2>&1`
+    if [[ $? -ne 0 ]]; then
+        echo "[Error   ] $root_query"
+        echo "$root_query" |& awk '/^psql:.*$/{$1=""; gsub(/^[ \t]+|[ \t]+$/,""); print "'"$(date '+%Y-%m-%d %H:%M:%S') ($current_user) [Error   ] DB Message: "'"$0}' >>"${logfile}"
+        echo "[Info    ] Postgresql may not be configured correctly. Please check configuration settings."
+        LogMsg "[Info    ] Postgresql may not be configured correctly. Please check configuration settings."
+        LogMsg "${line2_log}"
+        LogMsg "[End     ] Exiting csm_db_script.sh script"
+        echo "${line1_out}"
+        echo "${line3_log}" >> $logfile
+        exit 0
+    fi
 
 #---------------------------------------------------------------------------------
 # Check if postgresql exists already and DB name

--- a/csmdb/sql/csm_db_stats.sh
+++ b/csmdb/sql/csm_db_stats.sh
@@ -16,9 +16,9 @@
 
 #--------------------------------------------------------------------------------
 #   usage:              ./csm_db_stats.sh
-#   current_version:    01.10
+#   current_version:    01.11
 #   create:             08-02-2016
-#   last modified:      02-15-2019
+#   last modified:      03-04-2019
 #--------------------------------------------------------------------------------
 
 export PGOPTIONS='--client-min-messages=warning'
@@ -80,9 +80,8 @@ echo "[Start ] Welcome to CSM datatbase automation stats script."
 #echo "${line3_log}" >> $logfile
 LogMsg "[Start ] Welcome to CSM datatbase automation stats script."
 echo "${line1_out}"
+LogMsg "${line2_log}"
 echo "[Info  ] Log Dir: $logdir/$logname"
-
-
 
 #----------------------------------------------
 # Usage Command Line Functions
@@ -282,6 +281,8 @@ while getopts "t:i:l:s:c:u:v:a:x:d:k:h:" arg; do
                 echo "[Info  ] Example: ./csm_db_stats.sh -d csmdb 1 [min(s)]"
                 LogMsg "[Error ] Please specify the time interval"
                 LogMsg "[Info  ] Example: ./csm_db_stats.sh -d csmdb 1 [min(s)]"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
                 echo "${line1_out}"
                 echo "${line3_log}" >> $logfile
                 exit 0
@@ -300,7 +301,9 @@ while getopts "t:i:l:s:c:u:v:a:x:d:k:h:" arg; do
         h)
             usage
             LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -h, --help"
-            LogMsg "[End   ] Help menu query executed"
+            LogMsg "[Info  ] Help menu query executed"
+            LogMsg "${line2_log}"
+            LogMsg "[End   ] Exiting csm_db_stats.sh script."
             echo "${line3_log}" >> $logfile
             exit 0
             ;;
@@ -308,27 +311,44 @@ while getopts "t:i:l:s:c:u:v:a:x:d:k:h:" arg; do
             usage
             LogMsg "[Info  ] Script execution: $BASENAME [NO ARGUMENT]"
             LogMsg "[Info  ] Wrong arguments were passed in (Please choose appropriate option from usage list -h, --help)"
-            LogMsg "[End   ] Please choose another option"
+            LogMsg "[Info  ] Please choose another option"
+            LogMsg "${line2_log}"
+            LogMsg "[End   ] Exiting csm_db_stats.sh script."
             echo "${line3_log}" >> $logfile
             exit 0
             ;;
     esac
 done
 
+#----------------------------------------------------------------
+# Check the status of the PostgreSQl server
+#----------------------------------------------------------------
+
+systemctl status postgresql > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "[Error ] The PostgreSQL server: Is currently inactive and needs to be started"
+    echo "[Info  ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "[Error ] The PostgreSQL server: Is currently inactive and needs to be started"
+    LogMsg "[Info  ] If there is an issue please run: systemctl status postgresql for more info."
+    LogMsg "${line2_log}"
+    LogMsg "[End   ] Exiting csm_db_stats.sh script"
+    echo "${line1_out}"
+    echo "${line3_log}" >> $logfile
+    exit 0
+fi
+
 #-------------------------------------------------
 # Check if postgresql exists already and root user
 #-------------------------------------------------
-string1="$now1 ($current_user) [Info  ] DB Users:"
-    psql -U $db_username -t -c '\du' | cut -d \| -f 1 | grep -qw root
+    root_query=`psql -qtA $db_username -c "SELECT usename FROM pg_catalog.pg_user where usename = 'root';" 2>&1`
         if [ $? -ne 0 ]; then
-            db_user_query=`psql -U $db_username -q -A -t -P format=wrapped <<EOF
-            \set ON_ERROR_STOP true
-            select string_agg(usename,' | ') from pg_user;
-EOF`
-            echo "$string1 $db_user_query" | sed "s/.\{60\}|/&\n$string1 /g" >> $logfile
-            echo "${line1_out}"
-            echo "[Error ] Postgresql may not be configured correctly. Please check configuration settings."
-            LogMsg "[Error ] Postgresql may not be configured correctly. Please check configuration settings."
+            echo "[Error ] $root_query"    
+            echo "$root_query" |& awk '/^psql:.*$/{$1=""; gsub(/^[ \t]+|[ \t]+$/,""); print "'"$(date '+%Y-%m-%d %H:%M:%S') ($current_user) [Error ] DB Message: "'"$0}' >>"${logfile}"
+            echo "[Info  ] Postgresql may not be configured correctly. Please check configuration settings."
+            LogMsg "[Info  ] Postgresql may not be configured correctly. Please check configuration settings."
+            LogMsg "${line2_log}"
+            LogMsg "[End   ] Exiting csm_db_stats.sh script"
             echo "${line1_out}"
             echo "${line3_log}" >> $logfile
             exit 0
@@ -346,6 +366,7 @@ string2="$now1 ($current_user) [Info  ] DB Names:"
 EOF`
             echo "$string2 $db_query" | sed "s/.\{60\}|/&\n$string2 /g" >> $logfile
             LogMsg "[Info  ] PostgreSQL is installed"
+            LogMsg "${line2_log}"
         else
             echo "${line1_out}"
             echo "[Error ] PostgreSQL may not be installed or DB: $dbname may not exist."
@@ -353,6 +374,8 @@ EOF`
             echo "${line1_out}"
             LogMsg "[Error ] PostgreSQL may not be installed or DB $dbname may not exist."
             LogMsg "[Info  ] Please check configuration settings or psql -l"
+            LogMsg "${line2_log}"
+            LogMsg "[End   ] Exiting csm_db_stats.sh script."
             echo "${line3_log}" >> $logfile
             exit 1
         fi
@@ -365,7 +388,9 @@ if [ $# -eq 0 ]; then
     usage
     LogMsg "[Info  ] Script execution: $BASENAME [NO ARGUMENT]"
     LogMsg "[Info  ] Wrong arguments were passed in (Please choose appropriate option from usage list -h, --help)"
-    LogMsg "[End   ] Please choose another option"
+    LogMsg "[Info  ] Please choose another option"
+    LogMsg "${line2_log}"
+    LogMsg "[End   ] Exiting csm_db_stats.sh script."
     echo "${line3_log}" >> $logfile
     exit 0
 fi
@@ -403,11 +428,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -t, --tableinfo (db_name): $dbname"
-        LogMsg "[End   ] Table stats query executed"
+        LogMsg "[Info  ] Table stats query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -455,11 +485,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -i, --indexinfo (db_name): $dbname"
-        LogMsg "[End   ] Table index query executed"
+        LogMsg "[Info  ] Table index query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -490,11 +525,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -x, --indexanalysis (db_name): $dbname"
-        LogMsg "[End   ] Table index analysis query executed"
+        LogMsg "[Info  ] Table index analysis query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -526,11 +566,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -l, --lockinfo (db_name): $dbname"
-        LogMsg "[End   ] Table lock monitoring query executed"
+        LogMsg "[Info  ] Table lock monitoring query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -549,11 +594,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -c, --connectionsdb (db_name): $dbname"
-        LogMsg "[End   ] DB connections with stats query executed"
+        LogMsg "[Info  ] DB connections with stats query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -571,11 +621,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -u, --username (db_name): $dbname"
-        LogMsg "[End   ] DB usernames with stats query executed"
+        LogMsg "[Info  ] DB usernames with stats query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -593,11 +648,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system"
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -s, --schemaversion (db_name): $dbname"
-        LogMsg "[End   ] DB schema version query executed"
+        LogMsg "[Info  ] DB schema version query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -631,11 +691,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -a, --archivecount (db_name): $dbname"
-        LogMsg "[End   ] History table archive count query executed"
+        LogMsg "[Info  ] History table archive count query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -653,11 +718,16 @@ return_code=0
                 echo "[Error ] A valid database name has to be specified (Please run psql -l for a list of active databases)"
                 LogMsg "[Error ] A valid database name has to be specified (Please run psql -l for a list of active databases)" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -v, --postgresqlversion (db_name): $dbname"
-        LogMsg "[End   ] PostgeSQL version and environment query executed"
+        LogMsg "[Info  ] PostgeSQL version and environment query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -721,11 +791,16 @@ return_code=0
                 echo "[Error ] Table or database does not exist in the system or time interval not specified"
                 LogMsg "[Error ] Table or database does not exist in the system or time interval not specified"
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -d, --deletecount (db_name): $dbname"
-        LogMsg "[End   ] DB schema version query executed"
+        LogMsg "[Info  ] DB schema version query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi
@@ -744,11 +819,16 @@ return_code=0
                 echo "[Error ] Table and or database does not exist in the system"
                 LogMsg "[Error ] Table and or database does not exist in the system" 
                 echo "${line1_out}"
+                LogMsg "${line2_log}"
+                LogMsg "[End   ] Exiting csm_db_stats.sh script."
+                echo "${line3_log}" >> $logfile
             else
                 echo "${line1_out}"
             fi
         LogMsg "[Info  ] Script execution: ./csm_db_stats.sh -k, --vacuumstats (db_name): $dbname"
-        LogMsg "[End   ] DB vacuum stats query executed"
+        LogMsg "[Info  ] DB vacuum stats query executed"
+        LogMsg "${line2_log}"
+        LogMsg "[End   ] Exiting csm_db_stats.sh script."
         echo "${line3_log}" >> $logfile
         exit $return_code
     fi

--- a/csmdb/sql/csm_db_utility_setup_script.sh
+++ b/csmdb/sql/csm_db_utility_setup_script.sh
@@ -18,7 +18,7 @@
 #   usage:              ./csm_db_utility_setup_script.sh
 #   current_version:    01.0
 #   create:             02-20-2019
-#   last modified:      03-04-2019
+#   last modified:      03-07-2019
 #--------------------------------------------------------------------------------
 
 export PGOPTIONS='--client-min-messages=warning'
@@ -183,12 +183,12 @@ else
 	    LogMsg "[Complete] PostgreSQL pg_hba.conf file:         | $pg_hba_conf_file exists in directory"
 	else
 	    echo "[Error   ] File:                          | $pg_hba_conf_file does not exist in directory"
-    	echo "[Info    ] Please ensure:                 | the pg_hba.conf exists for proper setup."
+    	    echo "[Info    ] Please ensure:                 | the pg_hba.conf exists for proper setup."
 	    LogMsg "[Error   ] File:                          | $pg_hba_conf_file does not exist in directory"
-    	LogMsg "[Info    ] Please ensure:                 | the pg_hba.conf exists for proper setup."
-        LogMsg "${line2_log}"
-        LogMsg "[End     ] Exiting $0 script"
-        echo "${line1_out}"
+    	    LogMsg "[Info    ] Please ensure:                 | the pg_hba.conf exists for proper setup."
+            LogMsg "${line2_log}"
+            LogMsg "[End     ] Exiting $0 script"
+            echo "${line1_out}"
 	    exit 0 
 	fi
 fi
@@ -208,10 +208,10 @@ if [ $? -ne 0 ]; then
     	echo "[Complete] The PostgreSQL server:             | Is currently running"
     	LogMsg "[Complete] The PostgreSQL server:         	   | Is currently running"
     else
-	    echo "[Error   ] The PostgreSQL server:             | Is not currently running"	
-	    echo "[Info    ] If there is an issue please run:   | systemctl status postgresql for more info."
-	    LogMsg "[Error   ] The PostgreSQL server:             | Is not currently running"	
-	    LogMsg "[Info    ] If there is an issue please run:   | systemctl status postgresql for more info."
+	echo "[Error   ] The PostgreSQL server:             | Is not currently running"	
+	echo "[Info    ] If there is an issue please run:   | systemctl status postgresql for more info."
+	LogMsg "[Error   ] The PostgreSQL server:             | Is not currently running"	
+	LogMsg "[Info    ] If there is an issue please run:   | systemctl status postgresql for more info."
     fi
 fi
 

--- a/csmdb/sql/csm_db_utility_setup_script.sh
+++ b/csmdb/sql/csm_db_utility_setup_script.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+#--------------------------------------------------------------------------------
+#
+#    csm_db_utility_setup_script.sh
+#
+#  © Copyright IBM Corporation 2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#--------------------------------------------------------------------------------
+
+#--------------------------------------------------------------------------------
+#   usage:              ./csm_db_utility_setup_script.sh
+#   current_version:    01.0
+#   create:             02-20-2019
+#   last modified:      03-04-2019
+#--------------------------------------------------------------------------------
+
+export PGOPTIONS='--client-min-messages=warning'
+
+OPTERR=0
+logpath="/var/log/ibm/csm/db"
+#logpath=`pwd` #<------- Change this when pushing to the repo.
+logname="csm_db_utility_setup_script.log"
+cd "${BASH_SOURCE%/*}" || exit
+cur_path=`pwd`
+
+
+#----------------------------------------------
+# Current user connected
+#----------------------------------------------
+current_user=`id -u -n`
+db_username="postgres"
+csmdb_user="csmdb"
+root_user="root"
+xcat_admin_user="xcatadm"
+now1=$(date '+%Y-%m-%d %H:%M:%S')
+now=$(date '+%Y-%m-%d %H:%M:%S')
+hostname=`hostname -I | awk '{print $1}'`
+ext="321"
+host_ext="$hostname/$ext"
+pg_hba_conf_dir="/var/lib/pgsql/data/"
+pg_hba_conf_file="/var/lib/pgsql/data/pg_hba.conf"
+
+line1_out="------------------------------------------------------------------------------------------------------------------------"
+line2_log="------------------------------------------------------------------------------------"
+line3_log="---------------------------------------------------------------------------------------------------------------------------"
+line4_out="-------------------------------------------------------------------------------------------------------------"
+
+BASENAME=`basename "$0"`
+
+#-----------------------------------------------------------------------------
+# This checks the existence of the default log directory.
+# If the default doesn't exist it will write the log files to /tmp directory.
+# The current version will only display results to the screen
+#-----------------------------------------------------------------------------
+
+if [ -w "$logpath" ]; then
+    logdir="$logpath"
+else
+    logdir="/tmp"
+fi
+logfile="${logdir}/${logname}"
+
+#----------------------------------------------
+# Log Message
+#----------------------------------------------
+
+function LogMsg () {
+now=$(date '+%Y-%m-%d %H:%M:%S')
+echo "$now ($current_user) $1" >> $logfile
+}
+
+#--------------------------------
+# Log messaging intro. header
+#--------------------------------
+
+echo "${line1_out}"
+LogMsg "[Start   ] Welcome to CSM database utility setup script."
+LogMsg "${line2_log}" >> $logfile
+echo "[Start   ] Welcome to CSM database utility setup script."
+echo "${line1_out}"
+echo "[Info    ] Log Directory:                     | $logfile"
+
+#----------------------------------------------
+# Usage Command Line Functions
+#----------------------------------------------
+
+function usage () {
+echo "------------------------------------------------------------------------------------------------------------------------"
+echo "[Info    ] $BASENAME : Load CSM DB root, csmdb, xcatadm user(s) if not presnt in system"
+echo "[Usage   ] $BASENAME : $BASENAME (no additional arguments required)"
+echo "------------------------------------------------------------------------------------------------------------------------"
+echo "  Argument       | Description"
+echo "-----------------|------------------------------------------------------------------------------------------------------"
+echo "  script_name    | This script checks to see if the PostgreSQL RPMs are installed, the pg_hba.conf file is present"
+echo "                 | in the /var/lib/pgsql/data directory, checks the server status if its running, and also"
+echo "                 | creates a root, csmdb, and xcatadm db user(s) if not present in the system."
+echo "-----------------|------------------------------------------------------------------------------------------------------"
+echo "------------------------------------------------------------------------------------------------------------------------"
+}
+
+#---------------------------------------------
+# The optstring for input.
+#---------------------------------------------
+
+optstring="h"
+
+while getopts $optstring OPTION
+do
+    case $OPTION in
+        h|*)
+            usage; exit 1;;
+    esac
+done
+
+#------------------------------------------------
+# Check to see if PostgreSQL RPMs are installed
+#------------------------------------------------
+
+rpm -qa | grep postgresql | grep server > /dev/null
+
+    if [ $? -ne 0 ]; then
+        echo "[Error   ] PostgreSQL RPMs:                   | Are not installed"
+        echo "[Info    ] Please check:                      | Your configuration settings or install PostreSQL RPMs"
+        echo "[Info    ] Once the PostgreSQL RPMs:          | Are installed please re-run this script for setup"
+	echo "${line1_out}"
+        LogMsg "[Error   ] PostgreSQL RPMs:                     | Are not installed"
+        LogMsg "[Info    ] Please check:                        | Your configuration settings or install PostreSQL RPMs"
+        LogMsg "[Info    ] Once the PostgreSQL RPMs:            | Are installed please re-run this script for setup"
+	LogMsg "${line2_log}"
+	LogMsg "[End     ] Exiting $0 script"
+        echo "${line3_log}" >> $logfile
+	exit 0
+    else
+        echo "[Info    ] PostgreSQL RPMs:                   | Are already installed"
+        LogMsg "[Info    ] PostgreSQL RPMs:                     | Are already installed"
+    fi
+
+#----------------------------------------------------------------
+# Check the see if the /var/lib/pgsql/data/ directory exists
+#----------------------------------------------------------------
+
+if [ -d "$pg_hba_conf_dir" ]; then
+    echo "[Info    ] PostgreSQL Data Directory:         | $pg_hba_conf_dir already exists"
+    LogMsg "[Info    ] PostgreSQL Data Directory:           | $pg_hba_conf_dir already exists"
+else
+    echo "[Error   ] PostgreSQL Data Directory:         | $pg_hba_conf_dir does not exist"
+    echo "[Info    ] Something went wrong:              | In the PostgreSQL RPM install."
+    echo "[Info    ] Please ensure the:                 | $pg_hba_conf_dir exists for proper setup."
+    echo "${line1_out}"
+    LogMsg "[Error   ] PostgreSQL Data Directory:           | $pg_hba_conf_dir does not exist"
+    LogMsg "[Info    ] Something went wrong:                | In the PostgreSQL RPM install."
+    LogMsg "[Info    ] Please ensure the:                   | $pg_hba_conf_dir exists for proper setup."
+    LogMsg "${line2_log}"
+    LogMsg "[End     ] Exiting $0 script"
+    echo "${line3_log}" >> $logfile
+    exit 0
+fi
+
+#----------------------------------------------------------------
+# Check the see if the pg_hba.conf file exists
+#----------------------------------------------------------------
+
+if [ -f $pg_hba_conf_file ]; then
+    echo "[Info    ] PostgreSQL pg_hba.conf file:       | $pg_hba_conf_file already exists"
+    LogMsg "[Info    ] PostgreSQL pg_hba.conf file:         | $pg_hba_conf_file already exists"
+else
+    echo "[Info    ] Running:                           | The initdb setup"
+    su - postgres -c /usr/bin/initdb < /dev/null > /dev/null 2>&1
+	
+	#----------------------------------------------------------------
+	# Check the see if the pg_hba.conf file exists after
+	#----------------------------------------------------------------
+	
+	if [ -f $pg_hba_conf_file ]; then
+	    echo "[Complete] PostgreSQL pg_hba.conf file:	      | $pg_hba_conf_file exists in directory"
+	    LogMsg "[Complete] PostgreSQL pg_hba.conf file:         | $pg_hba_conf_file exists in directory"
+	else
+	    echo "[Error   ] File:                          | $pg_hba_conf_file does not exist in directory"
+    	echo "[Info    ] Please ensure:                 | the pg_hba.conf exists for proper setup."
+	    LogMsg "[Error   ] File:                          | $pg_hba_conf_file does not exist in directory"
+    	LogMsg "[Info    ] Please ensure:                 | the pg_hba.conf exists for proper setup."
+        LogMsg "${line2_log}"
+        LogMsg "[End     ] Exiting $0 script"
+        echo "${line1_out}"
+	    exit 0 
+	fi
+fi
+
+#----------------------------------------------------------------
+# Check the status of the PostgreSQl server
+#----------------------------------------------------------------
+
+systemctl status postgresql > /dev/null
+
+if [ $? -ne 0 ]; then
+    echo "[Info    ] The PostgreSQL server:             | Is currently inactive and needs to be started"
+    LogMsg "[Info    ] The PostgreSQL server:               | Is currently inactive and needs to be started"
+    systemctl start postgresql > /dev/null
+    
+    if [ $? -eq 0 ]; then
+    	echo "[Complete] The PostgreSQL server:             | Is currently running"
+    	LogMsg "[Complete] The PostgreSQL server:         	   | Is currently running"
+    else
+	    echo "[Error   ] The PostgreSQL server:             | Is not currently running"	
+	    echo "[Info    ] If there is an issue please run:   | systemctl status postgresql for more info."
+	    LogMsg "[Error   ] The PostgreSQL server:             | Is not currently running"	
+	    LogMsg "[Info    ] If there is an issue please run:   | systemctl status postgresql for more info."
+    fi
+fi
+
+#-------------------------------------------------------
+# Check to see if specific user root (as postgres user)
+# Create if not already in system
+#-------------------------------------------------------
+
+if [ $current_user == "postgres" ]; then
+    if psql $db_username -t -c '\du' | cut -d \| -f 1 | grep -qw $root_user; then
+        echo "[Info    ] PostgreSQL DB user:                | $root_user already exists"
+        LogMsg "[Info    ] PostgreSQL DB user:                  | $root_user already exists"
+    else
+        create_users=`psql -v ON_ERROR_STOP=1 -X -t -q -U postgres -d postgres << THE_END 2>/dev/null
+        CREATE USER $root_user;
+THE_END`
+        echo "[Complete] Created PostgreSQL DB user:        | $root_user"
+        LogMsg "[Complete] Created PostgreSQL DB user:          | $root_user"
+    fi
+fi
+
+#----------------------------------------------------------
+# Check to see if specific user root (as root user) exists
+# Create if not already in system
+#----------------------------------------------------------
+
+if [ $current_user != "postgres" ]; then
+    root_query=$( su - postgres -c "psql -d postgres --tuples-only -P format=unaligned -c \"SELECT usename FROM pg_catalog.pg_user where usename = 'root'\"" )
+    
+    if [ "$root_query" != "root" ]; then
+        echo "[Info    ] PostgreSQL DB user:                | $root_user does not exist"
+        LogMsg "[Info    ] PostgreSQL DB user:                  | $root_user does not exist"
+        sudo -u postgres createuser root
+        echo "[Complete] PostgreSQL DB created user:        | $root_user"
+        echo "$now ($current_user) [Complete] PostgreSQL DB created user:          | $root_user" >> $logfile
+    else
+        echo "[Info    ] PostgreSQL DB user:                | $root_user already exists"
+        LogMsg "[Info    ] PostgreSQL DB user:                  | $root_user already exists"
+    fi
+fi
+
+#-----------------------------------------------
+# Check to see if specific user csmdb exists
+# Create if not already in system
+#-----------------------------------------------
+
+if psql $db_username -t -c '\du' | cut -d \| -f 1 | grep -qw $csmdb_user; then
+    echo "[Info    ] PostgreSQL DB user:                | $csmdb_user already exists"
+    LogMsg "[Info    ] PostgreSQL DB user:                  | $csmdb_user already exists"
+else
+    create_users=`psql -v ON_ERROR_STOP=1 -X -t -q -U postgres -d postgres << THE_END 2>/dev/null
+    CREATE USER $csmdb_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO $csmdb_user;
+THE_END`
+    echo "[Complete] PostgreSQL DB created user:        | $csmdb_user"
+    echo "$now ($current_user) [Complete] PostgreSQL DB created user:          | $csmdb_user" >> $logfile
+fi
+
+#-----------------------------------------------
+# Check to see if specific user xcatadm exists
+# Create if not already in system
+#-----------------------------------------------
+
+if psql $db_username -t -c '\du' | cut -d \| -f 1 | grep -qw $xcat_admin_user; then
+    echo "[Info    ] PostgreSQL DB user:                | $xcat_admin_user already exists"
+    LogMsg "[Info    ] PostgreSQL DB user:                  | $xcat_admin_user already exists"
+    LogMsg "${line2_log}"
+    LogMsg "[End     ] Exiting $0 script"
+    echo "${line1_out}"
+    echo "${line3_log}" >> $logfile
+else
+    create_users=`psql -v ON_ERROR_STOP=1 -X -t -q -U postgres -d postgres << THE_END 2>/dev/null
+    CREATE USER $xcat_admin_user;
+THE_END`
+    echo "[Complete] PostgreSQL DB created user:        | $xcat_admin_user"
+    echo "$now ($current_user) [Complete] PostgreSQL DB created user:          | $xcat_admin_user" >> $logfile
+    echo "${line1_out}"
+    LogMsg "${line2_log}"
+    LogMsg "[End     ] Exiting $0 script"
+    echo "${line3_log}" >> $logfile
+fi


### PR DESCRIPTION
…cripts (DB server status and an ERROR output message related to a non root DB user in the system) and also creating a utility script to assist in the PostgreSQL DB auth^Ctication, server connectivity, and user(s) setup.

# Modified the scripts below with additional DB checks: (DB server status and an ERROR output message related to a non root DB user in the system)
* csm_db_backup_script_v1.sh
* csm_db_connections_script.sh
* csm_db_ras_type_script.sh
* csm_db_script.sh
* csm_db_stats.sh

If the DB server is inactive the following message will display
```
/opt/ibm/csm/db/csm_db_script.sh -n csmdb
------------------------------------------------------------------------------------------------------------------------
[Start   ] Welcome to CSM database automation script.
[Info    ] Log directory: /var/log/ibm/csm/db/csm_db_script.log
[Error   ] The PostgreSQL server: Is currently inactive and needs to be started
[Info    ] If there is an issue please run: systemctl status postgresql for more info.
------------------------------------------------------------------------------------------------------------------------
```

If the DB server is active and the DB "root" is not been created as a DB user the following message will display
```
/opt/ibm/csm/db/csm_db_script.sh -n csmdb
------------------------------------------------------------------------------------------------------------------------
[Start   ] Welcome to CSM database automation script.
[Info    ] Log directory: /var/log/ibm/csm/db/csm_db_script.log
[Error   ] psql: FATAL:  role "root" does not exist
[Info    ] Postgresql may not be configured correctly. Please check configuration settings.
------------------------------------------------------------------------------------------------------------------------
```
# How to Test (Scripts below)
Run regression against the changes above for following scripts:
* csm_db_backup_script_v1.sh
* csm_db_connections_script.sh
* csm_db_ras_type_script.sh
* csm_db_script.sh
* csm_db_stats.sh

1. `systemctl stop postgresql` can be used to stop the DB server.
2. Check to see if the scripts display the appropriate `Error` message handling.
3. `systemctl start postgresql` can be used to restart the DB server.
4. Remove the `root` user from the DB user list.
5. Check to see if the scripts display the appropriate `Error` message handling.
# Creating a utility script to assist in the PostgreSQL DB authentication, server connectivity, and user setup.

If the PostgreSQL RPMs are not installed, then the below message will display, and a complete installation is required before the `csm_db_utility_setup_script.sh`
can be executed. Once all the appropriate packages have been installed, then the `csm_db_utility_setup_script.sh` can be re-ran.

```
/opt/ibm/csm/db/csm_db_utility_setup_script.sh
------------------------------------------------------------------------------------------------------------------------
[Start   ] Welcome to CSM database utility setup script.
------------------------------------------------------------------------------------------------------------------------
[Info    ] Log Directory:                     | /var/log/ibm/csm/db/csm_db_utility_setup_script.log
[Error   ] PostgreSQL RPMs:                   | Are not installed
[Info    ] Please check:                      | Your configuration settings or install PostreSQL RPMs
[Info    ] Once the PostgreSQL RPMs:          | Are installed please re-run this script for setup
------------------------------------------------------------------------------------------------------------------------
```

If for some reason the /var/lib/pgsql/data/ directory have been misconfigured or not present, then an `Error` message will appear. A re-install of the
RPMs may need to take place to ensure the directory exists before the `csm_db_utility_setup_script.sh` can be executed successfully.

```
/opt/ibm/csm/db/csm_db_utility_setup_script.sh
------------------------------------------------------------------------------------------------------------------------
[Start   ] Welcome to CSM database utility setup script.
------------------------------------------------------------------------------------------------------------------------
[Info    ] Log Directory:                     | /var/log/ibm/csm/db/csm_db_utility_setup_script.log
[Info    ] PostgreSQL RPMs:                   | Are already installed
[Error   ] PostgreSQL Data Directory:         | /var/lib/pgsql/data/ does not exist
[Info    ] Something went wrong:              | In the PostgreSQL RPM install.
[Info    ] Please ensure the:                 | /var/lib/pgsql/data/ exists for proper setup.
------------------------------------------------------------------------------------------------------------------------
```

If there are no issues with the above steps, then the script will run and display the following output.
1. RPMs are installed
2. PostgreSQL Data Directory: /var/lib/pgsql/data/ already exists
3. Checks to see if the pg_hba.conf file is currently present in the directory.
4. If the pg_hba.conf doesn't exits then it will be created (HBA stands for host-based authentication.)
   A default pg_hba.conf file is installed when the data directory is initialized by initdb.
5. Activates the PostgreSQL server by running the `systemctl start postgresql` command.
6. Additional check to see if the server was started successfully.
7. Checks to see if the root user exists and if not creates one.
8. Checks to see if the csmdb user exists and if not creates one.
9. Checks to see if the xcatadm user exists and if not creates one.

```
/opt/ibm/csm/db/csm_db_utility_setup_script.sh
------------------------------------------------------------------------------------------------------------------------
[Start   ] Welcome to CSM database utility setup script.
------------------------------------------------------------------------------------------------------------------------
[Info    ] Log Directory:                     | /var/log/ibm/csm/db/csm_db_utility_setup_script.log
[Info    ] PostgreSQL RPMs:                   | Are already installed
[Info    ] PostgreSQL Data Directory:         | /var/lib/pgsql/data/ already exists
[Info    ] Running:                           | The initdb setup
[Complete] PostgreSQL pg_hba.conf file:       | /var/lib/pgsql/data/pg_hba.conf exists in directory
[Info    ] The PostgreSQL server:             | Is currently inactive and needs to be started
[Complete] The PostgreSQL server:             | Is currently running
[Info    ] PostgreSQL DB user:                | root does not exist
[Complete] PostgreSQL DB created user:        | root
[Complete] PostgreSQL DB created user:        | csmdb
[Complete] PostgreSQL DB created user:        | xcatadm
------------------------------------------------------------------------------------------------------------------------
```

If the user runs the script against a previously successful setup the following out will be displayed.

```
/opt/ibm/csm/db/csm_db_utility_setup_script.sh
------------------------------------------------------------------------------------------------------------------------
[Start   ] Welcome to CSM database utility setup script.
------------------------------------------------------------------------------------------------------------------------
[Info    ] Log Directory:                     | /var/log/ibm/csm/db/csm_db_utility_setup_script.log
[Info    ] PostgreSQL RPMs:                   | Are already installed
[Info    ] PostgreSQL Data Directory:         | /var/lib/pgsql/data/ already exists
[Info    ] PostgreSQL pg_hba.conf file:       | /var/lib/pgsql/data/pg_hba.conf already exists
[Info    ] PostgreSQL DB user:                | root already exists
[Info    ] PostgreSQL DB user:                | csmdb already exists
[Info    ] PostgreSQL DB user:                | xcatadm already exists
------------------------------------------------------------------------------------------------------------------------
```

if for some reason the PostgreSQL server has stopped then the `csm_db_utility_setup_script.sh` can be ran or the following command can be used
systemctl start postgresql

```
/opt/ibm/csm/db/csm_db_utility_setup_script.sh
------------------------------------------------------------------------------------------------------------------------
[Start   ] Welcome to CSM database utility setup script.
------------------------------------------------------------------------------------------------------------------------
[Info    ] Log Directory:                     | /var/log/ibm/csm/db/csm_db_utility_setup_script.log
[Info    ] PostgreSQL RPMs:                   | Are already installed
[Info    ] PostgreSQL Data Directory:         | /var/lib/pgsql/data/ already exists
[Info    ] PostgreSQL pg_hba.conf file:       | /var/lib/pgsql/data/pg_hba.conf already exists
[Info    ] The PostgreSQL server:             | Is currently inactive and needs to be started
[Complete] The PostgreSQL server:             | Is currently running
[Info    ] PostgreSQL DB user:                | root already exists
[Info    ] PostgreSQL DB user:                | csmdb already exists
[Info    ] PostgreSQL DB user:                | xcatadm already exists
------------------------------------------------------------------------------------------------------------------------
```

# How to Test (csm_db_utility_setup_script.sh)
test case 1:
1. Uninstall all the `PostgreSQL RPMs`
2. Run the `/opt/ibm/csm/db/csm_db_utility_setup_script.sh`
3. Check to see if the appropriate `Error` messages are displayed

test case 2:
1. Install the `PostgreSQL RPMs`, but remove the `data` directory (/var/lib/pgsql/data/) as `postgres` user.
2. Run the `/opt/ibm/csm/db/csm_db_utility_setup_script.sh`
3. Check to see if the appropriate `Error` messages are displayed

test case 3:
1. Create the the `data` directory (/var/lib/pgsql/data/) as `postgres` user.
2. Run the `/opt/ibm/csm/db/csm_db_utility_setup_script.sh`
3. Check to see if the script ran successfully with and created the appropriate users.

test case 4:
1. Stop the DB server `systemctl stop postgresql`.
2. Run the `/opt/ibm/csm/db/csm_db_utility_setup_script.sh`.
3. Check to see if the script ran successfully (with running server) and skipped the the user setup.
4. An additional check can be ran to see if the PostgreSQL server is up `systemctl status postgresql`.

## TODOs
- [x] @pdlun92 to review (regression)
- [ ] @mew2057 check the code.
- [ ] @fpizzano user and sanity check.
