### PR TITLE
Implemented a new mechanism for disabling core blinking

### DIFF
--- a/csmd/src/daemon/include/csm_jitter_info.h
+++ b/csmd/src/daemon/include/csm_jitter_info.h
@@ -31,11 +31,13 @@ private:
     int32_t     _SystemSMT;
     bool        _IRQAffinity;
     bool        _JitterMitigationEnabled;
+    bool        _CoreBlinkEnabled;
     std::string _SocketOrder;
 
 public:
     CSM_Jitter_Info():
         _MaxCoreIsolation(0), _SystemSMT(0), _IRQAffinity(true), _JitterMitigationEnabled(true),
+        _CoreBlinkEnabled(true),
         _SocketOrder("") {}
 
     void Init(
@@ -43,13 +45,15 @@ public:
             int32_t     maxCoreIsolation,
             int32_t     systemSMT,
             bool        irqAffinity,
-            bool        jitterMitigationEnabled) 
+            bool        jitterMitigationEnabled,
+            bool        coreBlinkEnabled) 
     {
         _MaxCoreIsolation = maxCoreIsolation;
         _SystemSMT        = systemSMT;
         _IRQAffinity      = irqAffinity;
         _SocketOrder      = socketOrder;
         _JitterMitigationEnabled = jitterMitigationEnabled;
+        _CoreBlinkEnabled = coreBlinkEnabled;
     }
 
     ~CSM_Jitter_Info() {}
@@ -59,6 +63,7 @@ public:
     int32_t     GetSystemSMT()     const { return _SystemSMT;        }
     bool        GetIRQAffinity()   const { return _IRQAffinity;      }
     bool        GetJitterMitigation()   const { return _JitterMitigationEnabled; }
+    bool        GetCoreBlink()   const { return _CoreBlinkEnabled;}
 
     std::string toString()
     {

--- a/csmd/src/daemon/src/csm_daemon_config.cc
+++ b/csmd/src/daemon/src/csm_daemon_config.cc
@@ -1330,6 +1330,7 @@ void Configuration::CreateThreadPool()
         const std::string CORE_ISO   = SECTION + "core_isolation_max";
         const int32_t     CORE_ISO_MAX= 4;
         const std::string ENABLED    = SECTION + "enabled";  
+        const std::string BLINK_ENABLED = SECTION + "blink_enabled";
         std::string keyStr = "";
 
         // Parse core mappings.
@@ -1353,6 +1354,10 @@ void Configuration::CreateThreadPool()
         boost::algorithm::to_lower(keyStr);
         bool jitterEnabled  =  ( keyStr.empty()  || (keyStr.compare("true") == 0) );
 
+        keyStr     = GetValueInConfig(BLINK_ENABLED);
+        boost::algorithm::to_lower(keyStr);
+        bool blinkEnabled  =  ( keyStr.empty()  || (keyStr.compare("true") == 0) );
+
         /*
         // If the Core Blink flag is unset default to true.
         keyStr     = GetValueInConfig( CORE_BLINK ) ;
@@ -1361,7 +1366,7 @@ void Configuration::CreateThreadPool()
         */
 
         // Build the object.
-        _JitterInfo.Init( socketOrder, maxCoreIso, systemSMT, irqAffinity, jitterEnabled);
+        _JitterInfo.Init( socketOrder, maxCoreIso, systemSMT, irqAffinity, jitterEnabled, blinkEnabled);
     } 
 
 }  // namespace daemon

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
@@ -1033,7 +1033,7 @@ int CGroup::CPUPower(
     const uint32_t thread,
     const char online ) 
 {
-    LOG( csmapi, trace ) << _LOG_PREFIX "CPUPower Enter; thread: " << thread << (online ? "; POWER ON": "; POWER OFF");
+    LOG( csmapi, trace ) << _LOG_PREFIX "CPUPower Enter; thread: " << thread << (online == '1'? "; POWER ON": "; POWER OFF");
 
     char path[CPU_PATH_MAX];
     int rc = 0;
@@ -1644,6 +1644,7 @@ void CGroup::GetCoreIsolation( int64_t cores, std::string &sysCores, std::string
 
     int32_t thread     = 0; // The active thread being processed.
     int32_t groupStart = 0; // Start of group.
+
     int32_t core       = 0; // The active core being processed.
     int32_t blinkOffset= jitterInfo.GetCoreBlink() ? 0 : threadsPerCore ; // The offset for blinking
     bool    startIRQBalance = false;
@@ -1668,12 +1669,12 @@ void CGroup::GetCoreIsolation( int64_t cores, std::string &sysCores, std::string
                 if ( isolation == 0 )
                 {
                     groupStart = thread;
-                    thread+= blinkOffset;
+                    thread = thread + ( threadsPerCoreMax - 1 );
                     // Offline all of the CPUs in the allocation section.
-                    for( int32_t cpu = blinkOffset; cpu < threadsPerCoreMax; ++cpu )
+                    for( int32_t cpu = threadsPerCoreMax; cpu > blinkOffset; --cpu )
                     {
                         // If the core blink fails, turn core zero back on and set the coreBlinkFailure flag.
-                        if ( CPUPower(thread++, CPU_OFFLINE) )
+                        if ( CPUPower(thread--, CPU_OFFLINE) )
                         {
                             CPUPower(0, CPU_ONLINE);
                             threadBlinkFailure = true;
@@ -1681,7 +1682,7 @@ void CGroup::GetCoreIsolation( int64_t cores, std::string &sysCores, std::string
                         }
                     }
 
-                    thread -=threadsPerCoreOffset;
+                    thread = groupStart + threadsPerCore;
                     assembleGroup(groupCores);
                 }
                 else
@@ -1725,12 +1726,13 @@ void CGroup::GetCoreIsolation( int64_t cores, std::string &sysCores, std::string
             {
                 thread =
                      ( socket * coresPerSocket * threadsPerCoreMax ) + (core * threadsPerCoreMax )  ;
-                int32_t extra_thread = thread + blinkOffset;
+                int32_t extra_thread = thread + + ( threadsPerCoreMax - 1 );
 
                 int32_t cpu = 0; 
                 for(; cpu < threadsPerCore; ++cpu ) sysCores.append(std::to_string(thread++)).append(",");
 
-                for(cpu=blinkOffset; cpu < threadsPerCoreMax; ++cpu ) CPUPower(extra_thread++, CPU_OFFLINE);
+                for( cpu = threadsPerCoreMax; cpu >= blinkOffset && extra_thread > 0; --cpu ) 
+                    CPUPower(extra_thread--, CPU_OFFLINE);
             }
         }
         sysCores.back() = ' ';

--- a/docs/source/csmd/csmd_config.rst
+++ b/docs/source/csmd/csmd_config.rst
@@ -651,11 +651,22 @@ Allocations. This block will only be required on Compute Node configurations.
 
     "jitter_mitigation" :
     {
+        "enabled"            : true,
+        "blink_enabled"      : true,
         "system_smt"         : 0,
         "irq_affinity"       : true,
         "core_isolation_max" : 4,
         "socket_order"       : "00"
     }
+
+:enabled:
+    Toggle for whether or not the cgroup mitigation should be executed.
+    Default is true (executes cgroup code).
+
+:blink_enabled:
+    Toggle for the blink feature when setting SMT mode, which shut downs cores to blink.
+    Default is true (executes the cgroup blink).
+     
 
 :system_smt:
     The SMT mode of the system cgroup, if unset this will use the maximum SMT mode.


### PR DESCRIPTION
New mechanism set through config file:

`blink_enable : false|true`

Regression path may reuse old tests, but with new flag added.
 