### PR TITLE
CSM updates needed to build against DCGM 1.6.3

### DIFF
--- a/csmd/dcgm.cmake
+++ b/csmd/dcgm.cmake
@@ -2,7 +2,7 @@
 #
 #    csmd/dcgm.cmake
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -36,7 +36,7 @@
 # CSM GA version:
 # datacenter-gpu-manager-1.4.0-1.ppc64le 
 # datacenter-gpu-manager-1.4.1-1.ppc64le
-set(REQUIRED_DCGM_VERSION "datacenter-gpu-manager-1.4")
+set(REQUIRED_DCGM_VERSION "datacenter-gpu-manager-1.6")
 
 # Check if DCGM is installed
 execute_process(COMMAND "/usr/bin/rpm" "-q" "datacenter-gpu-manager"

--- a/csmd/src/inv/include/inv_dcgm_access.h
+++ b/csmd/src/inv/include/inv_dcgm_access.h
@@ -2,7 +2,7 @@
 
     csmd/src/inv/include/inv_dcgm_access.h
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -88,8 +88,8 @@ public:
   typedef dcgmReturn_t (*dcgmGetDeviceAttributes_ptr_t)(dcgmHandle_t, unsigned int, dcgmDeviceAttributes_t*);
   // dcgmGetDeviceAttributes_ptr_t - dcgmReturn_t DECLDIR dcgmGetDeviceAttributes(dcgmHandle_t pDcgmHandle, unsigned int gpuId, dcgmDeviceAttributes_t *pDcgmAttr);
   
-  typedef dcgmReturn_t (*dcgmGetLatestValuesForFields_ptr_t)(dcgmHandle_t, int, unsigned short [], unsigned int, dcgmFieldValue_t []);
-  // dcgmGetLatestValuesForFields - dcgmReturn_t dcgmGetLatestValuesForFields(dcgmHandle_t pDcgmHandle, int gpuId, unsigned short fields[], unsigned int count, dcgmFieldValue_t values[]); 
+  typedef dcgmReturn_t (*dcgmGetLatestValuesForFields_ptr_t)(dcgmHandle_t, int, unsigned short [], unsigned int, dcgmFieldValue_v1 []);
+  // dcgmGetLatestValuesForFields - dcgmReturn_t dcgmGetLatestValuesForFields(dcgmHandle_t pDcgmHandle, int gpuId, unsigned short fields[], unsigned int count, dcgmFieldValue_v1 values[]); 
   
   typedef dcgmReturn_t (*dcgmFieldGroupDestroy_ptr_t)(dcgmHandle_t, dcgmFieldGrp_t);
   // dcgmFieldGroupDestroy - dcgmReturn_t dcgmFieldGroupDestroy(dcgmHandle_t dcgmHandle, dcgmFieldGrp_t dcgmFieldGroupId);

--- a/csmd/src/inv/src/inv_dcgm_access.cc
+++ b/csmd/src/inv/src/inv_dcgm_access.cc
@@ -2,7 +2,7 @@
 
     csmd/src/inv/src/inv_dcgm_access.cc
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2019. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -765,7 +765,7 @@ bool csm::daemon::INV_DCGM_ACCESS::ReadAllocationFields()
          return false;
       }
 
-      dcgmFieldValue_t csm_allocation_field_values[CSM_ALLOCATION_FIELD_COUNT]; 
+      dcgmFieldValue_v1 csm_allocation_field_values[CSM_ALLOCATION_FIELD_COUNT]; 
 
       // scanning the gpus
       for (int i = 0; i < dcgm_gpu_count; i++)
@@ -842,7 +842,7 @@ bool csm::daemon::INV_DCGM_ACCESS::CollectGpuData(std::list<boost::property_tree
    
    dcgmReturn_t rc(DCGM_ST_OK);
    
-   dcgmFieldValue_t csm_environmental_field_values[CSM_ENVIRONMENTAL_FIELD_COUNT]; 
+   dcgmFieldValue_v1 csm_environmental_field_values[CSM_ENVIRONMENTAL_FIELD_COUNT]; 
 
    // scan the gpus
    for (int i = 0; i < dcgm_gpu_count; i++)
@@ -902,8 +902,14 @@ bool csm::daemon::INV_DCGM_ACCESS::CollectGpuData(std::list<boost::property_tree
             }
             else
             {
-               LOG(csmenv, debug) << "GPU " << i << " " << csm_environmental_field_names[j]
-                                  << " unexpected case!";
+               LOG(csmenv, warning) << "GPU " << i << " " << csm_environmental_field_names[j]
+                                    << " unexpected case!";
+            
+               LOG(csmenv, warning) << "GPU " << i << " " << csm_environmental_field_names[j]
+                                    << " version = " << csm_environmental_field_values[j].version
+                                    << " fieldId = " << csm_environmental_field_values[j].fieldId
+                                    << " fieldType = " << csm_environmental_field_values[j].fieldType
+                                    << " status = " << csm_environmental_field_values[j].status;
             }
          }
 


### PR DESCRIPTION
This pull request primarily contains a workaround needed to handle changes in DCGM structure definitions that broke backward compatibility (associated NV issue: https://partners.nvidia.com/bug/viewbug/2560401).

Selected comments from the issue above:
```
I think this is the problem:

CSM calls dcgmGetLatestValuesForFields() like this:
dcgmReturn_t rc(DCGM_ST_OK);

dcgmFieldValue_t csm_environmental_field_values[CSM_ENVIRONMENTAL_FIELD_COUNT];

// scan the gpus
for (int i = 0; i < dcgm_gpu_count; i++)
{
rc = (*dcgmGetLatestValuesForFields_ptr)(dcgm_handle, gpu_ids[i], CSM_ENVIRONMENTAL_FIELDS, CSM_ENVIRONMENTAL_FIELD_COUNT, csm_environmental_field_values);
...
}


Previous versions of DCGM (v1.4.1, for example), contain these relevant definitions:
dcgm_agent.h:
dcgmReturn_t dcgmGetLatestValuesForFields(dcgmHandle_t pDcgmHandle, int gpuId, unsigned short fields[],
unsigned int count, dcgmFieldValue_t values[]);

dcgm_structs.h:
typedef struct
{
// version must always be first
unsigned int version; //!< version number (dcgmFieldValue_version)

unsigned short fieldId; //!< One of DCGM_FI_?
unsigned short fieldType; //!< One of DCGM_FT_?
int status; //!< Status for the querying the field. DCGM_ST_OK or one of DCGM_ST_?
int64_t ts; //!< Timestamp in usec since 1970 */
union {
int64_t i64; //!< Int64 value
double dbl; //!< Double value
char str[DCGM_MAX_STR_LENGTH]; //!< NULL terminated string
char blob[DCGM_MAX_BLOB_LENGTH]; //!< Binary blob
} value; //!< Value
}dcgmFieldValue_v1;

typedef dcgmFieldValue_v1 dcgmFieldValue_t;


DCGM v1.6.3 contains these definitions:
dcgm_agent.h:
dcgmReturn_t dcgmGetLatestValuesForFields(dcgmHandle_t pDcgmHandle, int gpuId, unsigned short fields[],
unsigned int count, dcgmFieldValue_v1 values[]);

dcgm_structs.h:
typedef struct
{
// version must always be first
unsigned int version; //!< version number (dcgmFieldValue_version1)

unsigned short fieldId; //!< One of DCGM_FI_?
unsigned short fieldType; //!< One of DCGM_FT_?
int status; //!< Status for the querying the field. DCGM_ST_OK or one of DCGM_ST_?
int64_t ts; //!< Timestamp in usec since 1970 */
union {
int64_t i64; //!< Int64 value
double dbl; //!< Double value
char str[DCGM_MAX_STR_LENGTH]; //!< NULL terminated string
char blob[DCGM_MAX_BLOB_LENGTH]; //!< Binary blob
} value; //!< Value
}dcgmFieldValue_v1;

typedef struct
{
// version must always be first
unsigned int version; //!< version number (dcgmFieldValue_version2)
dcgm_field_entity_group_t entityGroupId; //!< Entity group this field value's entity belongs to
dcgm_field_eid_t entityId; //!< Entity this field value belongs to
unsigned short fieldId; //!< One of DCGM_FI_?
unsigned short fieldType; //!< One of DCGM_FT_?
int status; //!< Status for the querying the field. DCGM_ST_OK or one of DCGM_ST_?
unsigned int unused; //!< Unused for now to align ts to an 8-byte boundary. */
int64_t ts; //!< Timestamp in usec since 1970 */
union {
int64_t i64; //!< Int64 value
double dbl; //!< Double value
char str[DCGM_MAX_STR_LENGTH]; //!< NULL terminated string
char blob[DCGM_MAX_BLOB_LENGTH]; //!< Binary blob
} value; //!< Value
}dcgmFieldValue_v2;

typedef dcgmFieldValue_v2 dcgmFieldValue_t;

I think this definition change of dcgmFieldValue_t is causing problems:
typedef dcgmFieldValue_v2 dcgmFieldValue_t; 
```

```
Building CSM against DCGM 1.4.1 and running with DCGM 1.6.3 works as expected.

Building CSM against DCGM 1.6.3 and running with DCGM 1.6.3 causes dcgmGetLatestValuesForFields() to return success, but the field values are then garbage because dcgmGetLatestValuesForFields() expects an array of dcgmFieldValue_v1, but due to the redefinition of dcgmFieldValue_t, it instead gets an array of dcgmFieldValue_v2.
```

```
I made a modified version of CSM that uses dcgmFieldValue_v1 instead of dcgmFieldValue_t.

I was able to run successfully when building against DCGM 1.4.1 and running with DCGM 1.6.3.

I was also able to run successfully when building against DCGM 1.6.3 and running with DCGM 1.6.3.
```