### PR TITLE
Fix:  Report to bhist status of stageout

### DIFF
--- a/bb/scripts/bbtools.pm
+++ b/bb/scripts/bbtools.pm
@@ -275,7 +275,9 @@ sub bbwaitTransfersComplete
         $numpending = $result->{"0"}{"out"}{"numavailhandles"};
         my $curtime = time();
         last if($curtime - $starttime > $timeout);
+        last if($result->{"rc"});
     }
+    return $result;
 }
 
 sub bbcmd

--- a/bb/scripts/stageout_admin.pl
+++ b/bb/scripts/stageout_admin.pl
@@ -75,7 +75,11 @@ sub phase1
 
 sub phase2
 {
-    &bbwaitTransfersComplete();
+    $result = &bbwaitTransfersComplete();
+    if($result->{"rc"})
+        {   $rc=$result->{"rc"};
+            bpost("BB: Stage-out phase2 waitTransfersComplete() completed with rc $rc.", $::BPOSTMBOX + 1, $::LASTOUTPUT);
+        }
 }
 
 sub phase3


### PR DESCRIPTION
Problem:
When a failure during stage out (injected error in these cases), the stage out fails (as expected) but that error is not percolated back to the user.
Provide status of stageout to bhist.