### PR TITLE
Check in preuninstall whether upgrade or delete of export_layout

### DIFF
--- a/export_layout/src/preuninstall.sh
+++ b/export_layout/src/preuninstall.sh
@@ -36,6 +36,8 @@
 #  in which case the provisions of the GPL apply INSTEAD OF those given above.
 # 
 
-echo Running export_layout pre-uninstall script
+echo Running export_layout pre-uninstall script arg=$1
+
 cd /opt/ibm/export_layout/modules
-make clean
+if [ "$1" -eq "0" ]; then make clean
+fi


### PR DESCRIPTION
Handles uninstall of export layout rpm and upgrade.
Previously, upgrade removed export_layout module.
This will require two successive RPM installs--first with previous export_layout RPM removed.  The second RPM install will work for rpm -U.