### PR TITLE
Issue #509: change cwd before calling user scripts

### DIFF
--- a/bb/scripts/bbtools.pm
+++ b/bb/scripts/bbtools.pm
@@ -464,6 +464,17 @@ sub setupUserEnvironment
         $ENV{$key} = $value;
     }
     close($BBENV);
+
+    if(exists $ENV{"LSB_SUB3_CWD"})
+    {
+        my $dir = $ENV{"LSB_SUB3_CWD"};
+        ($dir) =~ s/^\"(.*)\"/$1/;
+        chdir($dir);
+    }
+    elsif(exists $ENV{"PWD"})
+    {
+        chdir($ENV{"PWD"});
+    }
     return 0;
 }
 


### PR DESCRIPTION
LSF sets staging scripts cwd to /tmp.  This change captures the user submission parameters and chdir's to the bsub -cwd setting.  