### PR TITLE
add in search of 'N/A'

### DIFF
--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -272,7 +272,8 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 						//Is this a serial number?
 						if(i == 2){
 							//is it a bad serial_number?
-							if(line.find("NA") != std::string::npos){
+							if( line.find("NA") != std::string::npos ||
+								line.find("N/A") != std::string::npos ){
 								//override i value, set to extra case 13
 								i = 13;
 							}
@@ -366,7 +367,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			std::cout << "This report from UFM can be found in '" << ufm_ib_cable_output_filename << "' located at '" << csm_inv_log_dir << "'" << std::endl;
 	
 			if(NA_serials_count > 0){
-				std::cerr << "WARNING: " << NA_serials_count << " IB cables found with 'NA' serial numbers and have been removed from CSM inventory collection data." << std::endl;
+				std::cerr << "WARNING: " << NA_serials_count << " IB cables were discovered, but are missing serial numbers and have been removed from CSM inventory collection data." << std::endl;
 				std::cerr << "These records copied into '" << ib_cable_errors <<"' located at '" << csm_inv_log_dir << "'" << std::endl;
 			}
 			


### PR DESCRIPTION
- working on https://github.com/IBM/CAST/issues/682

# Purpose
Address issues in https://github.com/IBM/CAST/issues/682

# Approach
I believe that UFM restAPIs changed the output of a missing serial number in the most recent update. Previously we searched for `NA` now it displays as `N/A`. We now look for both forms in our code. 

**Future:** We need to add in more tests to regression: https://github.com/IBM/CAST/issues/686

# Origin
@thanh-lam opened https://github.com/IBM/CAST/issues/682

# How to Test
_This section will help the regression tester._
1. Have a cable with a `N/A` serial number.
2. run inventory on master, this cable will get put into the CSM database.
3. checkout this branch
4. Have a cable with a `N/A` serial number.
5. run inventory on this branch, this cable will not get put into the CSM database. instead get placed into 'bad_records'

# ToDo:
- [ ] @pdlun92 run regression. If you have any other questions please ask. 
