### PR TITLE
Algorithmic Core Blinking

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.cc
@@ -1864,9 +1864,9 @@ void CGroup::GetCoreIsolation( int64_t cores, std::string &sysCores, std::string
                     tempBlinkOffset = 0;
                     isolationOld--;
                 }
-                for( cpu = threadsPerCoreMax; cpu > tempBlinkOffset && extra_thread > 0; --cpu ) 
+                for( cpu = threadsPerCoreMax; cpu > tempBlinkOffset && extra_thread >= 0; --cpu ) 
                 {
-                    LOG(csmapi, trace) << "BLINKING THREAD (0->n): " << extra_thread;
+                    LOG(csmapi, trace) << "BLINKING THREAD (0): " << extra_thread;
                     CPUPower(extra_thread--, CPU_OFFLINE);
                 }
             }

--- a/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
+++ b/csmd/src/daemon/src/csmi_request_handler/helpers/cgroup.h
@@ -333,6 +333,19 @@ private:
      */
     bool CheckFile( const char* path, bool isDir = false ) const;
 
+    /** @brief Get the blink settings from the existing cgroups.
+     *
+     * @param[in] cpuCount The CPU count for the node (for all sockets).
+     * @param[in] maxSMT The maximum SMT for the node (effectively the threads per core).
+     * @param[in] coreIsolation The core isolation factor set by the user (per socket).
+     *
+     * @return A numeric value indicating one of three behaviors:
+     *  - -1 : The allocation cgroup cores need to be blinked to clear old processes.
+     *  -  0 : No blinking should occur.
+     *  - >0 : The System Cgroup needs blinking, returns the previous isolation factor.
+     */
+    int32_t GetBlinkSettings(int32_t cpuCount, int32_t maxSMT, int32_t coreIsolation) const;
+
     /**
      * @brief Builds the core isolation strings for the allocation and system cgroups.
      *


### PR DESCRIPTION
Core blinking now follows a deterministic algorithm which selects a behavior to reduce the number of cores blinked. The basic description of the algorithm is as follows:

> Let **X** be the previous core isolation.
> Let **Y** be the next core isolation.
> Then perform a blink operation when
> `X > Y OR ( X == 0 AND Y != 0 )`

The algorithm will then return different values  based on the evaluation of the above algorithm.
* **-1** : When the allocation cgroup cores should be blinked.
  * Occurs when `X == 0 AND Y != 0` (When going from no isolation to core isolation).

* **0** : Perform no blink operations.
   * Occurs when `X==Y` and `X<Y`.
   * Effectively means the set of cores isolated before is a subset of the cores isolated in the new job.

* **>0** : Perform a blink operation on the cores removed from isolation.
   * Occurs when `X>Y`
---
**Bug Fixes**

* Issue #622 
  * Improves general case performance for allocation create. 
  * Reduces worst case performance (previous was any->0, blink on).
* Issue #575 
  * Should remove the condition causing potential lockups when 
     blinking when `core_isolation == 0`

--- 
**Test Cases**

- [ ] Allocation Create on a Node with no cgroups.
  * Target `core_isolation`: 0
  * **Expected Behavior**:  No Core Blinking

- [ ] Allocation Create on a Node with no cgroups.
  * Target `core_isolation`: 1
  * Expected Behavior:  Allocation Cores will blink

- [ ] Allocation Create on a Node with previous job leaving a `core_isolation` of 1. 
  * Target `core_isolation`: 0
  * Expected Behavior:  System Core  blink

- [ ] Allocation Create on a Node with previous job leaving a `core_isolation` of 0. 
  * Target `core_isolation`: 1
  * Expected Behavior:  Allocation Cores will blink

- [ ] Allocation Create on a Node with previous job leaving a `core_isolation` of 1. 
  * Target `core_isolation`: 2
  * Expected Behavior:  No Core Blinking

- [ ] Allocation Create on a Node with previous job leaving a `core_isolation` of 2. 
  * Target `core_isolation`: 1
  * Expected Behavior:  System Core  blink

- [ ] Allocation Create on a Node with previous job leaving a `core_isolation` of 1. 
  * Target `core_isolation`: 0
  * Expected Behavior:  System Core blink (IRQBalance Daemon handles rebalance)

- [ ] Allocation Create on a Node with previous job leaving a `core_isolation` of 0. 
  * Target `core_isolation`: 0
  * Expected Behavior:  No Core Blinking

Sample Test Script (Psuedo):
```
# Run this on a node not used in the next steps.
# Test case 1: nil -> 0
csm_allocation_create -j 1 -n ${NODE1} --isolated_cores 0

# Test case 2: nil -> 1
csm_allocation_create -j 2 -n ${NODES} --isolated_cores 1
csm_allocation_delete -a ${allocation_id}

# Test case 3: 1 -> 0
csm_allocation_create -j 3 -n ${NODES} --isolated_cores 0
csm_allocation_delete -a ${allocation_id}

# Test case 4: 0 -> 1
csm_allocation_create -j 4 -n ${NODES} --isolated_cores 1
csm_allocation_delete -a ${allocation_id}

# Test case 5: 1 -> 2
csm_allocation_create -j 5 -n ${NODES} --isolated_cores 2
csm_allocation_delete -a ${allocation_id}

# Test case 6: 2 -> 1
csm_allocation_create -j 6 -n ${NODES} --isolated_cores 1
csm_allocation_delete -a ${allocation_id}

# Test case 7: 1 -> 0
csm_allocation_create -j 7 -n ${NODES} --isolated_cores 0
csm_allocation_delete -a ${allocation_id}

# Test case 8: 0 -> 0
csm_allocation_create -j 8 -n ${NODES} --isolated_cores 0
csm_allocation_delete -a ${allocation_id}
```
---


