### PR TITLE
CSM FVT Test Suite script for CI

### DIFF
--- a/csmtest/tools/ci_fvt.sh
+++ b/csmtest/tools/ci_fvt.sh
@@ -1,0 +1,123 @@
+#================================================================================
+#   
+#    tools/complete_fvt.sh
+# 
+#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+# 
+#================================================================================
+
+if [ -f "${BASH_SOURCE%/*}/../csm_test.cfg" ]
+then
+        . "${BASH_SOURCE%/*}/../csm_test.cfg"
+else
+        echo "Could not find csm_test.cfg file expected at "${BASH_SOURCE%/*}/../csm_test.cfg", exitting."
+        exit 1
+fi
+
+if [ -f "${BASH_SOURCE%/*}/../include/functions.sh" ]
+then
+        . "${BASH_SOURCE%/*}/../include/functions.sh"
+else
+        echo "Could not find functions file expected at /../../include/functions.sh, exitting."
+	exit 1
+fi
+
+source /etc/profile.d/xcat.sh
+MEMORY_LOG=${LOG_PATH}/performance/memory_usage.log
+SEGFAULT_LOG=${LOG_PATH}/performance/segfault.log
+
+segfault_scan () {
+	bucket_type=$1
+	bucket_name=$2
+
+	# Collect CSM logs
+	xdcp ${MASTER} -P /var/log/ibm/csm/csm_master.log ${LOG_PATH}/performance/
+	xdcp ${AGGREGATOR_A} -P /var/log/ibm/csm/csm_aggregator.log ${LOG_PATH}/performance/
+	xdcp ${AGGREGATOR_B} -P /var/log/ibm/csm/csm_aggregator.log ${LOG_PATH}/performance/
+	xdcp utility -P /var/log/ibm/csm/csm_utility.log ${LOG_PATH}/performance/
+	xdcp csm_comp -P /var/log/ibm/csm/csm_compute.log ${LOG_PATH}/performance/
+
+	# Grep for segfault
+	# Exit if found
+	grep segfault ${LOG_PATH}/performance/*
+	rc=$?
+	if [ "$rc" -eq 0 ]
+	then
+		echo "SEGFAULT DETECTED" >> ${LOG_PATH}/buckets/${bucket_type}/${bucket_name}.log
+		exit 1
+	fi
+}
+
+run_bucket () {
+	bucket_type=$1
+	bucket_name=$2
+	
+	# Collect memory usage before bucket
+	memory_usage=`ps -eo rss -o args | grep "csm[d]\b" | grep master | cut -d ' ' -f 1`
+	printf "%-40s %10s\n" "${bucket_type} ${bucket_name}" "BEFORE: ${memory_usage}" >> ${MEMORY_LOG}
+
+	# Determine bash or python bucket
+	bash_bucket="${FVT_PATH}/buckets/${bucket_type}/${bucket_name}.sh"
+        python_bucket="${FVT_PATH}/buckets/${bucket_type}/${bucket_name}.py"
+
+        if [ -e ${bash_bucket} ]
+        then
+                full_bucket="${bash_bucket}"
+        elif [ -e ${python_bucket} ]
+        then
+                full_bucket="${python_bucket}"
+        else
+                echo "error - could not find ${bucket_type} ${bucket_name} bucket"
+                exit 1
+        fi
+
+	# Run bucket script
+	${full_bucket}
+	rc=$?
+	if [ "$rc" -ne 0 ]
+	then
+		exit 1
+	fi
+
+	# Collect memory usage after bucket
+	memory_usage=`ps -eo rss -o args | grep "csm[d]\b" | grep master | cut -d ' ' -f 1`
+	printf "%-40s %10s\n" "${bucket_type} ${bucket_name}" "AFTER:  ${memory_usage}" >> ${MEMORY_LOG}
+
+	# Segfault scan
+	segfault_scan ${bucket_type} ${bucket_name}
+}
+
+run_bucket "basic" "node"
+run_bucket "basic" "allocation"
+run_bucket "basic" "jsrun_cmd"
+run_bucket "basic" "ras"
+run_bucket "basic" "step"
+run_bucket "basic" "bb"
+run_bucket "basic" "db_script"
+run_bucket "basic" "ib_inventory"
+run_bucket "basic" "compute_node"
+run_bucket "advanced" "allocation"
+run_bucket "error_injection" "allocation"
+run_bucket "error_injection" "bb"
+run_bucket "error_injection" "node"
+run_bucket "error_injection" "ib_inventory"
+run_bucket "error_injection" "switch_inventory"
+run_bucket "error_injection" "messaging"
+run_bucket "basic" "csm_ctrl_cmd"
+run_bucket "basic" "soft_failure_recovery"
+#${FVT_PATH}/setup/csm_uninstall.sh
+#${FVT_PATH}/setup/csm_install.sh
+${FVT_PATH}/tools/dual_aggregator/shutdown_daemons.sh
+${FVT_PATH}/tools/dual_aggregator/start_daemons.sh
+run_bucket "basic" "python_libraries"
+run_bucket "advanced" "allocation_timing"
+
+## TODO DON'T USE THIS IF USER AND SECOND_USER ARE NOT SET AND CONFIGURED!
+#run_bucket "basic" "pamd"

--- a/csmtest/tools/complete_fvt.sh
+++ b/csmtest/tools/complete_fvt.sh
@@ -63,8 +63,23 @@ run_bucket () {
 	memory_usage=`ps -eo rss -o args | grep "csm[d]\b" | grep master | cut -d ' ' -f 1`
 	printf "%-40s %10s\n" "${bucket_type} ${bucket_name}" "BEFORE: ${memory_usage}" >> ${MEMORY_LOG}
 
+	# Determine bash or python bucket
+	bash_bucket="${FVT_PATH}/buckets/${bucket_type}/${bucket_name}.sh"
+        python_bucket="${FVT_PATH}/buckets/${bucket_type}/${bucket_name}.py"
+
+        if [ -e ${bash_bucket} ]
+        then
+                full_bucket="${bash_bucket}"
+        elif [ -e ${python_bucket} ]
+        then
+                full_bucket="${python_bucket}"
+        else
+                echo "error - could not find ${bucket_type} ${bucket_name} bucket"
+                exit 1
+        fi
+
 	# Run bucket script
-	${FVT_PATH}/buckets/${bucket_type}/${bucket_name}.sh
+	${full_bucket}
 	rc=$?
 	if [ "$rc" -ne 0 ]
 	then
@@ -108,6 +123,7 @@ run_bucket "error_injection" "versioning"
 ${FVT_PATH}/setup/csm_uninstall.sh
 ${FVT_PATH}/setup/csm_install.sh
 run_bucket "basic" "python_libraries"
+run_bucket "advanced" "allocation_timing"
 
 ## TODO DON'T USE THIS IF USER AND SECOND_USER ARE NOT SET AND CONFIGURED!
 #run_bucket "basic" "pamd"


### PR DESCRIPTION
Wrote a first pass at a light weight test suite designed for CI environment.  The problem is that a fully "dockerized" csm environment has limited functionality (due to numerous things, for example: lack of systemctl, no access to inventory dependencies). The solution for now is to create `csmtest/tools/ci_fvt.sh` that mirrors `csmtest/tools/complete_fvt.sh` but with compromised test buckets removed.  `ci_fvt.sh` is intended to be run on pull request creation to provide more immediate feedback, `complete_fvt.sh` is intended to be run on baremetal systems (daily and as needed)

For first pass, removed the section that rely heavily on csm infrastructure manipulation and access to inventory modules.  List of removed buckets: 
- basic/hcdiag
- basic/switch_inventory
- basic/inventory_collection
- error_injection/infrastructure
- error_injection/versioning

Addtionally, added `advanced/allocation_timing.py` bucket to both `complete_fvt.sh` and `ci_fvt.sh` along with expanded capability to `run_bucket` to differentiate between python and bash scripts
