### PR TITLE
Enable distinct read and write NVMeoF connections

### DIFF
--- a/bb/scripts/bb.cfg.in
+++ b/bb/scripts/bb.cfg.in
@@ -42,9 +42,11 @@
 			"numRequestThreads"           : 8,
 			"flightlog"                   : "/var/log/bbproxy@USERSUFFIX@",
 			"ssdusagepollrate"            : 60,
-			"use_export_layout"	      : true,
+			"use_export_layout"	          : true,
 			"lvreadahead"                 : 65536,
 			"ras_max_rss_size"            : 2097152,
+			"readport"                    : 0,
+			"writeport"                   : 2,
 			"log" :
 			{
 				"consoleLog"   : @USECONSOLE@,

--- a/bb/scripts/nvme.conf
+++ b/bb/scripts/nvme.conf
@@ -1,1 +1,1 @@
-options nvme num_p2p_queues=2
+options nvme num_p2p_queues=4

--- a/bb/scripts/nvmet.json
+++ b/bb/scripts/nvmet.json
@@ -14,6 +14,20 @@
       "subsystems": [
         "burstbuffer"
       ]
+    },
+    {
+      "addr": {
+        "adrfam": "ipv4", 
+        "traddr": "127.0.0.1", 
+        "treq": "not specified", 
+        "trsvcid": "4421",
+        "trtype": "rdma"
+      }, 
+      "portid": 2,
+      "referrals": [], 
+      "subsystems": [
+        "burstbuffer"
+      ]
     }
   ], 
   "subsystems": [

--- a/bb/src/LVLookup.h
+++ b/bb/src/LVLookup.h
@@ -36,7 +36,7 @@ class filehandle;
 
 // Implemented in serial.cc
 extern string getDeviceBySerial(string serial);
-extern string getSerialByDevice(string device);
+extern string getSerialByDevice(string device, bool writeToSSD);
 extern string getNVMeByIndex(uint32_t index);
 extern string getNVMeDeviceInfo(string device, string key);
 extern vector<string> getDeviceSerials();
@@ -58,7 +58,7 @@ class LVLookup
 
     int build(const string& pVolumeGroup, const string& pLogicalVolumeName);
 
-    int build(const filehandle& fileh, const string& vg);
+    int build(const filehandle& fileh, const string& vg, bool iswrite);
 
     /**
      \brief Return data pertinent to the logical volume
@@ -75,7 +75,7 @@ class LVLookup
      \param[in] vg Burst buffer volume group
      \return error indicator
      */
-    int getLVExtents(const string& vg);
+    int getLVExtents(const string& vg, bool iswrite);
 
     int translate(Extent& input, vector<Extent>& list);
 

--- a/bb/src/fh.cc
+++ b/bb/src/fh.cc
@@ -843,7 +843,7 @@ int filehandle::protect(off_t start, size_t len, bool writing, Extent& input, ve
     LVLookup lookup;
     try
     {
-        rc = lookup.build(*this, vg);
+        rc = lookup.build(*this, vg, writing);
     }
     catch(exception& e)
     {

--- a/bb/src/lvlookup.cc
+++ b/bb/src/lvlookup.cc
@@ -33,16 +33,16 @@ int LVLookup::build(const string& pVolumeGroup, const string& pLogicalVolumeName
 {
     setLVName(pVolumeGroup + string("-") + pLogicalVolumeName);
 
-    return getLVExtents(pVolumeGroup);
+    return getLVExtents(pVolumeGroup, false);
 }
 
 
-int LVLookup::build(const filehandle& fh, const string& vg)
+int LVLookup::build(const filehandle& fh, const string& vg, bool writeToSSD)
 {
     int rc = getLVName(fh);
     if (!rc)
     {
-        rc = getLVExtents(vg);
+        rc = getLVExtents(vg, writeToSSD);
     }
     return rc;
 }
@@ -159,7 +159,7 @@ int LVLookup::getData(uint64_t& pFirstByte, size_t& pSize)
     return rc;
 }
 
-int LVLookup::getLVExtents(const string& vg)
+int LVLookup::getLVExtents(const string& vg, bool writeToSSD)
 {
     string cmd = "lvs --noheadings --units b --nosuffix -o lv_name,seg_pe_ranges,seg_start_pe,vg_extent_size " + vg;
     FILE* f;
@@ -256,7 +256,7 @@ int LVLookup::getLVExtents(const string& vg)
 
                 try
                 {
-                    tmp.serial = getSerialByDevice(string("/dev/") + mydevice);
+                    tmp.serial = getSerialByDevice(string("/dev/") + mydevice, writeToSSD);
                 }
                 catch(runtime_error& e)
                 {

--- a/bb/src/xfer.cc
+++ b/bb/src/xfer.cc
@@ -67,7 +67,6 @@ size_t  transferBufferSize   = 0;
 pthread_once_t startThreadsControl = PTHREAD_ONCE_INIT;
 
 string getDeviceBySerial(string serial);
-string getSerialByDevice(string device);
 string getNVMeByIndex(uint32_t index);
 
 FL_SetName(FLXfer, "Transfer Flightlog")


### PR DESCRIPTION
Allow splitting NVMe over Fabrics connections into separate read and write connections.  This potentially permits using different QoS and service levels for read and write paths.  
