### PR TITLE
Issue #776: Version wasn't checked in init code. Version now clamps.

### DIFF
--- a/csmi/include/struct_generator/c_funct.txt
+++ b/csmi/include/struct_generator/c_funct.txt
@@ -213,16 +213,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 

--- a/csmi/include/struct_generator/c_funct.txt
+++ b/csmi/include/struct_generator/c_funct.txt
@@ -230,11 +230,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF

--- a/csmi/src/bb/src/csmi_bb_serialization.c
+++ b/csmi/src/bb/src/csmi_bb_serialization.c
@@ -250,11 +250,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -496,11 +500,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -742,11 +750,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -988,11 +1000,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1234,11 +1250,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1480,11 +1500,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1726,11 +1750,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1972,11 +2000,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2218,11 +2250,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2464,11 +2500,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2710,11 +2750,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2956,11 +3000,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3202,11 +3250,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3448,11 +3500,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3694,11 +3750,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3940,11 +4000,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF

--- a/csmi/src/bb/src/csmi_bb_serialization.c
+++ b/csmi/src/bb/src/csmi_bb_serialization.c
@@ -233,16 +233,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -483,16 +486,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -733,16 +739,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -983,16 +992,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1233,16 +1245,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1483,16 +1498,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1733,16 +1751,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1983,16 +2004,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2233,16 +2257,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2483,16 +2510,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2733,16 +2763,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2983,16 +3016,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3233,16 +3269,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3483,16 +3522,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3733,16 +3775,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3983,16 +4028,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 

--- a/csmi/src/common/src/csmi_common_serial.c
+++ b/csmi/src/common/src/csmi_common_serial.c
@@ -246,16 +246,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -496,16 +499,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 

--- a/csmi/src/common/src/csmi_common_serial.c
+++ b/csmi/src/common/src/csmi_common_serial.c
@@ -263,11 +263,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -509,11 +513,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF

--- a/csmi/src/diag/src/csmi_diag_serialization.c
+++ b/csmi/src/diag/src/csmi_diag_serialization.c
@@ -235,16 +235,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -485,16 +488,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -735,16 +741,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -985,16 +994,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1235,16 +1247,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1485,16 +1500,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1735,16 +1753,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1985,16 +2006,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2235,16 +2259,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 

--- a/csmi/src/diag/src/csmi_diag_serialization.c
+++ b/csmi/src/diag/src/csmi_diag_serialization.c
@@ -252,11 +252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -498,11 +502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -744,11 +752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -990,11 +1002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1236,11 +1252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1482,11 +1502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1728,11 +1752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1974,11 +2002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2220,11 +2252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF

--- a/csmi/src/inv/src/csmi_inv_serialization.c
+++ b/csmi/src/inv/src/csmi_inv_serialization.c
@@ -252,11 +252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -498,11 +502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -744,11 +752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -990,11 +1002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1236,11 +1252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1482,11 +1502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1728,11 +1752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1974,11 +2002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2220,11 +2252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2466,11 +2502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2712,11 +2752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2958,11 +3002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3204,11 +3252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3450,11 +3502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3696,11 +3752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3942,11 +4002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4188,11 +4252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4434,11 +4502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4680,11 +4752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4926,11 +5002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5172,11 +5252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5418,11 +5502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5664,11 +5752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5910,11 +6002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6156,11 +6252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6402,11 +6502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6648,11 +6752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6894,11 +7002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7140,11 +7252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7386,11 +7502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7632,11 +7752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7878,11 +8002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8124,11 +8252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8370,11 +8502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8616,11 +8752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8862,11 +9002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9108,11 +9252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9354,11 +9502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9600,11 +9752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9846,11 +10002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10092,11 +10252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10338,11 +10502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10584,11 +10752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10830,11 +11002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -11076,11 +11252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -11322,11 +11502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -11568,11 +11752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -11814,11 +12002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -12060,11 +12252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -12306,11 +12502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -12552,11 +12752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -12798,11 +13002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -13044,11 +13252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -13290,11 +13502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -13536,11 +13752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -13782,11 +14002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -14028,11 +14252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF

--- a/csmi/src/inv/src/csmi_inv_serialization.c
+++ b/csmi/src/inv/src/csmi_inv_serialization.c
@@ -235,16 +235,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -485,16 +488,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -735,16 +741,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -985,16 +994,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1235,16 +1247,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1485,16 +1500,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1735,16 +1753,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1985,16 +2006,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2235,16 +2259,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2485,16 +2512,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2735,16 +2765,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2985,16 +3018,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3235,16 +3271,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3485,16 +3524,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3735,16 +3777,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3985,16 +4030,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4235,16 +4283,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4485,16 +4536,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4735,16 +4789,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4985,16 +5042,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5235,16 +5295,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5485,16 +5548,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5735,16 +5801,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5985,16 +6054,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6235,16 +6307,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6485,16 +6560,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6735,16 +6813,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6985,16 +7066,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7235,16 +7319,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7485,16 +7572,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7735,16 +7825,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7985,16 +8078,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8235,16 +8331,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8485,16 +8584,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8735,16 +8837,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8985,16 +9090,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9235,16 +9343,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9485,16 +9596,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9735,16 +9849,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9985,16 +10102,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10235,16 +10355,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10485,16 +10608,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10735,16 +10861,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10985,16 +11114,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -11235,16 +11367,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -11485,16 +11620,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -11735,16 +11873,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -11985,16 +12126,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -12235,16 +12379,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -12485,16 +12632,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -12735,16 +12885,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -12985,16 +13138,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -13235,16 +13391,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -13485,16 +13644,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -13735,16 +13897,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -13985,16 +14150,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -14235,16 +14403,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 

--- a/csmi/src/ras/src/csmi_ras_serialization.c
+++ b/csmi/src/ras/src/csmi_ras_serialization.c
@@ -252,11 +252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -498,11 +502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -744,11 +752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -990,11 +1002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1236,11 +1252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1482,11 +1502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1728,11 +1752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1974,11 +2002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2220,11 +2252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2466,11 +2502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2712,11 +2752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2958,11 +3002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3204,11 +3252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3450,11 +3502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3696,11 +3752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3942,11 +4002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4188,11 +4252,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4434,11 +4502,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4680,11 +4752,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4926,11 +5002,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF

--- a/csmi/src/ras/src/csmi_ras_serialization.c
+++ b/csmi/src/ras/src/csmi_ras_serialization.c
@@ -235,16 +235,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -485,16 +488,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -735,16 +741,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -985,16 +994,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1235,16 +1247,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1485,16 +1500,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1735,16 +1753,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1985,16 +2006,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2235,16 +2259,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2485,16 +2512,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2735,16 +2765,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2985,16 +3018,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3235,16 +3271,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3485,16 +3524,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3735,16 +3777,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3985,16 +4030,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4235,16 +4283,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4485,16 +4536,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4735,16 +4789,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4985,16 +5042,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 

--- a/csmi/src/wm/src/csmi_wm_serialization.c
+++ b/csmi/src/wm/src/csmi_wm_serialization.c
@@ -261,11 +261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -507,11 +511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -753,11 +761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -999,11 +1011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1245,11 +1261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1491,11 +1511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1737,11 +1761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -1983,11 +2011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2229,11 +2261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2475,11 +2511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2721,11 +2761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -2967,11 +3011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3213,11 +3261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3459,11 +3511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3705,11 +3761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -3951,11 +4011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4197,11 +4261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4443,11 +4511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4689,11 +4761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -4935,11 +5011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5181,11 +5261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5427,11 +5511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5673,11 +5761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -5919,11 +6011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6165,11 +6261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6411,11 +6511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6657,11 +6761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -6903,11 +7011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7149,11 +7261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7395,11 +7511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7641,11 +7761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -7887,11 +8011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8133,11 +8261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8379,11 +8511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8625,11 +8761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -8871,11 +9011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9117,11 +9261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9363,11 +9511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9609,11 +9761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -9855,11 +10011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10101,11 +10261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10347,11 +10511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10593,11 +10761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -10839,11 +11011,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -11085,11 +11261,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -11331,11 +11511,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF
@@ -11577,11 +11761,15 @@ INIT_FUNCT(CSMI_STRUCT_NAME)
 {
     if (!target) return; //< If the target is null return. TODO Error throwing.
     
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
+    
     // Initialize the members.
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata)\
         INIT_##serial_type(name, init_value, length_member)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 #undef STRUCT_DEF

--- a/csmi/src/wm/src/csmi_wm_serialization.c
+++ b/csmi/src/wm/src/csmi_wm_serialization.c
@@ -244,16 +244,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -494,16 +497,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -744,16 +750,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -994,16 +1003,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1244,16 +1256,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1494,16 +1509,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1744,16 +1762,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -1994,16 +2015,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2244,16 +2268,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2494,16 +2521,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2744,16 +2774,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -2994,16 +3027,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3244,16 +3280,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3494,16 +3533,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3744,16 +3786,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -3994,16 +4039,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4244,16 +4292,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4494,16 +4545,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4744,16 +4798,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -4994,16 +5051,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5244,16 +5304,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5494,16 +5557,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5744,16 +5810,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -5994,16 +6063,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6244,16 +6316,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6494,16 +6569,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6744,16 +6822,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -6994,16 +7075,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7244,16 +7328,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7494,16 +7581,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7744,16 +7834,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -7994,16 +8087,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8244,16 +8340,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8494,16 +8593,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8744,16 +8846,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -8994,16 +9099,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9244,16 +9352,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9494,16 +9605,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9744,16 +9858,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -9994,16 +10111,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10244,16 +10364,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10494,16 +10617,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10744,16 +10870,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -10994,16 +11123,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -11244,16 +11376,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -11494,16 +11629,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 
@@ -11744,16 +11882,19 @@ FREE_FUNCT(CSMI_STRUCT_NAME)
     uint32_t i = 0;             //< A counter variable.
     #endif
 
+    // Get the version the user is supplying.
+    uint64_t version_id    = target->_metadata <= CSM_VERSION_ID ? target->_metadata : CSM_MIN_VERSION;
+
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_ARRAY_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 
     #define CSMI_STRUCT_MEMBER(type, name, serial_type, length_member, init_value, metadata) \
         FREE_##serial_type(type, name, length_member, metadata)
-    #define CSMI_VERSION_START(version)
-    #define CSMI_VERSION_END(hash)
+    #define CSMI_VERSION_START(version) if (version_id >= version ) {
+    #define CSMI_VERSION_END(hash) } 
     #include STRUCT_DEF
 }
 


### PR DESCRIPTION
Fixing a bug in the x-macro for initialization. Version is now checked init code.