### PR TITLE
fix module issue?

### DIFF
--- a/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
+++ b/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
@@ -46,7 +46,7 @@ public:
   int GetCompiledWithSupport(); // get compiled_with_support_flag
   int ExecuteDataCollection(std::string rest_address, std::string authentication_string_for_the_http_request, std::string csm_inv_log_dir, std::string switch_errors, bool custom_input_override, std::string ufm_switch_output_file_name, std::string ufm_switch_input_file_name); // execute data collection
   std::string ReturnFieldValue(unsigned long int vector_id, unsigned long int index_in_the_vector); // return the value of the field
-  std::string ReturnFieldValue_module(std::string key, unsigned long int module_number); // return the value of the field
+  std::string ReturnFieldValue_module(std::string key, unsigned long int index); // return the value of the field
   int TotalNumberOfRecords();
   ~INV_SWITCH_CONNECTOR_ACCESS();
 
@@ -135,7 +135,7 @@ public:
   int GetCompiledWithSupport(); // get compiled_with_support
   int ExecuteDataCollection(); // execute data collection
   std::string ReturnFieldValue(unsigned long int vector_id, unsigned long int index_in_the_vector); // return the value of the field
-  std::string ReturnFieldValue_module(std::string key, unsigned long int module_number); // return the value of the field
+  std::string ReturnFieldValue_module(std::string key, unsigned long int index); // return the value of the field
   int TotalNumberOfRecords();
   ~INV_SWITCH_CONNECTOR_ACCESS();
 

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -774,12 +774,19 @@ int INV_SWITCH_CONNECTOR_ACCESS::module_key_value_vector_builder(char* module_ke
 	return 0;
 }
 
-std::string INV_SWITCH_CONNECTOR_ACCESS::ReturnFieldValue_module(std::string key, unsigned long int module_number)
+std::string INV_SWITCH_CONNECTOR_ACCESS::ReturnFieldValue_module(std::string key, unsigned long int index)
 {
 
 	// setting field value
 	std::string field_value = "NULL";
 	std::size_t found; 
+	
+	// Notes to remember when someone fixes later.
+	// inventory can have different number of modules. 
+	// this is tracked outside this function. (via index parameter)
+	// the way fautso vectors work is one long list.
+	// gotta offset this list by the number of total modules coming before
+	// when we build a json tree from the raw json file, hopefully we can eliminate this whole list system. 
 
 	// take in keys and values and make fautso vectors
 	for(unsigned int i = 0; i < vector_of_the_comparing_strings_modules.size(); i++)
@@ -796,75 +803,75 @@ std::string INV_SWITCH_CONNECTOR_ACCESS::ReturnFieldValue_module(std::string key
 		switch (i)
 		{
 			case 0:
-				if(module_number < module_status.size())
+				if(index < module_status.size())
 				{
-					field_value = module_status.at( module_number );
+					field_value = module_status.at( index );
 				}
 				break;
 			case 1:
-				if(module_number < module_hw_version.size())
+				if(index < module_hw_version.size())
 				{
-					field_value = module_hw_version.at(module_number);
+					field_value = module_hw_version.at(index);
 				}
 				break;
 			case 2:
-				if(module_number < module_name.size())
+				if(index < module_name.size())
 				{
-					field_value = module_name.at(module_number);
+					field_value = module_name.at(index);
 				}
 				break;
 			case 3:
-				if(module_number < module_number_of_chips.size())
+				if(index < module_number_of_chips.size())
 				{
-					field_value = module_number_of_chips.at(module_number);
+					field_value = module_number_of_chips.at(index);
 				}
 				break;
 			case 4:
-				if(module_number < module_description.size())
+				if(index < module_description.size())
 				{
-					field_value = module_description.at(module_number);
+					field_value = module_description.at(index);
 				}
 				break;
 			case 5:
-				if(module_number < module_max_ib_ports.size())
+				if(index < module_max_ib_ports.size())
 				{
-					field_value = module_max_ib_ports.at(module_number);
+					field_value = module_max_ib_ports.at(index);
 				}
 				break;
 			case 6:
-				if(module_number < module_module_index.size())
+				if(index < module_module_index.size())
 				{
-					field_value = module_module_index.at(module_number);
+					field_value = module_module_index.at(index);
 				}
 				break;
 			case 7:
-				if(module_number < module_device_type.size())
+				if(index < module_device_type.size())
 				{
-					field_value = module_device_type.at(module_number);
+					field_value = module_device_type.at(index);
 				}
 				break;
 			case 8:
-				if(module_number < module_serial_number.size())
+				if(index < module_serial_number.size())
 				{
-					field_value = module_serial_number.at(module_number);
+					field_value = module_serial_number.at(index);
 				}
 				break;
 			case 9:
-				if(module_number < module_path.size())
+				if(index < module_path.size())
 				{
-					field_value = module_path.at(module_number);
+					field_value = module_path.at(index);
 				}
 				break;
 			case 10:
-				if(module_number < module_device_name.size())
+				if(index < module_device_name.size())
 				{
-					field_value = module_device_name.at(module_number);
+					field_value = module_device_name.at(index);
 				}
 				break;
 			case 11:
-				if(module_number < module_severity.size())
+				if(index < module_severity.size())
 				{
-					field_value = module_severity.at(module_number);
+					field_value = module_severity.at(index);
 				}
 				break;
 			default:
@@ -1031,7 +1038,7 @@ std::string INV_SWITCH_CONNECTOR_ACCESS::ReturnFieldValue(unsigned long int vect
 	return "NULL";
 }
 
-std::string INV_SWITCH_CONNECTOR_ACCESS::ReturnFieldValue_module(std::string key, unsigned long int module_number)
+std::string INV_SWITCH_CONNECTOR_ACCESS::ReturnFieldValue_module(std::string key, unsigned long int index)
 {
 	return "NULL";
 }


### PR DESCRIPTION
# Purpose
We noticed an issue with switch module inventory collection. The issue was that each new set of modules over rode the primary key value of the previous set. Effectively only inserting 1 set of module data into CSM database. This pull request resolves that issue. (to the best of my knowledge. I did some minor testing. It seems to be working as expected on my machine.)

# Approach
In this pull request I added a `rolling_total_module_counter` which keeps track of how many modules came before. This is used to offset the index when grabbing the module data. I used a rolling counter because there may not be the same number of modules on each switch. We can't offset by the same number for each switch.
*Future approach*: This current approach should be removed when we re-work this process to read in the pure json and build a key-value tree. 

# Origin
- @williammorrison2 and I noticed this issue working on an unrelated db issue.
- @thanh-lam also noticed this issue during his testing. 

# How to Test
This issue request should cover how to test this new pull request. Eventually we need to add it into some sort of regression bucket. I'm working with @pdlun92 on how to do regression testing for big data. As I gain more knowledge, I'll eventually create a test case for this. 
https://github.com/IBM/CAST/issues/686

# Reviewers
- [x] @williammorrison2 please run regression
