### PR TITLE
csm: fixing event type check for timeout responses

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/csmi_base.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_base.h
@@ -831,7 +831,7 @@ protected:
                                                                  const int aErrorCode,
                                                                  const std::string &aErrorText )
   {
-    if( isNetworkEvent( aEvent ) )
+    if( isTimerEvent( aEvent ) )
     {
       csm::daemon::TimerContent timerData = dynamic_cast<const csm::daemon::TimerEvent *>( &aEvent )->GetContent();
       const csm::daemon::NetworkEvent *request = dynamic_cast<const csm::daemon::NetworkEvent *>( aEvent.GetEventContext()->GetReqEvent() );


### PR DESCRIPTION
This PR fixes a problem with timeout responses caused by checking for the wrong event type.

To test run:
```
error_inject -t 5
```
old behavior:
  * causes the master daemon to segfault.
  * request times out after ~30-35 seconds

new behavior:
 * master daemon stays alive
 * request returns after 5s

Setting Sev2 because it seems the function that causes this problem is only used by tests like infrastructure_health_check or the above error_inject.
That said, running the infrastructure health test on a system with some failed compute nodes would cause daemons to segfault too. If you feel this is worth a Sev1, please bump up the severity.