### PR TITLE
Fix multithread issue w/ putenv during proxy hello

### DIFF
--- a/bb/scripts/nvmfConnect.sh
+++ b/bb/scripts/nvmfConnect.sh
@@ -16,6 +16,7 @@ network=$1
 nameSpace=$2
 ipAddr=$3
 port=$4
+keyfile=$5
 
 # exit on any script failure
 set -e
@@ -23,6 +24,8 @@ set -e
 cmd="modprobe nvme-rdma"
 echo "Executing: $cmd"
 $cmd
+
+NVMEKEY=$(<$keyfile)
 
 cmd="/usr/sbin/nvme connect -t $network -n $nameSpace -a $ipAddr -s $port --hostnqn"
 echo "Executing: $cmd <redacted>"


### PR DESCRIPTION
The NVMe key was set via putenv to the connection script, which caused problems when multiple threads were concurrently handling sayHello requests from multiple compute nodes.  
