### PR TITLE
Fixing the serialization of the Red-Black Tree for json serialization.

### DIFF
--- a/csmi/include/struct_generator/rb_tree.pl
+++ b/csmi/include/struct_generator/rb_tree.pl
@@ -209,17 +209,29 @@ sub RBArrayOrder{
     my $depth = 0;
     print("\n");
 
+    my $terminal_node = {};
+    $terminal_node->{DEPTH} = -1;
+
     if ( defined $tree )
     {
         $tree->{DEPTH} = 0;
     }
 
+    my $count  = 1;
     # A queue is used to gereate an array mapping of the tree for the C const.
     while (@tree_queue)
     {
+        $count +=1;
         my $node = shift @tree_queue;
         if (defined $node )
         {
+            if ($node->{DEPTH} == -1 )
+            {
+                $null_string.= "$default_string,\n"; 
+                $null_count++;
+                next;
+            }
+
             # If a real value was found after a string of nulls add it to the string.
             if ($null_count > 0)
             {
@@ -259,6 +271,8 @@ sub RBArrayOrder{
         }
         else
         {
+            push @tree_queue,$terminal_node;
+            push @tree_queue,$terminal_node;
             $null_string.= "$default_string,\n"; 
             $null_count++;
         }
@@ -279,7 +293,7 @@ sub RBArrayOrder{
 
     substr($string,-2)="";
     $string .="}\n";
-    
+   
     return ($num_fields,$string);
 }
 1; #true value for compilation

--- a/csmi/src/bb/src/csmi_bb_internal.c
+++ b/csmi/src/bb/src/csmi_bb_internal.c
@@ -100,13 +100,15 @@ const csmi_struct_mapping_t map_csm_bb_cmd_output_t= {
     cast_csm_bb_cmd_output_t
 };
 
-const csmi_struct_node_t csm_bb_lv_create_input_tree[11] = {{"current_size",offsetof(csm_bb_lv_create_input_t,current_size),0,NULL,0x454b21c2,40},
+const csmi_struct_node_t csm_bb_lv_create_input_tree[13] = {{"current_size",offsetof(csm_bb_lv_create_input_t,current_size),0,NULL,0x454b21c2,40},
 {"state",offsetof(csm_bb_lv_create_input_t,state),0,NULL,0x10614a06,68},
 {"allocation_id",offsetof(csm_bb_lv_create_input_t,allocation_id),0,NULL,0x99d3da77,40},
 {NULL,0,0,NULL,0,0},
 {"file_system_mount",offsetof(csm_bb_lv_create_input_t,file_system_mount),0,NULL,0x33eec6bb,4},
 {"node_name",offsetof(csm_bb_lv_create_input_t,node_name),0,NULL,0x746e3e2b,4},
 {"file_system_type",offsetof(csm_bb_lv_create_input_t,file_system_type),0,NULL,0xa47f99ea,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"logical_volume_name",offsetof(csm_bb_lv_create_input_t,logical_volume_name),0,NULL,0x7221a037,4},
@@ -118,18 +120,22 @@ void* cast_csm_bb_lv_create_input_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_bb_lv_create_input_t= {
-    11,
+    13,
     csm_bb_lv_create_input_tree,
     cast_csm_bb_lv_create_input_t
 };
 
-const csmi_struct_node_t csm_bb_lv_delete_input_tree[11] = {{"num_bytes_read",offsetof(csm_bb_lv_delete_input_t,num_bytes_read),0,NULL,0x38181676,40},
+const csmi_struct_node_t csm_bb_lv_delete_input_tree[15] = {{"num_bytes_read",offsetof(csm_bb_lv_delete_input_t,num_bytes_read),0,NULL,0x38181676,40},
 {"num_bytes_written",offsetof(csm_bb_lv_delete_input_t,num_bytes_written),0,NULL,0xd3acfa7,40},
 {"node_name",offsetof(csm_bb_lv_delete_input_t,node_name),0,NULL,0x746e3e2b,4},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"logical_volume_name",offsetof(csm_bb_lv_delete_input_t,logical_volume_name),0,NULL,0x7221a037,4},
 {"allocation_id",offsetof(csm_bb_lv_delete_input_t,allocation_id),0,NULL,0x99d3da77,40},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"num_writes",offsetof(csm_bb_lv_delete_input_t,num_writes),0,NULL,0x75dc6b52,40},
@@ -141,7 +147,7 @@ void* cast_csm_bb_lv_delete_input_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_bb_lv_delete_input_t= {
-    11,
+    15,
     csm_bb_lv_delete_input_tree,
     cast_csm_bb_lv_delete_input_t
 };
@@ -205,13 +211,17 @@ const csmi_struct_mapping_t map_csm_bb_lv_update_input_t= {
     cast_csm_bb_lv_update_input_t
 };
 
-const csmi_struct_node_t csm_bb_vg_create_input_tree[9] = {{"ssd_info_count",offsetof(csm_bb_vg_create_input_t,ssd_info_count),0,NULL,0xbca8962,24},
+const csmi_struct_node_t csm_bb_vg_create_input_tree[13] = {{"ssd_info_count",offsetof(csm_bb_vg_create_input_t,ssd_info_count),0,NULL,0xbca8962,24},
 {"available_size",offsetof(csm_bb_vg_create_input_t,available_size),0,NULL,0x9b91340,40},
 {"total_size",offsetof(csm_bb_vg_create_input_t,total_size),0,NULL,0xc7f736e3,40},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"node_name",offsetof(csm_bb_vg_create_input_t,node_name),0,NULL,0x746e3e2b,4},
 {"scheduler",offsetof(csm_bb_vg_create_input_t,scheduler),0,NULL,0xdc0deaa4,16},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"ssd_info",offsetof(csm_bb_vg_create_input_t,ssd_info),offsetof(csm_bb_vg_create_input_t, ssd_info_count),&map_csmi_bb_vg_ssd_info_t,0x21e5a1da,1},
 {"vg_name",offsetof(csm_bb_vg_create_input_t,vg_name),0,NULL,0x76500bc2,4}}
 ;
@@ -221,7 +231,7 @@ void* cast_csm_bb_vg_create_input_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_bb_vg_create_input_t= {
-    9,
+    13,
     csm_bb_vg_create_input_tree,
     cast_csm_bb_vg_create_input_t
 };

--- a/csmi/src/diag/src/csmi_diag_internal.c
+++ b/csmi/src/diag/src/csmi_diag_internal.c
@@ -75,13 +75,17 @@ const csmi_struct_mapping_t map_csm_diag_run_end_input_t= {
     cast_csm_diag_run_end_input_t
 };
 
-const csmi_struct_node_t csm_diag_result_create_input_tree[9] = {{"status",offsetof(csm_diag_result_create_input_t,status),16,NULL,0x1c8a8d49,70},
+const csmi_struct_node_t csm_diag_result_create_input_tree[13] = {{"status",offsetof(csm_diag_result_create_input_t,status),16,NULL,0x1c8a8d49,70},
 {"run_id",offsetof(csm_diag_result_create_input_t,run_id),0,NULL,0x1a4e4326,40},
 {"test_name",offsetof(csm_diag_result_create_input_t,test_name),0,NULL,0x9a6d8425,4},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"node_name",offsetof(csm_diag_result_create_input_t,node_name),0,NULL,0x746e3e2b,4},
 {"serial_number",offsetof(csm_diag_result_create_input_t,serial_number),0,NULL,0xd931f68d,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"begin_time",offsetof(csm_diag_result_create_input_t,begin_time),0,NULL,0x5f818b18,4},
 {"log_file",offsetof(csm_diag_result_create_input_t,log_file),0,NULL,0x7f2d9ce6,4}}
 ;
@@ -91,7 +95,7 @@ void* cast_csm_diag_result_create_input_t(void* ptr,size_t index, char isArray) 
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_diag_result_create_input_t= {
-    9,
+    13,
     csm_diag_result_create_input_tree,
     cast_csm_diag_result_create_input_t
 };
@@ -113,7 +117,7 @@ const csmi_struct_mapping_t map_csm_diag_run_begin_input_t= {
     cast_csm_diag_run_begin_input_t
 };
 
-const csmi_struct_node_t csm_diag_run_query_input_tree[22] = {{"allocation_ids_count",offsetof(csm_diag_run_query_input_t,allocation_ids_count),0,NULL,0x49964552,24},
+const csmi_struct_node_t csm_diag_run_query_input_tree[30] = {{"allocation_ids_count",offsetof(csm_diag_run_query_input_t,allocation_ids_count),0,NULL,0x49964552,24},
 {"offset",offsetof(csm_diag_run_query_input_t,offset),0,NULL,0x123b4b4c,36},
 {"inserted_ras",offsetof(csm_diag_run_query_input_t,inserted_ras),0,NULL,0x89b6b1e8,16},
 {"limit",offsetof(csm_diag_run_query_input_t,limit),0,NULL,0xfdcc804,36},
@@ -134,6 +138,14 @@ const csmi_struct_node_t csm_diag_run_query_input_tree[22] = {{"allocation_ids_c
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"allocation_ids",offsetof(csm_diag_run_query_input_t,allocation_ids),offsetof(csm_diag_run_query_input_t, allocation_ids_count),NULL,0xd44f29ca,1}}
 ;
 
@@ -142,7 +154,7 @@ void* cast_csm_diag_run_query_input_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_diag_run_query_input_t= {
-    22,
+    30,
     csm_diag_run_query_input_tree,
     cast_csm_diag_run_query_input_t
 };

--- a/csmi/src/inv/src/csmi_inv_internal.c
+++ b/csmi/src/inv/src/csmi_inv_internal.c
@@ -81,7 +81,7 @@ const csmi_struct_mapping_t map_csmi_hca_record_t= {
     cast_csmi_hca_record_t
 };
 
-const csmi_struct_node_t csmi_ib_cable_record_tree[23] = {{"discovery_time",offsetof(csmi_ib_cable_record_t,discovery_time),0,NULL,0x603630cb,4},
+const csmi_struct_node_t csmi_ib_cable_record_tree[25] = {{"discovery_time",offsetof(csmi_ib_cable_record_t,discovery_time),0,NULL,0x603630cb,4},
 {"guid_s1",offsetof(csmi_ib_cable_record_t,guid_s1),0,NULL,0x14fe2691,4},
 {"identifier",offsetof(csmi_ib_cable_record_t,identifier),0,NULL,0xbe5ad288,4},
 {"length",offsetof(csmi_ib_cable_record_t,length),0,NULL,0xb2deac7,4},
@@ -99,6 +99,8 @@ const csmi_struct_node_t csmi_ib_cable_record_tree[23] = {{"discovery_time",offs
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"severity",offsetof(csmi_ib_cable_record_t,severity),0,NULL,0x16a499a0,4},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -111,7 +113,7 @@ void* cast_csmi_ib_cable_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_ib_cable_record_t= {
-    23,
+    25,
     csmi_ib_cable_record_tree,
     cast_csmi_ib_cable_record_t
 };
@@ -153,7 +155,7 @@ const csmi_struct_mapping_t map_csmi_ib_cable_history_record_t= {
     cast_csmi_ib_cable_history_record_t
 };
 
-const csmi_struct_node_t csmi_node_attributes_record_tree[57] = {{"type",offsetof(csmi_node_attributes_record_t,type),csmi_node_type_t_MAX,&csmi_node_type_t_strs,0x7c9ebd07,8},
+const csmi_struct_node_t csmi_node_attributes_record_tree[61] = {{"type",offsetof(csmi_node_attributes_record_t,type),csmi_node_type_t_MAX,&csmi_node_type_t_strs,0x7c9ebd07,8},
 {"available_cores",offsetof(csmi_node_attributes_record_t,available_cores),0,NULL,0x3fbd1be1,36},
 {"comment",offsetof(csmi_node_attributes_record_t,comment),0,NULL,0xd363aa58,4},
 {"ready",offsetof(csmi_node_attributes_record_t,ready),0,NULL,0x1046f5da,16},
@@ -209,6 +211,10 @@ const csmi_struct_node_t csmi_node_attributes_record_tree[57] = {{"type",offseto
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"collection_time",offsetof(csmi_node_attributes_record_t,collection_time),0,NULL,0xd67e7d1f,4}}
 ;
 
@@ -217,12 +223,12 @@ void* cast_csmi_node_attributes_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_node_attributes_record_t= {
-    57,
+    61,
     csmi_node_attributes_record_tree,
     cast_csmi_node_attributes_record_t
 };
 
-const csmi_struct_node_t csmi_node_attributes_history_record_tree[57] = {{"type",offsetof(csmi_node_attributes_history_record_t,type),csmi_node_type_t_MAX,&csmi_node_type_t_strs,0x7c9ebd07,8},
+const csmi_struct_node_t csmi_node_attributes_history_record_tree[61] = {{"type",offsetof(csmi_node_attributes_history_record_t,type),csmi_node_type_t_MAX,&csmi_node_type_t_strs,0x7c9ebd07,8},
 {"available_cores",offsetof(csmi_node_attributes_history_record_t,available_cores),0,NULL,0x3fbd1be1,36},
 {"comment",offsetof(csmi_node_attributes_history_record_t,comment),0,NULL,0xd363aa58,4},
 {"ready",offsetof(csmi_node_attributes_history_record_t,ready),0,NULL,0x1046f5da,16},
@@ -278,6 +284,10 @@ const csmi_struct_node_t csmi_node_attributes_history_record_tree[57] = {{"type"
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"collection_time",offsetof(csmi_node_attributes_history_record_t,collection_time),0,NULL,0xd67e7d1f,4}}
 ;
 
@@ -286,7 +296,7 @@ void* cast_csmi_node_attributes_history_record_t(void* ptr,size_t index, char is
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_node_attributes_history_record_t= {
-    57,
+    61,
     csmi_node_attributes_history_record_tree,
     cast_csmi_node_attributes_history_record_t
 };
@@ -310,13 +320,17 @@ const csmi_struct_mapping_t map_csmi_node_query_state_history_record_t= {
     cast_csmi_node_query_state_history_record_t
 };
 
-const csmi_struct_node_t csmi_processor_record_tree[9] = {{"status",offsetof(csmi_processor_record_t,status),0,NULL,0x1c8a8d49,68},
+const csmi_struct_node_t csmi_processor_record_tree[13] = {{"status",offsetof(csmi_processor_record_t,status),0,NULL,0x1c8a8d49,68},
 {"socket",offsetof(csmi_processor_record_t,socket),0,NULL,0x1c31032e,36},
 {"node_name",offsetof(csmi_processor_record_t,node_name),0,NULL,0x746e3e2b,4},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"available_cores",offsetof(csmi_processor_record_t,available_cores),0,NULL,0x3fbd1be1,36},
 {"serial_number",offsetof(csmi_processor_record_t,serial_number),0,NULL,0xd931f68d,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"discovered_cores",offsetof(csmi_processor_record_t,discovered_cores),0,NULL,0x20dc9308,36},
 {"physical_location",offsetof(csmi_processor_record_t,physical_location),0,NULL,0x63efcf7a,4}}
 ;
@@ -326,12 +340,12 @@ void* cast_csmi_processor_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_processor_record_t= {
-    9,
+    13,
     csmi_processor_record_tree,
     cast_csmi_processor_record_t
 };
 
-const csmi_struct_node_t csmi_ssd_record_tree[25] = {{"wear_total_bytes_read",offsetof(csmi_ssd_record_t,wear_total_bytes_read),0,NULL,0x9e5253b8,40},
+const csmi_struct_node_t csmi_ssd_record_tree[31] = {{"wear_total_bytes_read",offsetof(csmi_ssd_record_t,wear_total_bytes_read),0,NULL,0x9e5253b8,40},
 {"wear_lifespan_used",offsetof(csmi_ssd_record_t,wear_lifespan_used),0,NULL,0x7bc95915,56},
 {"total_size",offsetof(csmi_ssd_record_t,total_size),0,NULL,0xc7f736e3,40},
 {"discovery_time",offsetof(csmi_ssd_record_t,discovery_time),0,NULL,0x603630cb,4},
@@ -355,6 +369,12 @@ const csmi_struct_node_t csmi_ssd_record_tree[25] = {{"wear_total_bytes_read",of
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"fw_ver",offsetof(csmi_ssd_record_t,fw_ver),0,NULL,0xfe6cb44e,4}}
 ;
 
@@ -363,12 +383,12 @@ void* cast_csmi_ssd_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_ssd_record_t= {
-    25,
+    31,
     csmi_ssd_record_tree,
     cast_csmi_ssd_record_t
 };
 
-const csmi_struct_node_t csmi_switch_record_tree[44] = {{"discovery_time",offsetof(csmi_switch_record_t,discovery_time),0,NULL,0x603630cb,4},
+const csmi_struct_node_t csmi_switch_record_tree[50] = {{"discovery_time",offsetof(csmi_switch_record_t,discovery_time),0,NULL,0x603630cb,4},
 {"fw_version",offsetof(csmi_switch_record_t,fw_version),0,NULL,0x136b0847,4},
 {"has_ufm_agent",offsetof(csmi_switch_record_t,has_ufm_agent),0,NULL,0xaab4c3f6,16},
 {"gu_id",offsetof(csmi_switch_record_t,gu_id),0,NULL,0xf88a66d,4},
@@ -410,6 +430,12 @@ const csmi_struct_node_t csmi_switch_record_tree[44] = {{"discovery_time",offset
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"total_alarms",offsetof(csmi_switch_record_t,total_alarms),0,NULL,0x78cc7a28,36},
 {"type",offsetof(csmi_switch_record_t,type),0,NULL,0x7c9ebd07,4}}
 ;
@@ -419,12 +445,12 @@ void* cast_csmi_switch_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_switch_record_t= {
-    44,
+    50,
     csmi_switch_record_tree,
     cast_csmi_switch_record_t
 };
 
-const csmi_struct_node_t csmi_switch_inventory_record_tree[27] = {{"name",offsetof(csmi_switch_inventory_record_t,name),0,NULL,0x7c9b0c46,4},
+const csmi_struct_node_t csmi_switch_inventory_record_tree[29] = {{"name",offsetof(csmi_switch_inventory_record_t,name),0,NULL,0x7c9b0c46,4},
 {"max_ib_ports",offsetof(csmi_switch_inventory_record_t,max_ib_ports),0,NULL,0x1c135c0c,36},
 {"host_system_guid",offsetof(csmi_switch_inventory_record_t,host_system_guid),0,NULL,0xd5e2674f,4},
 {"severity",offsetof(csmi_switch_inventory_record_t,severity),0,NULL,0x16a499a0,4},
@@ -445,6 +471,8 @@ const csmi_struct_node_t csmi_switch_inventory_record_tree[27] = {{"name",offset
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"path",offsetof(csmi_switch_inventory_record_t,path),0,NULL,0x7c9c25f2,4},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -458,12 +486,12 @@ void* cast_csmi_switch_inventory_record_t(void* ptr,size_t index, char isArray) 
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_switch_inventory_record_t= {
-    27,
+    29,
     csmi_switch_inventory_record_tree,
     cast_csmi_switch_inventory_record_t
 };
 
-const csmi_struct_node_t csmi_switch_ports_record_tree[42] = {{"description",offsetof(csmi_switch_ports_record_t,description),0,NULL,0x91b0c789,4},
+const csmi_struct_node_t csmi_switch_ports_record_tree[46] = {{"description",offsetof(csmi_switch_ports_record_t,description),0,NULL,0x91b0c789,4},
 {"enabled_speed",offsetof(csmi_switch_ports_record_t,enabled_speed),0,NULL,0x2c6b10c0,4},
 {"comment",offsetof(csmi_switch_ports_record_t,comment),0,NULL,0xd363aa58,4},
 {"mirror",offsetof(csmi_switch_ports_record_t,mirror),0,NULL,0xdcdd520,4},
@@ -497,6 +525,10 @@ const csmi_struct_node_t csmi_switch_ports_record_tree[42] = {{"description",off
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"severity",offsetof(csmi_switch_ports_record_t,severity),0,NULL,0x16a499a0,4},
 {"max_supported_speed",offsetof(csmi_switch_ports_record_t,max_supported_speed),0,NULL,0x3c485ae0,4},
 {"mirror_traffic",offsetof(csmi_switch_ports_record_t,mirror_traffic),0,NULL,0x43338b1e,4},
@@ -512,7 +544,7 @@ void* cast_csmi_switch_ports_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_switch_ports_record_t= {
-    42,
+    46,
     csmi_switch_ports_record_tree,
     cast_csmi_switch_ports_record_t
 };
@@ -535,7 +567,7 @@ const csmi_struct_mapping_t map_csmi_switch_details_t= {
     cast_csmi_switch_details_t
 };
 
-const csmi_struct_node_t csmi_switch_history_record_tree[49] = {{"history_time",offsetof(csmi_switch_history_record_t,history_time),0,NULL,0x60dc8265,4},
+const csmi_struct_node_t csmi_switch_history_record_tree[55] = {{"history_time",offsetof(csmi_switch_history_record_t,history_time),0,NULL,0x60dc8265,4},
 {"fw_version",offsetof(csmi_switch_history_record_t,fw_version),0,NULL,0x136b0847,4},
 {"has_ufm_agent",offsetof(csmi_switch_history_record_t,has_ufm_agent),0,NULL,0xaab4c3f6,16},
 {"gu_id",offsetof(csmi_switch_history_record_t,gu_id),0,NULL,0xf88a66d,4},
@@ -571,8 +603,14 @@ const csmi_struct_node_t csmi_switch_history_record_tree[49] = {{"history_time",
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"vendor",offsetof(csmi_switch_history_record_t,vendor),0,NULL,0x228173b3,4},
 {"operation",offsetof(csmi_switch_history_record_t,operation),0,NULL,0x40a16e96,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -591,7 +629,7 @@ void* cast_csmi_switch_history_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_switch_history_record_t= {
-    49,
+    55,
     csmi_switch_history_record_tree,
     cast_csmi_switch_history_record_t
 };
@@ -688,13 +726,15 @@ const csmi_struct_mapping_t map_csmi_cluster_query_state_record_t= {
     cast_csmi_cluster_query_state_record_t
 };
 
-const csmi_struct_node_t csmi_node_find_job_record_tree[11] = {{"allocation_id",offsetof(csmi_node_find_job_record_t,allocation_id),0,NULL,0x99d3da77,40},
+const csmi_struct_node_t csmi_node_find_job_record_tree[13] = {{"allocation_id",offsetof(csmi_node_find_job_record_t,allocation_id),0,NULL,0x99d3da77,40},
 {"node_name",offsetof(csmi_node_find_job_record_t,node_name),0,NULL,0x746e3e2b,4},
 {"user_name",offsetof(csmi_node_find_job_record_t,user_name),0,NULL,0xc029f5a4,4},
 {"begin_time",offsetof(csmi_node_find_job_record_t,begin_time),0,NULL,0x5f818b18,4},
 {NULL,0,0,NULL,0,0},
 {"num_nodes",offsetof(csmi_node_find_job_record_t,num_nodes),0,NULL,0xa5d6722d,36},
 {"primary_job_id",offsetof(csmi_node_find_job_record_t,primary_job_id),0,NULL,0xcfd430cf,40},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -706,7 +746,7 @@ void* cast_csmi_node_find_job_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_node_find_job_record_t= {
-    11,
+    13,
     csmi_node_find_job_record_tree,
     cast_csmi_node_find_job_record_t
 };
@@ -1040,7 +1080,7 @@ const csmi_struct_mapping_t map_csm_node_delete_output_t= {
     cast_csm_node_delete_output_t
 };
 
-const csmi_struct_node_t csm_node_find_job_input_tree[21] = {{"begin_time_search_begin",offsetof(csm_node_find_job_input_t,begin_time_search_begin),0,NULL,0x34e5bb11,4},
+const csmi_struct_node_t csm_node_find_job_input_tree[27] = {{"begin_time_search_begin",offsetof(csm_node_find_job_input_t,begin_time_search_begin),0,NULL,0x34e5bb11,4},
 {"offset",offsetof(csm_node_find_job_input_t,offset),0,NULL,0x123b4b4c,36},
 {"begin_time_search_end",offsetof(csm_node_find_job_input_t,begin_time_search_end),0,NULL,0xc583ac83,4},
 {"limit",offsetof(csm_node_find_job_input_t,limit),0,NULL,0xfdcc804,36},
@@ -1057,6 +1097,12 @@ const csmi_struct_node_t csm_node_find_job_input_tree[21] = {{"begin_time_search
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"search_range_begin",offsetof(csm_node_find_job_input_t,search_range_begin),0,NULL,0x35fc576b,4},
 {"node_names_count",offsetof(csm_node_find_job_input_t,node_names_count),0,NULL,0x868cf686,24},
 {"midpoint",offsetof(csm_node_find_job_input_t,midpoint),0,NULL,0x97cb1ba9,4},
@@ -1068,7 +1114,7 @@ void* cast_csm_node_find_job_input_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_node_find_job_input_t= {
-    21,
+    27,
     csm_node_find_job_input_tree,
     cast_csm_node_find_job_input_t
 };

--- a/csmi/src/ras/src/csmi_ras_internal.c
+++ b/csmi/src/ras/src/csmi_ras_internal.c
@@ -84,13 +84,15 @@ const csmi_struct_mapping_t map_csmi_ras_event_action_record_t= {
     cast_csmi_ras_event_action_record_t
 };
 
-const csmi_struct_node_t csmi_ras_event_action_tree[13] = {{"rec_id",offsetof(csmi_ras_event_action_t,rec_id),0,NULL,0x1926b2eb,40},
+const csmi_struct_node_t csmi_ras_event_action_tree[15] = {{"rec_id",offsetof(csmi_ras_event_action_t,rec_id),0,NULL,0x1926b2eb,40},
 {"count",offsetof(csmi_ras_event_action_t,count),0,NULL,0xf3d586e,36},
 {"time_stamp",offsetof(csmi_ras_event_action_t,time_stamp),0,NULL,0xae3ff458,4},
 {"msg_id",offsetof(csmi_ras_event_action_t,msg_id),0,NULL,0xe7c7058,4},
 {NULL,0,0,NULL,0,0},
 {"location_name",offsetof(csmi_ras_event_action_t,location_name),0,NULL,0x54e4507e,4},
 {"msg_id_seq",offsetof(csmi_ras_event_action_t,msg_id_seq),0,NULL,0xdda2eb00,36},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -104,12 +106,12 @@ void* cast_csmi_ras_event_action_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_ras_event_action_t= {
-    13,
+    15,
     csmi_ras_event_action_tree,
     cast_csmi_ras_event_action_t
 };
 
-const csmi_struct_node_t csmi_ras_event_tree[22] = {{"processor",offsetof(csmi_ras_event_t,processor),0,NULL,0x6cb287a5,36},
+const csmi_struct_node_t csmi_ras_event_tree[30] = {{"processor",offsetof(csmi_ras_event_t,processor),0,NULL,0x6cb287a5,36},
 {"count",offsetof(csmi_ras_event_t,count),0,NULL,0xf3d586e,36},
 {"suppress_ids",offsetof(csmi_ras_event_t,suppress_ids),0,NULL,0xad086749,4},
 {"msg_id",offsetof(csmi_ras_event_t,msg_id),0,NULL,0xe7c7058,4},
@@ -124,8 +126,16 @@ const csmi_struct_node_t csmi_ras_event_tree[22] = {{"processor",offsetof(csmi_r
 {NULL,0,0,NULL,0,0},
 {"time_stamp",offsetof(csmi_ras_event_t,time_stamp),0,NULL,0xae3ff458,4},
 {"raw_data",offsetof(csmi_ras_event_t,raw_data),0,NULL,0xf85a97e8,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"kvcsv",offsetof(csmi_ras_event_t,kvcsv),0,NULL,0xfd1a732,4},
 {"rec_id",offsetof(csmi_ras_event_t,rec_id),0,NULL,0x1926b2eb,40},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -138,7 +148,7 @@ void* cast_csmi_ras_event_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_ras_event_t= {
-    22,
+    30,
     csmi_ras_event_tree,
     cast_csmi_ras_event_t
 };
@@ -158,7 +168,7 @@ const csmi_struct_mapping_t map_csmi_ras_event_vector_t= {
     cast_csmi_ras_event_vector_t
 };
 
-const csmi_struct_node_t csm_ras_event_query_input_tree[22] = {{"order_by",offsetof(csm_ras_event_query_input_t,order_by),0,NULL,0x245553bb,68},
+const csmi_struct_node_t csm_ras_event_query_input_tree[26] = {{"order_by",offsetof(csm_ras_event_query_input_t,order_by),0,NULL,0x245553bb,68},
 {"offset",offsetof(csm_ras_event_query_input_t,offset),0,NULL,0x123b4b4c,36},
 {"location_name",offsetof(csm_ras_event_query_input_t,location_name),0,NULL,0x54e4507e,4},
 {"limit",offsetof(csm_ras_event_query_input_t,limit),0,NULL,0xfdcc804,36},
@@ -179,6 +189,10 @@ const csmi_struct_node_t csm_ras_event_query_input_tree[22] = {{"order_by",offse
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"master_time_stamp_search_end",offsetof(csm_ras_event_query_input_t,master_time_stamp_search_end),0,NULL,0x45dc3cce,4}}
 ;
 
@@ -187,7 +201,7 @@ void* cast_csm_ras_event_query_input_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_ras_event_query_input_t= {
-    22,
+    26,
     csm_ras_event_query_input_tree,
     cast_csm_ras_event_query_input_t
 };
@@ -349,13 +363,15 @@ const csmi_struct_mapping_t map_csm_ras_msg_type_update_output_t= {
     cast_csm_ras_msg_type_update_output_t
 };
 
-const csmi_struct_node_t csm_ras_msg_type_query_input_tree[13] = {{"offset",offsetof(csm_ras_msg_type_query_input_t,offset),0,NULL,0x123b4b4c,36},
+const csmi_struct_node_t csm_ras_msg_type_query_input_tree[15] = {{"offset",offsetof(csm_ras_msg_type_query_input_t,offset),0,NULL,0x123b4b4c,36},
 {"limit",offsetof(csm_ras_msg_type_query_input_t,limit),0,NULL,0xfdcc804,36},
 {"control_action",offsetof(csm_ras_msg_type_query_input_t,control_action),0,NULL,0x4bd6e603,4},
 {"msg_id",offsetof(csm_ras_msg_type_query_input_t,msg_id),0,NULL,0xe7c7058,4},
 {NULL,0,0,NULL,0,0},
 {"severity",offsetof(csm_ras_msg_type_query_input_t,severity),csmi_ras_severity_t_MAX,&csmi_ras_severity_t_strs,0x16a499a0,8},
 {"set_states",offsetof(csm_ras_msg_type_query_input_t,set_states),offsetof(csm_ras_msg_type_query_input_t, set_states_count),NULL,0xaee22e84,5},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -369,7 +385,7 @@ void* cast_csm_ras_msg_type_query_input_t(void* ptr,size_t index, char isArray) 
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_ras_msg_type_query_input_t= {
-    13,
+    15,
     csm_ras_msg_type_query_input_tree,
     cast_csm_ras_msg_type_query_input_t
 };

--- a/csmi/src/wm/src/csmi_wm_internal.c
+++ b/csmi/src/wm/src/csmi_wm_internal.c
@@ -29,7 +29,7 @@ const csmi_struct_mapping_t map_csmi_allocation_history_t= {
     cast_csmi_allocation_history_t
 };
 
-const csmi_struct_node_t csmi_allocation_tree[53] = {{"allocation_id",offsetof(csmi_allocation_t,allocation_id),0,NULL,0x99d3da77,40},
+const csmi_struct_node_t csmi_allocation_tree[63] = {{"allocation_id",offsetof(csmi_allocation_t,allocation_id),0,NULL,0x99d3da77,40},
 {"user_id",offsetof(csmi_allocation_t,user_id),0,NULL,0x45c27210,36},
 {"ssd_min",offsetof(csmi_allocation_t,ssd_min),0,NULL,0xabb1b072,40},
 {"shared",offsetof(csmi_allocation_t,shared),0,NULL,0x1bb15c9c,16},
@@ -75,6 +75,16 @@ const csmi_struct_node_t csmi_allocation_tree[53] = {{"allocation_id",offsetof(c
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"user_group_id",offsetof(csmi_allocation_t,user_group_id),0,NULL,0xb690441c,36},
 {"user_name",offsetof(csmi_allocation_t,user_name),0,NULL,0xc029f5a4,4},
 {NULL,0,0,NULL,0,0},
@@ -89,12 +99,12 @@ void* cast_csmi_allocation_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_allocation_t= {
-    53,
+    63,
     csmi_allocation_tree,
     cast_csmi_allocation_t
 };
 
-const csmi_struct_node_t csmi_allocation_accounting_tree[16] = {{"gpu_usage",offsetof(csmi_allocation_accounting_t,gpu_usage),0,NULL,0x4178e945,40},
+const csmi_struct_node_t csmi_allocation_accounting_tree[20] = {{"gpu_usage",offsetof(csmi_allocation_accounting_t,gpu_usage),0,NULL,0x4178e945,40},
 {"ib_tx",offsetof(csmi_allocation_accounting_t,ib_tx),0,NULL,0xfa26dbb,40},
 {"gpfs_write",offsetof(csmi_allocation_accounting_t,gpfs_write),0,NULL,0x6947993f,40},
 {"ib_rx",offsetof(csmi_allocation_accounting_t,ib_rx),0,NULL,0xfa26d79,40},
@@ -109,6 +119,10 @@ const csmi_struct_node_t csmi_allocation_accounting_tree[16] = {{"gpu_usage",off
 {"ssd_write",offsetof(csmi_allocation_accounting_t,ssd_write),0,NULL,0x5f997379,40},
 {"cpu_usage",offsetof(csmi_allocation_accounting_t,cpu_usage),0,NULL,0x6f872541,40},
 {"gpfs_read",offsetof(csmi_allocation_accounting_t,gpfs_read),0,NULL,0xebe7ef50,40},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"power_cap",offsetof(csmi_allocation_accounting_t,power_cap),0,NULL,0x15494165,36}}
 ;
 
@@ -117,7 +131,7 @@ void* cast_csmi_allocation_accounting_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_allocation_accounting_t= {
-    16,
+    20,
     csmi_allocation_accounting_tree,
     cast_csmi_allocation_accounting_t
 };
@@ -152,13 +166,15 @@ const csmi_struct_mapping_t map_csmi_allocation_state_history_t= {
     cast_csmi_allocation_state_history_t
 };
 
-const csmi_struct_node_t csmi_allocation_details_tree[13] = {{"power_cap_hit",offsetof(csmi_allocation_details_t,power_cap_hit),0,NULL,0x315b4c49,28},
+const csmi_struct_node_t csmi_allocation_details_tree[15] = {{"power_cap_hit",offsetof(csmi_allocation_details_t,power_cap_hit),0,NULL,0x315b4c49,28},
 {"ssd_read",offsetof(csmi_allocation_details_t,ssd_read),0,NULL,0x21ea6a4a,28},
 {"num_nodes",offsetof(csmi_allocation_details_t,num_nodes),0,NULL,0xa5d6722d,24},
 {"steps",offsetof(csmi_allocation_details_t,steps),offsetof(csmi_allocation_details_t, num_steps),&map_csmi_allocation_step_list_t,0x10615a94,1},
 {NULL,0,0,NULL,0,0},
 {"ssd_write",offsetof(csmi_allocation_details_t,ssd_write),0,NULL,0x5f997379,28},
 {"num_steps",offsetof(csmi_allocation_details_t,num_steps),0,NULL,0xa633b043,24},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"num_transitions",offsetof(csmi_allocation_details_t,num_transitions),0,NULL,0x3fe3fad2,24},
@@ -172,12 +188,12 @@ void* cast_csmi_allocation_details_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_allocation_details_t= {
-    13,
+    15,
     csmi_allocation_details_tree,
     cast_csmi_allocation_details_t
 };
 
-const csmi_struct_node_t csmi_allocation_step_history_tree[21] = {{"omp_thread_limit",offsetof(csmi_allocation_step_history_t,omp_thread_limit),0,NULL,0x8884ccc6,4},
+const csmi_struct_node_t csmi_allocation_step_history_tree[29] = {{"omp_thread_limit",offsetof(csmi_allocation_step_history_t,omp_thread_limit),0,NULL,0x8884ccc6,4},
 {"max_memory",offsetof(csmi_allocation_step_history_t,max_memory),0,NULL,0x66b074e3,40},
 {"total_u_time",offsetof(csmi_allocation_step_history_t,total_u_time),0,NULL,0xa692ad0b,56},
 {"gpu_stats",offsetof(csmi_allocation_step_history_t,gpu_stats),0,NULL,0x4155465f,4},
@@ -197,6 +213,14 @@ const csmi_struct_node_t csmi_allocation_step_history_tree[21] = {{"omp_thread_l
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"end_time",offsetof(csmi_allocation_step_history_t,end_time),0,NULL,0xb56ec18a,4}}
 ;
 
@@ -205,7 +229,7 @@ void* cast_csmi_allocation_step_history_t(void* ptr,size_t index, char isArray) 
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_allocation_step_history_t= {
-    21,
+    29,
     csmi_allocation_step_history_tree,
     cast_csmi_allocation_step_history_t
 };
@@ -263,7 +287,7 @@ const csmi_struct_mapping_t map_csmi_ssd_resources_record_t= {
     cast_csmi_ssd_resources_record_t
 };
 
-const csmi_struct_node_t csmi_node_resources_record_tree[23] = {{"node_available_gpus",offsetof(csmi_node_resources_record_t,node_available_gpus),0,NULL,0x2fe53009,36},
+const csmi_struct_node_t csmi_node_resources_record_tree[27] = {{"node_available_gpus",offsetof(csmi_node_resources_record_t,node_available_gpus),0,NULL,0x2fe53009,36},
 {"ssds_count",offsetof(csmi_node_resources_record_t,ssds_count),0,NULL,0x1d4cb32a,24},
 {"vg_available_size",offsetof(csmi_node_resources_record_t,vg_available_size),0,NULL,0xa5e09dbc,40},
 {"node_state",offsetof(csmi_node_resources_record_t,node_state),csmi_node_state_t_MAX,&csmi_node_state_t_strs,0x29ab88b,8},
@@ -283,6 +307,10 @@ const csmi_struct_node_t csmi_node_resources_record_tree[23] = {{"node_available
 {"vg_update_time",offsetof(csmi_node_resources_record_t,vg_update_time),0,NULL,0x70e3692,4},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"node_discovered_gpus",offsetof(csmi_node_resources_record_t,node_discovered_gpus),0,NULL,0x5a2162f0,36},
 {"node_type",offsetof(csmi_node_resources_record_t,node_type),csmi_node_type_t_MAX,&csmi_node_type_t_strs,0x7471eeec,8},
 {"node_discovered_cores",offsetof(csmi_node_resources_record_t,node_discovered_cores),0,NULL,0x9e04c46d,36}}
@@ -293,7 +321,7 @@ void* cast_csmi_node_resources_record_t(void* ptr,size_t index, char isArray) {
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_node_resources_record_t= {
-    23,
+    27,
     csmi_node_resources_record_tree,
     cast_csmi_node_resources_record_t
 };
@@ -579,13 +607,15 @@ const csmi_struct_mapping_t map_csm_allocation_resources_query_output_t= {
     cast_csm_allocation_resources_query_output_t
 };
 
-const csmi_struct_node_t csm_allocation_update_history_input_tree[12] = {{"allocation_id",offsetof(csm_allocation_update_history_input_t,allocation_id),0,NULL,0x99d3da77,40},
+const csmi_struct_node_t csm_allocation_update_history_input_tree[14] = {{"allocation_id",offsetof(csm_allocation_update_history_input_t,allocation_id),0,NULL,0x99d3da77,40},
 {"user_id",offsetof(csm_allocation_update_history_input_t,user_id),0,NULL,0x45c27210,36},
 {"user_name",offsetof(csm_allocation_update_history_input_t,user_name),0,NULL,0xc029f5a4,4},
 {"account",offsetof(csm_allocation_update_history_input_t,account),0,NULL,0x1cbdb112,4},
 {NULL,0,0,NULL,0,0},
 {"user_group_id",offsetof(csm_allocation_update_history_input_t,user_group_id),0,NULL,0xb690441c,36},
 {"comment",offsetof(csm_allocation_update_history_input_t,comment),0,NULL,0xd363aa58,4},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"job_name",offsetof(csm_allocation_update_history_input_t,job_name),0,NULL,0x9b046920,4},
@@ -598,7 +628,7 @@ void* cast_csm_allocation_update_history_input_t(void* ptr,size_t index, char is
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csm_allocation_update_history_input_t= {
-    12,
+    14,
     csm_allocation_update_history_input_tree,
     cast_csm_allocation_update_history_input_t
 };
@@ -715,7 +745,7 @@ const csmi_struct_mapping_t map_csmi_allocation_gpu_metrics_t= {
     cast_csmi_allocation_gpu_metrics_t
 };
 
-const csmi_struct_node_t csmi_allocation_mcast_context_tree[47] = {{"allocation_id",offsetof(csmi_allocation_mcast_context_t,allocation_id),0,NULL,0x99d3da77,40},
+const csmi_struct_node_t csmi_allocation_mcast_context_tree[51] = {{"allocation_id",offsetof(csmi_allocation_mcast_context_t,allocation_id),0,NULL,0x99d3da77,40},
 {"num_gpus",offsetof(csmi_allocation_mcast_context_t,num_gpus),0,NULL,0x338e5253,36},
 {"num_processors",offsetof(csmi_allocation_mcast_context_t,num_processors),0,NULL,0xeac9b7c7,36},
 {"ib_tx",offsetof(csmi_allocation_mcast_context_t,ib_tx),offsetof(csmi_allocation_mcast_context_t, num_nodes),NULL,0xfa26dbb,1},
@@ -748,6 +778,10 @@ const csmi_struct_node_t csmi_allocation_mcast_context_tree[47] = {{"allocation_
 {"gpu_metrics",offsetof(csmi_allocation_mcast_context_t,gpu_metrics),offsetof(csmi_allocation_mcast_context_t, num_nodes),&map_csmi_allocation_gpu_metrics_t,0xfc3c27a7,1},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {"shared",offsetof(csmi_allocation_mcast_context_t,shared),0,NULL,0x1bb15c9c,16},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
@@ -769,7 +803,7 @@ void* cast_csmi_allocation_mcast_context_t(void* ptr,size_t index, char isArray)
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_allocation_mcast_context_t= {
-    47,
+    51,
     csmi_allocation_mcast_context_tree,
     cast_csmi_allocation_mcast_context_t
 };
@@ -805,7 +839,7 @@ const csmi_struct_mapping_t map_csmi_allocation_mcast_payload_request_t= {
     cast_csmi_allocation_mcast_payload_request_t
 };
 
-const csmi_struct_node_t csmi_allocation_mcast_payload_response_tree[25] = {{"gpu_usage",offsetof(csmi_allocation_mcast_payload_response_t,gpu_usage),0,NULL,0x4178e945,40},
+const csmi_struct_node_t csmi_allocation_mcast_payload_response_tree[31] = {{"gpu_usage",offsetof(csmi_allocation_mcast_payload_response_t,gpu_usage),0,NULL,0x4178e945,40},
 {"ib_tx",offsetof(csmi_allocation_mcast_payload_response_t,ib_tx),0,NULL,0xfa26dbb,40},
 {"gpfs_read",offsetof(csmi_allocation_mcast_payload_response_t,gpfs_read),0,NULL,0xebe7ef50,40},
 {"ib_rx",offsetof(csmi_allocation_mcast_payload_response_t,ib_rx),0,NULL,0xfa26d79,40},
@@ -820,6 +854,12 @@ const csmi_struct_node_t csmi_allocation_mcast_payload_response_tree[25] = {{"gp
 {"cpu_usage",offsetof(csmi_allocation_mcast_payload_response_t,cpu_usage),0,NULL,0x6f872541,40},
 {"memory_max",offsetof(csmi_allocation_mcast_payload_response_t,memory_max),0,NULL,0xee7ddc83,40},
 {"energy",offsetof(csmi_allocation_mcast_payload_response_t,energy),0,NULL,0xfb77e8af,40},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
+{NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {NULL,0,0,NULL,0,0},
 {"gpu_energy",offsetof(csmi_allocation_mcast_payload_response_t,gpu_energy),0,NULL,0x4aeb6e5a,40},
@@ -837,7 +877,7 @@ void* cast_csmi_allocation_mcast_payload_response_t(void* ptr,size_t index, char
     return ptr_cast && isArray ? ptr_cast[index] : (void*)ptr_cast;
 };
 const csmi_struct_mapping_t map_csmi_allocation_mcast_payload_response_t= {
-    25,
+    31,
     csmi_allocation_mcast_payload_response_tree,
     cast_csmi_allocation_mcast_payload_response_t
 };


### PR DESCRIPTION
# Purpose
To repair a bug in the serialization engine for CSM json.

# Approach
Fix was applied to the static code generation. The Red Black Tree serialization was fixed to process children of inner leaves (see #610 for more details).

# Origin
Issue #610 

# How to Test
The transaction log for csm_allocation_create needs the following fields:
```
allocation_id,begin_time,primary_job_id,secondary_job_id,ssd_file_system_name,
launch_node_name,user_flags,system_flags,ssd_min,ssd_max,num_nodes,num_processors,num_gpus,
projected_memory,state,type,job_type,user_name,user_id,user_group_id,user_script,account,
comment,job_name,job_submit_time,queue,requeue,time_limit,wc_key,isolated_cores,compute_nodes
```