### PR TITLE
Removing python-elasticsearch dependency

### DIFF
--- a/csm_big_data/python/CMakeLists.txt
+++ b/csm_big_data/python/CMakeLists.txt
@@ -33,6 +33,7 @@ install(PROGRAMS ${INSTALL_PROGRAMS} COMPONENT ${BDS_RPM_NAME} DESTINATION ${BDS
 file(GLOB INSTALL_FILES
     "cast_helper.py"
     "sampleWeightedErrorMap.json"
+    "requirements.txt"
 )
 
 install(FILES ${INSTALL_FILES} COMPONENT ${BDS_RPM_NAME} DESTINATION ${BDS_BASE_NAME}/${SUBDIR})

--- a/csm_big_data/python/requirements.txt
+++ b/csm_big_data/python/requirements.txt
@@ -1,0 +1,2 @@
+elasticsearch>=6.0.0,<7.0.0
+

--- a/csm_big_data/setupRPM.cmake
+++ b/csm_big_data/setupRPM.cmake
@@ -18,7 +18,7 @@ set( CPACK_RPM_csm-bds_POST_INSTALL_SCRIPT_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/csm_big_data/rpmscripts/cast-bds.post.install" )
 set( CPACK_RPM_csm-bds_PRE_UNINSTALL_SCRIPT_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/csm_big_data/rpmscripts/cast-bds.pre.uninstall" )
-set(CPACK_RPM_csm-bds_PACKAGE_REQUIRES "python-psycopg2 >= 2.5.1, python-elasticsearch >= 1.9")
+set(CPACK_RPM_csm-bds_PACKAGE_REQUIRES "python-psycopg2 >= 2.5.1")
 
 # Setup Kibana RPM
 SET(CPACK_RPM_csm-bds-kibana_PACKAGE_ARCHITECTURE "noarch")

--- a/docs/source/cast-big-data/python-guide.rst
+++ b/docs/source/cast-big-data/python-guide.rst
@@ -10,11 +10,13 @@ Elasticsearch API
 -----------------
 CAST leverages the `Elasticsearch API`_ python library to interact with Elasticsearch. 
 If the API is being run on a node with internet access the following process may be used to install this
-library:
+library. 
+
+A requirements file is provided in the RPM:
 
 .. code-block:: bash
 
-   pip install elasticsearch
+   pip install -r /opt/ibm/csm/bigdata/python/requirements.txt
 
 If the node doesn't have access to the internet please refer to the official python documentation for the installation
 of wheels: `Installing Packages`_.


### PR DESCRIPTION
The python-elasticsearch dependency was erroneously added. The version present in the rhels 7.5 epel is far too old for the BDS offering. A requirements.txt file will now be provided with the CSM BDS usecases to handle dependencies.