### PR TITLE
Issue #596 Enable logs before version check to avoid git commit msg

### DIFF
--- a/bb/src/bbapi2.cc
+++ b/bb/src/bbapi2.cc
@@ -98,8 +98,6 @@ int BB_InitLibrary2(uint32_t contribId, const char* clientVersion, const char* u
 
     try
     {
-        std::string l_clientVersion = clientVersion;
-        rc=versionCheck(l_clientVersion);
 
         if (unixpath && strlen(unixpath))
         {
@@ -124,6 +122,9 @@ int BB_InitLibrary2(uint32_t contribId, const char* clientVersion, const char* u
             bberror << err("error.flightlogPath", config.get(who + ".flightlog", NO_CONFIG_VALUE));
             LOG_ERROR_TEXT_RC_AND_BAIL(errorText, rc);
         }
+
+        std::string l_clientVersion = clientVersion;
+        rc=versionCheck(l_clientVersion);
 
         char myjobid[256];
 

--- a/bb/tests/src/test_GetUsage.c
+++ b/bb/tests/src/test_GetUsage.c
@@ -49,7 +49,7 @@ int main(int argc, char** argv)
     uint32_t l_contribId = 0;
     char* l_MountPoint = "/tmp/GetUsage";
     BBUsage_t l_Usage;
-    BBCREATEFLAGS l_CreateFlags = (BBCREATEFLAGS)0;
+    BBCREATEFLAGS l_CreateFlags = BBXFS;
     char bbsize[]="200M";
     
     size_t l_Size = (size_t)2048;


### PR DESCRIPTION
# Purpose
Fix issue [IBM/CAST] BB gitcommit version mismatch message displayed via libbbapi (#596)

# Approach
Version check is now done after setting up logging facility.

# Origin
Issue 596 discovery.

Future versions of libbbAPI.so will print the git version mismatch only if logging is appropriately set up.