### PR TITLE
Fixing debug level for PAM scripts

### DIFF
--- a/csmd/src/pamd/src/csm_pam.cc
+++ b/csmd/src/pamd/src/csm_pam.cc
@@ -39,7 +39,7 @@ int check_users(const char* userName, char migrate_pid)
         return PAM_SUCCESS;
 
     // Disable logging.
-    csmutil_logging_level_set((char*)"off");
+    csmutil_logging_level_set((char*)"disable");
 
     // 1. Check the active list if the NO_CG flag is not set.
     csm_init_lib();

--- a/csmutil/src/csmutil_logging.c
+++ b/csmutil/src/csmutil_logging.c
@@ -42,7 +42,7 @@ void csmutil_logging_level_set(char *aLevelStr)
     if (strcasecmp(csmutil_logging_str[i], aLevelStr) == 0) break;
   if (i < NUM_SEVERITIES)
   {
-     fprintf( fp, "[csmapi]: The default log level: %s...\n", aLevelStr);
+     //fprintf( fp, "[csmapi]: The default log level: %s...\n", aLevelStr);
      default_log_level = (csmutil_logging_level) i;
   }
   else


### PR DESCRIPTION
The debug level `off` is incorrectly named in the context of the logging utility. Setting the logging level to `disabled`.

New library retested and no output was found.