### PR TITLE
csmdb: update to descriptions related to the csm_step_history table w…

### DIFF
--- a/csmdb/sql/csm_create_tables.sql
+++ b/csmdb/sql/csm_create_tables.sql
@@ -17,10 +17,17 @@
 --   usage:             run ./csm_db_script.sh <----- to create the csm_db with tables
 --   current_version:   18.0
 --   create:            12-14-2015
---   last modified:     05-22-2019
+--   last modified:     05-29-2019
 --   change log:
 --   18.0   Added core_blink (boolean) field to the csm_allocation and csm_allocation_history tables with comments.
 --          Added in type and fw_version to the csm_switch_inventory and csm_inventory_history tables with comments.
+--          Additional descriptions that have been updated include the following fields in the csm_step_history table:
+--              cpu_stats            - 'statistics gathered from the CPU for the step.';
+--              omp_thread_limit     - 'max number of omp threads used by the step.';
+--              gpu_stats            - 'statistics gathered from the GPU for the step.';
+--              memory_stats         - 'memory statistics for the the step.';
+--              max_memory           - 'the maximum memory usage of the step.';
+--              io_stats             - 'general input output statistics for the step.';
 --   17.0   Added smt_mode to csm_allocation and csm_allocation_history
 --	    Added new fields to csm_lv_history - num_reads, num_writes (01-25-2019)
 --   16.2   Modified TYPE csm_compute_node_states - added in HARD_FAILURE (Included below is the updated comments)
@@ -1177,14 +1184,14 @@ CREATE INDEX ix_csm_step_history_g
     COMMENT ON COLUMN csm_step_history.user_flags is 'user space prolog/epilog flags';
     COMMENT ON COLUMN csm_step_history.exit_status is 'step/s exit status. will be tracked and given to csm by job leader';
     COMMENT ON COLUMN csm_step_history.error_message is 'step/s error text. will be tracked and given to csm by job leader. the following columns need their proper data types tbd:';
-    COMMENT ON COLUMN csm_step_history.cpu_stats is 'will be tracked and given to csm by job leader';
+    COMMENT ON COLUMN csm_step_history.cpu_stats is 'statistics gathered from the CPU for the step.';
     COMMENT ON COLUMN csm_step_history.total_u_time is 'relates to the (us) (aka: user mode) value of %cpu(s) of the (top) linux cmd. todo: design how we get this data';
     COMMENT ON COLUMN csm_step_history.total_s_time is 'relates to the (sy) (aka: system mode) value of %cpu(s) of the (top) linux cmd. todo: design how we get this data';
-    COMMENT ON COLUMN csm_step_history.omp_thread_limit is 'will be tracked and given to csm by job leader';
-    COMMENT ON COLUMN csm_step_history.gpu_stats is 'will be tracked and given to csm by job leader';
-    COMMENT ON COLUMN csm_step_history.memory_stats is 'will be tracked and given to csm by job leader';
-    COMMENT ON COLUMN csm_step_history.max_memory is 'will be tracked and given to csm by job leader';
-    COMMENT ON COLUMN csm_step_history.io_stats is 'will be tracked and given to csm by job leader';
+    COMMENT ON COLUMN csm_step_history.omp_thread_limit is 'max number of omp threads used by the step.';
+    COMMENT ON COLUMN csm_step_history.gpu_stats is 'statistics gathered from the GPU for the step.';
+    COMMENT ON COLUMN csm_step_history.memory_stats is 'memory statistics for the the step.';
+    COMMENT ON COLUMN csm_step_history.max_memory is 'the maximum memory usage of the step.';
+    COMMENT ON COLUMN csm_step_history.io_stats is 'general input output statistics for the step.';
     COMMENT ON COLUMN csm_step_history.archive_history_time is 'timestamp when the history data has been archived and sent to: BDS, archive file, and or other';    
     COMMENT ON INDEX ix_csm_step_history_a IS 'index on history_time';
     COMMENT ON INDEX ix_csm_step_history_b IS 'index on begin_time, end_time';

--- a/csmdb/sql/csm_db_migration_scripts/csm_db_schema_updates_18_0_ms.sql
+++ b/csmdb/sql/csm_db_migration_scripts/csm_db_schema_updates_18_0_ms.sql
@@ -39,6 +39,16 @@ BEGIN;
 -- fn_csm_allocation_update (added field core_blink)
 -- fn_csm_allocation_history_dump (added field core_blink)
 ---------------------------------------------------------------------------------
+-- Additional descriptions that have been updated include the following fields
+-- in the csm_step_history table:
+---------------------------------------------------------------------------------
+-- cpu_stats            | 'statistics gathered from the CPU for the step.';
+-- omp_thread_limit     | 'max number of omp threads used by the step.';
+-- gpu_stats            | 'statistics gathered from the GPU for the step.';
+-- memory_stats         | 'memory statistics for the the step.';
+-- max_memory           | 'the maximum memory usage of the step.';
+-- io_stats             | 'general input output statistics for the step.';
+---------------------------------------------------------------------------------
 
 DO $$ 
     BEGIN
@@ -83,5 +93,13 @@ COMMENT ON COLUMN csm_switch_inventory_history.type is 'The category of this pie
 
 COMMENT ON COLUMN csm_switch_inventory.fw_version is 'The firmware version on this piece of inventory.';
 COMMENT ON COLUMN csm_switch_inventory_history.fw_version is 'The firmware version on this piece of inventory.';
+
+-- Additional descriptions that have been updated include:
+COMMENT ON COLUMN csm_step_history.cpu_stats is 'statistics gathered from the CPU for the step.';
+COMMENT ON COLUMN csm_step_history.omp_thread_limit is 'max number of omp threads used by the step.';
+COMMENT ON COLUMN csm_step_history.gpu_stats is 'statistics gathered from the GPU for the step.';
+COMMENT ON COLUMN csm_step_history.memory_stats is 'memory statistics for the the step.';
+COMMENT ON COLUMN csm_step_history.max_memory is 'the maximum memory usage of the step.';
+COMMENT ON COLUMN csm_step_history.io_stats is 'general input output statistics for the step.';
 
 COMMIT;

--- a/docs/source/csm/csmdb/csm_db_appendix.rst
+++ b/docs/source/csm/csmdb/csm_db_appendix.rst
@@ -1007,14 +1007,14 @@ csm_step_history (DB table overview)
   user_flags           | text                        |           | extended |              | user space prolog/epilog flags
   exit_status          | integer                     |           | plain    |              | step/s exit status. will be tracked and given to csm by job leader
   error_message        | text                        |           | extended |              | step/s error text. will be tracked and given to csm by job leader. the following columns need their proper data types tbd:
-  cpu_stats            | text                        |           | extended |              | will be tracked and given to csm by job leader
+  cpu_stats            | text                        |           | extended |              | statistics gathered from the CPU for the step.
   total_u_time         | double precision            |           | plain    |              | relates to the (us) (aka: user mode) value of %cpu(s) of the (top) linux cmd. todo: design how we get this data
   total_s_time         | double precision            |           | plain    |              | relates to the (sy) (aka: system mode) value of %cpu(s) of the (top) linux cmd. todo: design how we get this data
-  omp_thread_limit     | text                        |           | extended |              | will be tracked and given to csm by job leader
-  gpu_stats            | text                        |           | extended |              | will be tracked and given to csm by job leader
-  memory_stats         | text                        |           | extended |              | will be tracked and given to csm by job leader
-  max_memory           | bigint                      |           | plain    |              | will be tracked and given to csm by job leader
-  io_stats             | text                        |           | extended |              | will be tracked and given to csm by job leader
+  omp_thread_limit     | text                        |           | extended |              | max number of omp threads used by the step.
+  gpu_stats            | text                        |           | extended |              | statistics gathered from the GPU for the step.
+  memory_stats         | text                        |           | extended |              | memory statistics for the the step.
+  max_memory           | bigint                      |           | plain    |              | the maximum memory usage of the step.
+  io_stats             | text                        |           | extended |              | general input output statistics for the step.
   archive_history_time | timestamp without time zone |           | plain    |              | timestamp when the history data has been archived and sent to: BDS, archive file, and or other
  Indexes:
      "ix_csm_step_history_a" btree (history_time)


### PR DESCRIPTION
…hich can be rolled into the db schema migration 18.0 process.

# Purpose
update descriptions related to the csm_step_history table. Below are the details of the old descriptions and the updated ones.

# Files touched
`csm_create_tables.sql`
`csm_db_schema_updates_18_0_ms.sql`
`csm_db_appendix.rst`

```
OLD:
---------------------------------------------------------------------------------
cpu_stats        | will be tracked and given to csm by job leader
omp_thread_limit | will be tracked and given to csm by job leader
gpu_stats        | will be tracked and given to csm by job leader
memory_stats     | will be tracked and given to csm by job leader
max_memory       | will be tracked and given to csm by job leader
io_stats         | will be tracked and given to csm by job leader
---------------------------------------------------------------------------------
```
```
NEW:
---------------------------------------------------------------------------------
cpu_stats        | statistics gathered from the CPU for the step.
omp_thread_limit | max number of omp threads used by the step.
gpu_stats        | statistics gathered from the GPU for the step.
memory_stats     | memory statistics for the the step.
max_memory       | the maximum memory usage of the step.
io_stats         | general input output statistics for the step.
---------------------------------------------------------------------------------
```

## TODOs
- [x]  @pdlun92 review (regression/sanity check)
- [ ]  @NickyDaB (code review)
