### PR TITLE
CSM FVT: Allocation Timing mechanism

### DIFF
--- a/csmtest/buckets/advanced/allocation_timing.py
+++ b/csmtest/buckets/advanced/allocation_timing.py
@@ -16,18 +16,35 @@
 #================================================================================
 
 import sys
+import os
 
-#add the python library to the path
+# Add the python library to the path
 sys.path.append('/opt/ibm/csm/lib')
 
+# Import libraries
 import lib_csm_py as csm
 import lib_csm_inv_py as inv
 import lib_csm_wm_py as wm
 from pprint import pprint
 from datetime import datetime
 
+# Init CSM LIB object
 csm.init_lib()
 
+# Read log path and compute nodes from config file
+configf = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, "csm_test.cfg"))
+config = open(str(configf),"r")
+for line in config:
+    if "LOG_PATH" in line: 
+        log_path = line[16:len(line)-1]
+    if "COMPUTE_NODES" in line:
+        compute_nodes = line[22:len(line)-2]
+config.close()
+
+# Open Log file
+log = open(str(log_path) + "/buckets/advanced/allocation_timing.log","w")
+
+# Create an allocation and capture timing information in log based on allocation_create_input_t object
 def create_timed_allocation(alloc_input):
     start_time=datetime.now()
     rc,handler,aid=wm.allocation_create(alloc_input)
@@ -35,9 +52,9 @@ def create_timed_allocation(alloc_input):
     time_to_create = end_time - start_time
     if (rc == 0):
         print("Created allocation: " + str(aid) + " (isolated_cores = " + str(alloc_input.isolated_cores) + ")")
-#        print("Start time: " + str(start_time))
-#        print("End time: " + str(end_time))
+        log.write("Allocation: " + str(aid) + " (isolated_cores = " + str(alloc_input.isolated_cores) + ")\n")
         print("Create time: " + str(time_to_create.total_seconds()))
+        log.write("Create time: " + str(time_to_create.total_seconds()) + "\n")
         return aid
     else:
         print("Create Failed")
@@ -45,6 +62,7 @@ def create_timed_allocation(alloc_input):
         csm.term_lib()
         sys.exit(rc)
 
+# Delete allocation based on allocation_delete_input_t object
 def delete_allocation(alloc_delete_input):
     rc,handler=wm.allocation_delete(alloc_delete_input)
     if (rc == 0):
@@ -55,9 +73,9 @@ def delete_allocation(alloc_delete_input):
         csm.term_lib()
         sys.exit(rc)
 
+# Create node attributes query to identify nodes to use for allocation
 input = inv.node_attributes_query_input_t()
-nodes=[str(sys.argv[1])]
-node_list=[]
+nodes=[str(compute_nodes)]
 input.set_node_names(nodes)
 input.limit=-1
 input.offset=-1
@@ -65,25 +83,27 @@ alloc_input=wm.allocation_t()
 alloc_input.primary_job_id=1
 alloc_input.job_submit_time="now"
 
+# initialize node_list: List of nodes in service
+node_list=[]
+
+# Node Attributes Query
 rc,handler,output = inv.node_attributes_query(input)
 
+# Append names of nodes in service to node_list
 if(rc == csm.csmi_cmd_err_t.CSMI_SUCCESS):
     for i in range (0, output.results_count):
         node = output.get_results(i)
         print("node: " + str(node.node_name))
-        print("node_state_value: " + str(node.state))
+        print("node state: " + str(node.state))
         if(str(node.state) == "CSM_NODE_IN_SERVICE"):
             node_list.append(str(node.node_name))
-
 else:
     print("No matching records found.")
     csm.api_object_destroy(handler)
     csm.term_lib()
     sys.exit(rc)
 
-
-print("Ready nodes: " + str(node_list))
-
+# Initialize cores: Sequential list of isolated_cores input values
 cores = [0, 0, 1, 0, 1, 2, 1, 0]
 
 # Initialize allocation create input struct
@@ -104,4 +124,5 @@ for i in cores:
 
 # Clean up handler and term lib
 csm.api_object_destroy(handler)
+log.close()
 csm.term_lib()

--- a/csmtest/buckets/advanced/allocation_timing.py
+++ b/csmtest/buckets/advanced/allocation_timing.py
@@ -1,0 +1,154 @@
+#!/bin/python
+# encoding: utf-8
+#================================================================================
+#
+#    allocation_timing.py 
+#
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+import sys
+
+#add the python library to the path
+sys.path.append('/opt/ibm/csm/lib')
+
+# eventually append the path as part of an rpm install
+
+import lib_csm_py as csm
+import lib_csm_inv_py as inv
+import lib_csm_wm_py as wm
+from pprint import pprint
+
+csm.init_lib()
+
+input = inv.node_attributes_query_input_t()
+nodes=[str(sys.argv[1])]
+node_list=[]
+input.set_node_names(nodes)
+input.limit=-1
+input.offset=-1
+alloc_input=wm.allocation_t()
+alloc_input.primary_job_id=1
+alloc_input.job_submit_time="now"
+
+rc,handler,output = inv.node_attributes_query(input)
+
+if(rc == csm.csmi_cmd_err_t.CSMI_SUCCESS):
+    for i in range (0, output.results_count):
+        node = output.get_results(i)
+        print("node: " + str(node.node_name))
+        print("node_state_value: " + str(node.state))
+        if(str(node.state) == "CSM_NODE_IN_SERVICE"):
+            node_list.append(str(node.node_name))
+
+else:
+    print("No matching records found.")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+
+print("Ready nodes: " + str(node_list))
+
+alloc_input.set_compute_nodes(node_list)
+alloc_input.isolated_cores=0
+alloc_input.state=wm.csmi_state_t.CSM_RUNNING
+rc,handler,aid=wm.allocation_create(alloc_input)
+
+if (rc == 0):
+    print("Created allocation: " + str(aid))
+else:
+    print("Create Failed")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+alloc_delete_input=wm.allocation_delete_input_t()
+alloc_delete_input.allocation_id=aid
+rc,handler=wm.allocation_delete(alloc_delete_input)
+if (rc == 0):
+    print("Allocation " + str(alloc_delete_input.allocation_id) + " successfully deleted")
+else:
+    print("Failed to delete allocation " + str(alloc_delete_input.allocation_id))
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+alloc_input.isolated_cores=0
+rc,handler,aid=wm.allocation_create(alloc_input)
+
+if (rc == 0):
+    print("Created allocation: " + str(aid))
+else:
+    print("Create Failed")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+alloc_delete_input=wm.allocation_delete_input_t()
+alloc_delete_input.allocation_id=aid
+rc,handler=wm.allocation_delete(alloc_delete_input)
+if (rc == 0):
+    print("Allocation " + str(alloc_delete_input.allocation_id) + " successfully deleted")
+else:
+    print("Failed to delete allocation " + str(alloc_delete_input.allocation_id))
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+alloc_input.isolated_cores=1
+rc,handler,aid=wm.allocation_create(alloc_input)
+
+if (rc == 0):
+    print("Created allocation: " + str(aid))
+else:
+    print("Create Failed")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+alloc_delete_input=wm.allocation_delete_input_t()
+alloc_delete_input.allocation_id=aid
+rc,handler=wm.allocation_delete(alloc_delete_input)
+if (rc == 0):
+    print("Allocation " + str(alloc_delete_input.allocation_id) + " successfully deleted")
+else:
+    print("Failed to delete allocation " + str(alloc_delete_input.allocation_id))
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+alloc_input.isolated_cores=0
+rc,handler,aid=wm.allocation_create(alloc_input)
+
+if (rc == 0):
+    print("Created allocation: " + str(aid))
+else:
+    print("Create Failed")
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+alloc_delete_input=wm.allocation_delete_input_t()
+alloc_delete_input.allocation_id=aid
+rc,handler=wm.allocation_delete(alloc_delete_input)
+if (rc == 0):
+    print("Allocation " + str(alloc_delete_input.allocation_id) + " successfully deleted")
+else:
+    print("Failed to delete allocation " + str(alloc_delete_input.allocation_id))
+    csm.api_object_destroy(handler)
+    csm.term_lib()
+    sys.exit(rc)
+
+csm.api_object_destroy(handler)
+
+csm.term_lib()
+


### PR DESCRIPTION
Wrote a new bucket (utilizing python libraries) to generate timing data for `csm_allocation_create` calls with specified numbers of isolated cores.  As it stands now, the sequence is to create allocations with `0, 0, 1, 0, 1, 2, 1, 0` to stimulate different conditions of the smart core-blinking algorithm.  

Here is a sample output file
```
Allocation: 272 (isolated_cores = 0)
Create time: 0.077843
Allocation: 273 (isolated_cores = 0)
Create time: 0.075625
Allocation: 274 (isolated_cores = 1)
Create time: 12.136847
Allocation: 275 (isolated_cores = 0)
Create time: 1.355861
Allocation: 276 (isolated_cores = 1)
Create time: 10.705613
Allocation: 277 (isolated_cores = 2)
Create time: 0.081201
Allocation: 278 (isolated_cores = 1)
Create time: 1.452159
Allocation: 279 (isolated_cores = 0)
Create time: 1.373047
```
feedback on the output syntax, core isolation sequence and script in general welcome!