### PR TITLE
csmdb_python_dependency

### DIFF
--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -30,6 +30,7 @@ set( CPACK_RPM_csm-core_POST_INSTALL_SCRIPT_FILE
 # ibm-csm-db rpm settings
 set(CPACK_RPM_csm-db_PACKAGE_ARCHITECTURE "noarch")
 set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv")
+set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "python-psycopg2")
 
 # ibm-csm-hcdiag rpm settings
 set(CPACK_RPM_csm-hcdiag_PACKAGE_ARCHITECTURE "noarch")

--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -29,8 +29,7 @@ set( CPACK_RPM_csm-core_POST_INSTALL_SCRIPT_FILE
 
 # ibm-csm-db rpm settings
 set(CPACK_RPM_csm-db_PACKAGE_ARCHITECTURE "noarch")
-set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv")
-set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "python-psycopg2")
+set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv,python-psycopg2")
 
 # ibm-csm-hcdiag rpm settings
 set(CPACK_RPM_csm-hcdiag_PACKAGE_ARCHITECTURE "noarch")

--- a/csmdb/sql/CMakeLists.txt
+++ b/csmdb/sql/CMakeLists.txt
@@ -43,4 +43,3 @@ file(GLOB INSTALL_FILES
   "csm_ras_type_data.csv"
 )
 install(FILES ${INSTALL_FILES} COMPONENT ${DB_RPM_NAME} DESTINATION ${DB_BASE_NAME})
-set(CPACK_RPM_${DB_RPM_NAME}_PACKAGE_REQUIRES "python-psycopg2 >= 2.5.1")


### PR DESCRIPTION
# Purpose
Python dependency (add appropriate dependencies to the CSM rpms so yum can automatically install all of the right packages.)

- [x]  @pdlun92 to review (regression)
- [x] @besawn review
- [ ] @mew2057 review
- [ ] @fpizzano  review