### PR TITLE
Fixed the post install to only trigger when uninstalls are run.

### DIFF
--- a/csmd/rpmscripts/csmd.post.uninstall
+++ b/csmd/rpmscripts/csmd.post.uninstall
@@ -3,9 +3,9 @@
 # ------------------------------------------------------------
 p_wl="whitelist"
 p_al="activelist"
-
+#
 # If pam.d ssh is found remove all of the csm related things.
-if [ -f /etc/pam.d/sshd ]
+if [ -f /etc/pam.d/sshd ] && [[ ${1} == 0 ]]
 then
     restart_sshd=0
 


### PR DESCRIPTION
Added a check of the input variable to the `%postun` scriptlet. Removal does not occur in upgrade as seen in issue # #640.