### PR TITLE
Issues/770 csm allocation step query details segmentation fault

### DIFF
--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -345,15 +345,16 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
     int32_t step_count = tuples.size();
     int32_t num_records_of_unique_steps = tuples.size();
     int32_t num_records_of_steps = output->num_steps;
-    printf("hi.\n");
-    printf("output->num_steps: %i\n", output->num_steps);
-    printf("step_count: %i\n", step_count);
+    // printf("hi.\n");
+    // printf("output->num_steps: %i\n", output->num_steps);
+    // printf("step_count: %i\n", step_count);
+    
     // This assumes a 1:1 parity between the first and second queries, some checks are made to ensure this.
     if ( step_count > 0  && output->num_steps == step_count )
     {
-        printf("hello.\n");
-        printf("output->num_steps: %i\n", output->num_steps);
-        printf("step_count: %i\n", step_count);
+        // printf("hello.\n");
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("step_count: %i\n", step_count);
         for (int32_t i = 0; i < step_count; ++i)
         {
             csm::db::DBTuple * const & fields = tuples[i];
@@ -391,23 +392,24 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         // best of both worlds
         // doesnt hold records back from customer (duplicate steps on an allocation -- ie, 2 step #1s in the history table)
         // doesnt seg fault
-        printf("hello 2.\n");
-        printf("output->num_steps: %i\n", output->num_steps);
-        printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
-        printf("num_records_of_steps: %i\n", num_records_of_steps);
-        printf("step_count: %i\n", step_count);
+
+        // printf("hello 2.\n");
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
+        // printf("num_records_of_steps: %i\n", num_records_of_steps);
+        // printf("step_count: %i\n", step_count);
 
         //set num steps  equal to the step count
         //step_count = output->num_steps;
         //don't do this in the good case, only the edge case. 
 
-        printf("output->num_steps: %i\n", output->num_steps);
-        printf("step_count: %i\n", step_count);
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("step_count: %i\n", step_count);
 
         // loop i for the unique number of steps found
         for (int32_t i = 0; i < num_records_of_unique_steps; ++i)
         {
-            printf("i: %i\n", i);
+            //printf("i: %i\n", i);
             csm::db::DBTuple * const & fields = tuples[i];
             if (fields->nfields != 2 ) continue;
             
@@ -415,20 +417,21 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
             int64_t step_id = strtoll(fields->data[0], nullptr, 10);
             //record number
             int32_t num_nodes = output->steps[i]->num_nodes;
-            printf("step_id: %li\n", step_id);
-            printf("num_nodes: %i\n", num_nodes);
+            // printf("step_id: %li\n", step_id);
+            // printf("num_nodes: %i\n", num_nodes);
 
             int32_t j = 0;
             //loop j for the total number of steps found, non unique
             for(j = 0; j < num_records_of_steps; j++)
             {
-                printf("j: %i\n", j);
-                printf("step_id: %li\n", step_id);
-                printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
+                // printf("j: %i\n", j);
+                // printf("step_id: %li\n", step_id);
+                // printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
+
                 // i think this is the faulty line -- because it won't make the compute nodes if there is no match in the previous if
                 if (step_id == output->steps[j]->step_id && num_nodes > 0)
                 {
-                    printf("match. \n");
+                    //printf("match. \n");
                     char** nodes = (char**)malloc( sizeof(char*) * output->steps[j]->num_nodes );
 
                     int32_t node = 0;
@@ -464,18 +467,18 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         // i beleive that "step count" may be related to the total number of steps found in an allocation. 
         // not necessarily the total number of steps found matching our current query. 
 
-        printf("hello 3.\n");
-        printf("output->num_steps: %i\n", output->num_steps);
-        printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
-        printf("num_records_of_steps: %i\n", num_records_of_steps);
-        printf("step_count: %i\n", step_count);
+        // printf("hello 3.\n");
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
+        // printf("num_records_of_steps: %i\n", num_records_of_steps);
+        // printf("step_count: %i\n", step_count);
 
         //set num steps  equal to the step count
         //step_count = output->num_steps;
         //don't do this in the good case, only the edge case. 
 
-        printf("output->num_steps: %i\n", output->num_steps);
-        printf("step_count: %i\n", step_count);
+        //printf("output->num_steps: %i\n", output->num_steps);
+        //printf("step_count: %i\n", step_count);
 
         // loop i for the unique number of steps found
 
@@ -490,16 +493,17 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
             int64_t step_id = strtoll(fields->data[0], nullptr, 10);
             //record number
             int32_t num_nodes = output->steps[i]->num_nodes;
-            printf("step_id: %li\n", step_id);
-            printf("num_nodes: %i\n", num_nodes);
+            //printf("step_id: %li\n", step_id);
+            //printf("num_nodes: %i\n", num_nodes);
 
             int32_t j = 0;
             //loop j for the total number of steps found, non unique
             for(j = 0; j < num_records_of_steps; j++)
             {
-                printf("j: %i\n", j);
-                printf("step_id: %li\n", step_id);
-                printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
+                //printf("j: %i\n", j);
+                //printf("step_id: %li\n", step_id);
+                //printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
+
                 // i think this is the faulty line -- because it won't make the compute nodes if there is no match in the previous if
                 if (step_id == output->steps[j]->step_id && num_nodes > 0)
                 {

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -348,7 +348,7 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
     // printf("hi.\n");
     // printf("output->num_steps: %i\n", output->num_steps);
     // printf("step_count: %i\n", step_count);
-    
+
     // This assumes a 1:1 parity between the first and second queries, some checks are made to ensure this.
     if ( step_count > 0  && output->num_steps == step_count )
     {
@@ -485,7 +485,7 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         //actually a change here.... only loong for num of steps found that match
         for (int32_t i = 0; i < num_records_of_steps; ++i)
         {
-            printf("i: %i\n", i);
+            //printf("i: %i\n", i);
             csm::db::DBTuple * const & fields = tuples[i];
             if (fields->nfields != 2 ) continue;
             
@@ -507,7 +507,7 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
                 // i think this is the faulty line -- because it won't make the compute nodes if there is no match in the previous if
                 if (step_id == output->steps[j]->step_id && num_nodes > 0)
                 {
-                    printf("match. \n");
+                    //printf("match. \n");
                     char** nodes = (char**)malloc( sizeof(char*) * output->steps[j]->num_nodes );
 
                     int32_t node = 0;

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -345,16 +345,10 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
     int32_t step_count = tuples.size();
     int32_t num_records_of_unique_steps = tuples.size();
     int32_t num_records_of_steps = output->num_steps;
-    // printf("hi.\n");
-    // printf("output->num_steps: %i\n", output->num_steps);
-    // printf("step_count: %i\n", step_count);
 
     // This assumes a 1:1 parity between the first and second queries, some checks are made to ensure this.
     if ( step_count > 0  && output->num_steps == step_count )
     {
-        // printf("hello.\n");
-        // printf("output->num_steps: %i\n", output->num_steps);
-        // printf("step_count: %i\n", step_count);
         for (int32_t i = 0; i < step_count; ++i)
         {
             csm::db::DBTuple * const & fields = tuples[i];
@@ -393,23 +387,13 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         // doesnt hold records back from customer (duplicate steps on an allocation -- ie, 2 step #1s in the history table)
         // doesnt seg fault
 
-        // printf("hello 2.\n");
-        // printf("output->num_steps: %i\n", output->num_steps);
-        // printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
-        // printf("num_records_of_steps: %i\n", num_records_of_steps);
-        // printf("step_count: %i\n", step_count);
-
         //set num steps  equal to the step count
         //step_count = output->num_steps;
         //don't do this in the good case, only the edge case. 
 
-        // printf("output->num_steps: %i\n", output->num_steps);
-        // printf("step_count: %i\n", step_count);
-
         // loop i for the unique number of steps found
         for (int32_t i = 0; i < num_records_of_unique_steps; ++i)
         {
-            //printf("i: %i\n", i);
             csm::db::DBTuple * const & fields = tuples[i];
             if (fields->nfields != 2 ) continue;
             
@@ -417,21 +401,15 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
             int64_t step_id = strtoll(fields->data[0], nullptr, 10);
             //record number
             int32_t num_nodes = output->steps[i]->num_nodes;
-            // printf("step_id: %li\n", step_id);
-            // printf("num_nodes: %i\n", num_nodes);
 
             int32_t j = 0;
             //loop j for the total number of steps found, non unique
             for(j = 0; j < num_records_of_steps; j++)
             {
-                // printf("j: %i\n", j);
-                // printf("step_id: %li\n", step_id);
-                // printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
 
                 // i think this is the faulty line -- because it won't make the compute nodes if there is no match in the previous if
                 if (step_id == output->steps[j]->step_id && num_nodes > 0)
                 {
-                    //printf("match. \n");
                     char** nodes = (char**)malloc( sizeof(char*) * output->steps[j]->num_nodes );
 
                     int32_t node = 0;
@@ -467,18 +445,9 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         // i beleive that "step count" may be related to the total number of steps found in an allocation. 
         // not necessarily the total number of steps found matching our current query. 
 
-        // printf("hello 3.\n");
-        // printf("output->num_steps: %i\n", output->num_steps);
-        // printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
-        // printf("num_records_of_steps: %i\n", num_records_of_steps);
-        // printf("step_count: %i\n", step_count);
-
         //set num steps  equal to the step count
         //step_count = output->num_steps;
         //don't do this in the good case, only the edge case. 
-
-        //printf("output->num_steps: %i\n", output->num_steps);
-        //printf("step_count: %i\n", step_count);
 
         // loop i for the unique number of steps found
 
@@ -500,10 +469,6 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
             //loop j for the total number of steps found, non unique
             for(j = 0; j < num_records_of_steps; j++)
             {
-                //printf("j: %i\n", j);
-                //printf("step_id: %li\n", step_id);
-                //printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
-
                 // i think this is the faulty line -- because it won't make the compute nodes if there is no match in the previous if
                 if (step_id == output->steps[j]->step_id && num_nodes > 0)
                 {
@@ -593,27 +558,6 @@ void CSMIAllocationStepQueryDetails::CreateStepStruct(
 	                                                   
         s->history  = h;
     }
-	
-    //// Parse the nodes from csv
-    //if ( s->num_nodes > 0 )
-    //{
-	//    s->compute_nodes = (char**)malloc( sizeof(char*) * s->num_nodes);
-
-    //    int32_t i = 0;
-    //    char *saveptr;
-    //    char *nodeStr = strtok_r(fields->data[26], ",", &saveptr);
-
-    //    while (nodeStr != NULL && i < s->num_nodes)
-    //    {
-    //        s->compute_nodes[i++] = strdup(nodeStr);
-    //        nodeStr = strtok_r(NULL, ",", &saveptr);
-    //    }
-
-    //    while ( i < s->num_nodes )
-    //    {
-    //        s->compute_nodes[i++] = strdup("N/A");
-    //    }
-    //}
 
 	*step = s;
 

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -478,7 +478,9 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         printf("step_count: %i\n", step_count);
 
         // loop i for the unique number of steps found
-        for (int32_t i = 0; i < num_records_of_unique_steps; ++i)
+
+        //actually a change here.... only loong for num of steps found that match
+        for (int32_t i = 0; i < num_records_of_steps; ++i)
         {
             printf("i: %i\n", i);
             csm::db::DBTuple * const & fields = tuples[i];

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -61,9 +61,9 @@ bool CSMIAllocationStepQueryDetails::RetrieveDataForPrivateCheck(
 {
     //TODO: Add in history table check as well. 
     LOG( csmapi, trace ) << STATE_NAME ":RetrieveDataForPrivateCheck: Enter";
-	
-	// Unpack the buffer.
-	INPUT_STRUCT* input = nullptr;
+    
+    // Unpack the buffer.
+    INPUT_STRUCT* input = nullptr;
 
     if( csm_deserialize_struct(INPUT_STRUCT, &input, arguments.c_str(), len) == 0 )
     {
@@ -108,12 +108,12 @@ bool CSMIAllocationStepQueryDetails::CompareDataForPrivateCheck(
         csm::daemon::EventContextHandlerState_sptr& ctx)
 {
     LOG( csmapi, trace ) << STATE_NAME ":CompareDataForPrivateCheck: Enter";
-	
+    
     bool success = false;
 
     if ( tuples.size() == 1 )
     {
-		uint32_t userID = strtoul(tuples[0]->data[0], nullptr, 10);
+        uint32_t userID = strtoul(tuples[0]->data[0], nullptr, 10);
         success = (userID == msg.GetUserID());
 
         // If the success failed report it.
@@ -136,10 +136,10 @@ bool CSMIAllocationStepQueryDetails::CompareDataForPrivateCheck(
         ctx->SetErrorCode(CSMERR_DB_ERROR);
         ctx->AppendErrorMessage("Database check failed for user id " + std::to_string(msg.GetUserID()) + ";" );
     }
-	
+    
     LOG( csmapi, trace ) << STATE_NAME ":CompareDataForPrivateCheck: Exit";
 
-	return success;
+    return success;
 }
 
 bool CSMIAllocationStepQueryDetails::CreatePayload(
@@ -148,13 +148,13 @@ bool CSMIAllocationStepQueryDetails::CreatePayload(
         csm::db::DBReqContent **dbPayload,
         csm::daemon::EventContextHandlerState_sptr& ctx )
 {
-	// TODO: Old log. Should this be a trace only?
+    // TODO: Old log. Should this be a trace only?
     LOG(csmapi, trace) << STATE_NAME ":CreatePayload: Enter";
-	
+    
     // TODO should this live in StatefulDBRecvPrivate?
-		
-	// Unpack the buffer.
-	INPUT_STRUCT* input = nullptr;
+        
+    // Unpack the buffer.
+    INPUT_STRUCT* input = nullptr;
     
     if ( csm_deserialize_struct(INPUT_STRUCT, &input, arguments.c_str(), len) == 0 )
     {
@@ -165,28 +165,28 @@ bool CSMIAllocationStepQueryDetails::CreatePayload(
         std::string stmt = "(WITH s AS ("
             "SELECT "
                 "s.step_id, "
-				"s.allocation_id, "
+                "s.allocation_id, "
                 "CAST(NULL AS DATE) as archive_history_time, "
-				"s.argument as argument, "
+                "s.argument as argument, "
                 "s.begin_time, "
-				"CAST(NULL AS TEXT) as cpu_stats, "
+                "CAST(NULL AS TEXT) as cpu_stats, "
                 "CAST(NULL AS DATE) as end_time, "
-				"s.environment_variable as environment_variable, "
+                "s.environment_variable as environment_variable, "
                 "CAST(NULL AS TEXT) as error_message, s.executable as executable, "
                 "CAST(NULL AS INT) as exit_status, CAST(NULL AS TEXT) as gpu_stats, "   
                 "CAST(NULL AS TEXT) as io_stats, "    
                 "CAST(NULL AS BIGINT) as max_memory, "  
                 "CAST(NULL AS TEXT) as memory_stats, "
-				"s.num_gpus as num_gpus, "
+                "s.num_gpus as num_gpus, "
                 "s.projected_memory as projected_memory, "
-				"s.num_nodes as num_nodes, "
+                "s.num_nodes as num_nodes, "
                 "s.num_processors as num_processors, "
-				"s.num_tasks as num_tasks, "
-				"s.status as status, "
-				"CAST(NULL AS TEXT) as omp_thread_limit, "
-		        "CAST(NULL AS DOUBLE PRECISION) as total_s_time, "
+                "s.num_tasks as num_tasks, "
+                "s.status as status, "
+                "CAST(NULL AS TEXT) as omp_thread_limit, "
+                "CAST(NULL AS DOUBLE PRECISION) as total_s_time, "
                 "CAST(NULL AS DOUBLE PRECISION) as total_u_time, "
-		        "s.user_flags as user_flags, s.working_directory as working_directory "
+                "s.user_flags as user_flags, s.working_directory as working_directory "
             "FROM csm_step AS s "
             "WHERE s.allocation_id = $1::bigint ";
 
@@ -199,27 +199,27 @@ bool CSMIAllocationStepQueryDetails::CreatePayload(
         stmt.append( "ORDER BY s.allocation_id, s.step_id) "
             "SELECT * FROM s UNION ALL ( "
                 "SELECT "
-        	        "sh.step_id, "
-					"sh.allocation_id, "
-        	        "sh.archive_history_time, "
-					"sh.argument as argument, "
-        	        "sh.begin_time, "
-					"sh.cpu_stats as cpu_stats, "
-        	        "sh.end_time, "
-					"sh.environment_variable as environment_variable, "
-        	        "sh.error_message as error_message, sh.executable as executable, "
-        	        "sh.exit_status as exit_status, sh.gpu_stats as gpu_stats, "
-        	        "sh.io_stats as io_stats, "
-        	        "sh.max_memory as max_memory, "
-        	        "sh.memory_stats as memory_stats, "
-        	        "sh.num_gpus as num_gpus, "
-        	        "sh.projected_memory as projected_memory, sh.num_nodes as num_nodes, "
-        	        "sh.num_processors as num_processors, sh.num_tasks as num_tasks, "
-        	        "sh.status as status, "
+                    "sh.step_id, "
+                    "sh.allocation_id, "
+                    "sh.archive_history_time, "
+                    "sh.argument as argument, "
+                    "sh.begin_time, "
+                    "sh.cpu_stats as cpu_stats, "
+                    "sh.end_time, "
+                    "sh.environment_variable as environment_variable, "
+                    "sh.error_message as error_message, sh.executable as executable, "
+                    "sh.exit_status as exit_status, sh.gpu_stats as gpu_stats, "
+                    "sh.io_stats as io_stats, "
+                    "sh.max_memory as max_memory, "
+                    "sh.memory_stats as memory_stats, "
+                    "sh.num_gpus as num_gpus, "
+                    "sh.projected_memory as projected_memory, sh.num_nodes as num_nodes, "
+                    "sh.num_processors as num_processors, sh.num_tasks as num_tasks, "
+                    "sh.status as status, "
                     "sh.omp_thread_limit,"
-        	        "sh.total_s_time as total_s_time, "
-        	        "sh.total_u_time as total_u_time, "
-        	        "sh.user_flags as user_flags, sh.working_directory as working_directory "
+                    "sh.total_s_time as total_s_time, "
+                    "sh.total_u_time as total_u_time, "
+                    "sh.user_flags as user_flags, sh.working_directory as working_directory "
                 "FROM csm_step_history AS sh "
                 "WHERE sh.allocation_id = $1::bigint ");
         
@@ -233,11 +233,11 @@ bool CSMIAllocationStepQueryDetails::CreatePayload(
         if(input->step_id >= 0) dbReq->AddNumericParam<int64_t>( input->step_id );
 
         *dbPayload = dbReq;
-	    csm_free_struct_ptr(INPUT_STRUCT, input);
+        csm_free_struct_ptr(INPUT_STRUCT, input);
 
         LOG( csmapi, trace ) << STATE_NAME ":CreatePayload: Parameterized SQL: " << stmt;
     }
-	else
+    else
     {
         LOG( csmapi, error ) << STATE_NAME ":CreatePayload: argUnpackFunc failed...";
         LOG( csmapi, trace  ) << STATE_NAME ":CreatePayload: Exit";
@@ -249,7 +249,7 @@ bool CSMIAllocationStepQueryDetails::CreatePayload(
 
     LOG( csmapi, trace ) << STATE_NAME ":CreatePayload: Exit";
 
-	return true;
+    return true;
 }
 
 bool CSMIAllocationStepQueryDetails::CreateResponsePayload(
@@ -332,7 +332,7 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         const std::vector<csm::db::DBTuple *>&tuples,
         char **buf, uint32_t &bufLen,
         csm::daemon::EventContextHandlerState_sptr& ctx )
-{	
+{   
     LOG( csmapi, trace ) << STATE_NAME ":CreateByteArray: Enter";
     
     // Init the buffer
@@ -345,10 +345,16 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
     int32_t step_count = tuples.size();
     int32_t num_records_of_unique_steps = tuples.size();
     int32_t num_records_of_steps = output->num_steps;
+    // printf("hi.\n");
+    // printf("output->num_steps: %i\n", output->num_steps);
+    // printf("step_count: %i\n", step_count);
 
     // This assumes a 1:1 parity between the first and second queries, some checks are made to ensure this.
     if ( step_count > 0  && output->num_steps == step_count )
     {
+        // printf("hello.\n");
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("step_count: %i\n", step_count);
         for (int32_t i = 0; i < step_count; ++i)
         {
             csm::db::DBTuple * const & fields = tuples[i];
@@ -387,13 +393,23 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         // doesnt hold records back from customer (duplicate steps on an allocation -- ie, 2 step #1s in the history table)
         // doesnt seg fault
 
+        // printf("hello 2.\n");
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
+        // printf("num_records_of_steps: %i\n", num_records_of_steps);
+        // printf("step_count: %i\n", step_count);
+
         //set num steps  equal to the step count
         //step_count = output->num_steps;
         //don't do this in the good case, only the edge case. 
 
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("step_count: %i\n", step_count);
+
         // loop i for the unique number of steps found
         for (int32_t i = 0; i < num_records_of_unique_steps; ++i)
         {
+            //printf("i: %i\n", i);
             csm::db::DBTuple * const & fields = tuples[i];
             if (fields->nfields != 2 ) continue;
             
@@ -401,15 +417,21 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
             int64_t step_id = strtoll(fields->data[0], nullptr, 10);
             //record number
             int32_t num_nodes = output->steps[i]->num_nodes;
+            // printf("step_id: %li\n", step_id);
+            // printf("num_nodes: %i\n", num_nodes);
 
             int32_t j = 0;
             //loop j for the total number of steps found, non unique
             for(j = 0; j < num_records_of_steps; j++)
             {
+                // printf("j: %i\n", j);
+                // printf("step_id: %li\n", step_id);
+                // printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
 
                 // i think this is the faulty line -- because it won't make the compute nodes if there is no match in the previous if
                 if (step_id == output->steps[j]->step_id && num_nodes > 0)
                 {
+                    //printf("match. \n");
                     char** nodes = (char**)malloc( sizeof(char*) * output->steps[j]->num_nodes );
 
                     int32_t node = 0;
@@ -445,9 +467,18 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
         // i beleive that "step count" may be related to the total number of steps found in an allocation. 
         // not necessarily the total number of steps found matching our current query. 
 
+        // printf("hello 3.\n");
+        // printf("output->num_steps: %i\n", output->num_steps);
+        // printf("num_records_of_unique_steps: %i\n", num_records_of_unique_steps);
+        // printf("num_records_of_steps: %i\n", num_records_of_steps);
+        // printf("step_count: %i\n", step_count);
+
         //set num steps  equal to the step count
         //step_count = output->num_steps;
         //don't do this in the good case, only the edge case. 
+
+        //printf("output->num_steps: %i\n", output->num_steps);
+        //printf("step_count: %i\n", step_count);
 
         // loop i for the unique number of steps found
 
@@ -469,6 +500,10 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
             //loop j for the total number of steps found, non unique
             for(j = 0; j < num_records_of_steps; j++)
             {
+                //printf("j: %i\n", j);
+                //printf("step_id: %li\n", step_id);
+                //printf("output->steps[j]->step_id: %li\n", output->steps[j]->step_id);
+
                 // i think this is the faulty line -- because it won't make the compute nodes if there is no match in the previous if
                 if (step_id == output->steps[j]->step_id && num_nodes > 0)
                 {
@@ -525,41 +560,62 @@ void CSMIAllocationStepQueryDetails::CreateStepStruct(
 
     s->step_id              = strtoll(fields->data[0], nullptr, 10);
     s->allocation_id        = strtoll(fields->data[1], nullptr, 10);
-	s->argument             = strdup (fields->data[3]);
-	s->begin_time           = strdup (fields->data[4]);
-	s->environment_variable = strdup (fields->data[7]);
-	s->executable           = strdup (fields->data[9]);
-	s->num_gpus             = strtol(fields->data[15], nullptr, 10);
-	s->projected_memory     = strtol(fields->data[16], nullptr, 10);
-	s->num_nodes            = strtol(fields->data[17], nullptr, 10);
+    s->argument             = strdup (fields->data[3]);
+    s->begin_time           = strdup (fields->data[4]);
+    s->environment_variable = strdup (fields->data[7]);
+    s->executable           = strdup (fields->data[9]);
+    s->num_gpus             = strtol(fields->data[15], nullptr, 10);
+    s->projected_memory     = strtol(fields->data[16], nullptr, 10);
+    s->num_nodes            = strtol(fields->data[17], nullptr, 10);
     if ( s->num_nodes < 0 ) s->num_nodes = 0; // Zero for serialization's sake.
-	s->num_processors       = strtol(fields->data[18], nullptr, 10);
-	s->num_tasks            = strtol(fields->data[19], nullptr, 10);
-	s->status               = (csmi_step_status_t)csm_get_enum_from_string(csmi_step_status_t, fields->data[20]);
-	s->user_flags           = strdup (fields->data[24]);
-	s->working_directory    = strdup (fields->data[25]);
+    s->num_processors       = strtol(fields->data[18], nullptr, 10);
+    s->num_tasks            = strtol(fields->data[19], nullptr, 10);
+    s->status               = (csmi_step_status_t)csm_get_enum_from_string(csmi_step_status_t, fields->data[20]);
+    s->user_flags           = strdup (fields->data[24]);
+    s->working_directory    = strdup (fields->data[25]);
     
 
     if ( fields->data[6][0] )
     {
-	    HISTORY_STRUCT *h = (HISTORY_STRUCT*) malloc(sizeof(HISTORY_STRUCT));
-	    h->archive_history_time = strdup (fields->data[2]);
-	    h->cpu_stats            = strdup (fields->data[5]);
-	    h->end_time             = strdup (fields->data[6]);
-	    h->error_message        = strdup (fields->data[8]);
-	    h->exit_status          = strtol(fields->data[10], nullptr, 10);
-	    h->gpu_stats            = strdup (fields->data[11]);
-	    h->io_stats             = strdup (fields->data[12]);
-	    h->max_memory           = strtoll (fields->data[13], nullptr, 10);
-	    h->memory_stats         = strdup (fields->data[14]);
-	    h->omp_thread_limit     = strdup (fields->data[21]);
-	    h->total_s_time         = strtod (fields->data[22], nullptr);
-	    h->total_u_time         = strtod (fields->data[23], nullptr);
-	                                                   
+        HISTORY_STRUCT *h = (HISTORY_STRUCT*) malloc(sizeof(HISTORY_STRUCT));
+        h->archive_history_time = strdup (fields->data[2]);
+        h->cpu_stats            = strdup (fields->data[5]);
+        h->end_time             = strdup (fields->data[6]);
+        h->error_message        = strdup (fields->data[8]);
+        h->exit_status          = strtol(fields->data[10], nullptr, 10);
+        h->gpu_stats            = strdup (fields->data[11]);
+        h->io_stats             = strdup (fields->data[12]);
+        h->max_memory           = strtoll (fields->data[13], nullptr, 10);
+        h->memory_stats         = strdup (fields->data[14]);
+        h->omp_thread_limit     = strdup (fields->data[21]);
+        h->total_s_time         = strtod (fields->data[22], nullptr);
+        h->total_u_time         = strtod (fields->data[23], nullptr);
+                                                       
         s->history  = h;
     }
+    
+    //// Parse the nodes from csv
+    //if ( s->num_nodes > 0 )
+    //{
+    //    s->compute_nodes = (char**)malloc( sizeof(char*) * s->num_nodes);
 
-	*step = s;
+    //    int32_t i = 0;
+    //    char *saveptr;
+    //    char *nodeStr = strtok_r(fields->data[26], ",", &saveptr);
+
+    //    while (nodeStr != NULL && i < s->num_nodes)
+    //    {
+    //        s->compute_nodes[i++] = strdup(nodeStr);
+    //        nodeStr = strtok_r(NULL, ",", &saveptr);
+    //    }
+
+    //    while ( i < s->num_nodes )
+    //    {
+    //        s->compute_nodes[i++] = strdup("N/A");
+    //    }
+    //}
+
+    *step = s;
 
     LOG( csmapi, debug ) << STATE_NAME ":CreateStepStruct: Exit";
 }

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -459,7 +459,7 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
                 }
             }
         }
-    }elseif(step_count > 0  && output->num_steps < step_count)
+    }else if(step_count > 0  && output->num_steps < step_count)
     {
         //another case in 770
         // but where the step count is greater than num steps

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationStepQueryDetails.cc
@@ -342,14 +342,21 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
     OUTPUT_STRUCT *output= nullptr;
     std::unique_lock<std::mutex>dataLock = ctx->GetUserData<OUTPUT_STRUCT*>(&output);
 
+    // tuples.size() is number of unique steps found in this query
     int32_t step_count = tuples.size();
     int32_t num_records_of_unique_steps = tuples.size();
     int32_t num_records_of_steps = output->num_steps;
-    // printf("hi.\n");
-    // printf("output->num_steps: %i\n", output->num_steps);
-    // printf("step_count: %i\n", step_count);
+    //printf("hi.\n");
+    // output->num_steps is total records found in this query
+    //printf("output->num_steps: %i\n", output->num_steps);
+    //printf("step_count: %i\n", step_count);
 
     // This assumes a 1:1 parity between the first and second queries, some checks are made to ensure this.
+    // NOTE: there is another wierd edge case here...
+    // where if the total number of records returned matches the unique number of steps in the allocation. it will blow up. 
+    // ie there are 3 unique steps in allocation 1
+    // steps: 1,2,3
+    // but there is also 3 step 1s
     if ( step_count > 0  && output->num_steps == step_count )
     {
         // printf("hello.\n");
@@ -452,7 +459,7 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
                 }
             }
         }
-    }else
+    }elseif(step_count > 0  && output->num_steps < step_count)
     {
         //another case in 770
         // but where the step count is greater than num steps
@@ -528,7 +535,10 @@ bool CSMIAllocationStepQueryDetails::CreateByteArray(
                 }
             }
         }
-        
+    }else{
+        //test
+        //printf("hello else.\n");
+
     }
 
     // Package the data for transport.

--- a/csmi/src/wm/cmd/allocation_step_query_details.c
+++ b/csmi/src/wm/cmd/allocation_step_query_details.c
@@ -98,6 +98,7 @@ int main(int argc, char *argv[])
 	int return_value = 0;
 	int requiredParameterCounter = 0;
 	int optionalParameterCounter = 0;
+	char s_flag = 0;
 	const int NUMBER_OF_REQUIRED_ARGUMENTS = 1;
 	const int MINIMUM_NUMBER_OF_OPTIONAL_ARGUMENTS = 0;
 	/*Variables for checking cmd line args*/
@@ -136,6 +137,7 @@ int main(int argc, char *argv[])
                 csm_str_to_int64( input.step_id, optarg, arg_check,
                                "-s, --step_id", USAGE )
 				optionalParameterCounter++;
+				s_flag = 1;
 				break;
 			default:
 				csmutil_logging(error, "unknown arg: '%c'\n", opt);
@@ -181,6 +183,11 @@ int main(int argc, char *argv[])
 	        /*Print out the output of the query to stdout in YAML format*/
 	        puts("---");
 	        printf("Total_Records: %u\n", output->num_steps);
+	        if(s_flag == 1 && output->num_steps > 1)
+	        {
+	        	printf("# Error: There should only be one matching step record. Verify the database. \n");
+	        	return CSMERR_GENERIC;
+	        }
 	        for(i = 0; i < output->num_steps; i++){
                 csmi_allocation_step_t *step = output->steps[i];
 	        	printf("Record_%u:\n", i+1);

--- a/csmtest/buckets/basic/step.sh
+++ b/csmtest/buckets/basic/step.sh
@@ -36,6 +36,15 @@ LOG=${LOG_PATH}/buckets/basic/step.log
 TEMP_LOG=${LOG_PATH}/buckets/basic/step_tmp.log
 FLAG_LOG=${LOG_PATH}/buckets/basic/step_flags.log
 
+# Local variables for the CSM DB record checks
+DB_NAME="csmdb"
+DB_USER="csmdb"
+
+# Local variables for step ids passed into the functions
+sid_1=1
+sid_2=2
+sid_3=3
+
 if [ -f "${BASH_SOURCE%/*}/../../include/functions.sh" ]
 then
         . "${BASH_SOURCE%/*}/../../include/functions.sh"
@@ -51,48 +60,376 @@ echo "------------------------------------------------------------" >> ${LOG}
 
 # Test Case 1: Calling csm_allocation_create
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 1: Calling csm_allocation_create" 
+check_return_exit $? 0 "Test Case 1:  Calling csm_allocation_create                    (allocation_id: created     )" 
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
 # Test Case 2: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 2: Calling csm_allocation_query_active_all"
+check_return_exit $? 0 "Test Case 2:  Calling csm_allocation_query_active_all"
 
 # Test Case 3: Calling csm_allocation_step_begin
 ${CSM_PATH}/csm_allocation_step_begin --step_id 1 --allocation_id ${allocation_id} --executable "my_executable" --working_directory "my_workding_directory" --argument "my_argument" --environment_variable "my_environment_variable" --num_processors 1 --num_gpus 1 --projected_memory 512 --num_tasks 1 --compute_nodes ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 3: Calling csm_allocation_step_begin"
+check_return_exit $? 0 "Test Case 3:  Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: 1)"
 
 # Test Case 4: Calling csm_allocation_step_query_active_all
 ${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 4: Calling csm_allocation_step_query_active_all"
+check_return_flag_value $? 0 "Test Case 4:  Calling csm_allocation_step_query_active_all"
 
 # Test Case 5: Calling csm_allocation_step_end
 ${CSM_PATH}/csm_allocation_step_end -a ${allocation_id} -s 1 -e 1 -E "error" -c "cpu_good" -t 0.0 -T 1.5 -n "t_num_threads_good" -G "gpu_s_good" -m "mem_sts_good" -M 512 -i "io_sts_good" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 5: Calling csm_allocation_step_end"
+check_return_exit $? 0 "Test Case 5:  Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: 1)"
 
 # Test Case 6: Calling csm_allocation_step_query_active_all
 ${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "No matching records found."
-check_return_flag_value $? 0 "Test Case 6: Calling csm_allocation_step_query_active_all"
+check_return_flag_value $? 0 "Test Case 6:  Calling csm_allocation_step_query_active_all"
 
 # Test Case 7: Calling csm_allocation_step_query
 ${CSM_PATH}/csm_allocation_step_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 7: Calling csm_allocation_step_query"
+check_return_flag_value $? 0 "Test Case 7:  Calling csm_allocation_step_query"
 
 # Test Case 8: Calling csm_allocation_step_query_details
 ${CSM_PATH}/csm_allocation_step_query_details -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 8: Calling csm_allocation_step_query_details"
+check_return_flag_value $? 0 "Test Case 8:  Calling csm_allocation_step_query_details"
 
-# Test Case 9: Calling csm_allocation_delete
+# Test Case 9: Check csm_allocation_step_query_details record count
+rcount_0=`grep Total_Records: ${TEMP_LOG} | awk -F': ' '{print $2}'`
+csm_step_hist_ct_0=`psql -qtA -U $DB_USER -d $DB_NAME -c "select count(*) from csm_step_history where step_id=1 and allocation_id=${allocation_id}"`
+
+    if [[ "$csm_step_hist_ct_0" -eq "$rcount_0" ]]; then
+        check_return_flag_value $? 0 "Test Case 9:  Check   csm_allocation_step_query_details        (Total_Records:${rcount_0})"
+    else
+        check_return_exit $? 0 "Test Case 9: Check   csm_allocation_step_query_details        (Total_Records:${rcount_0})"
+    fi
+
+# Test Case 10: Calling csm_allocation_delete
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 9: Calling csm_allocation_delete"
+check_return_flag_value $? 0 "Test Case 10:  Calling csm_allocation_delete"
 
-# Test Case 10: Calling csm_allocation_query_active_all
+# Test Case 11: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
 check_all_output "No matching records found"
-check_return_flag_value $? 0 "Test Case 10: Calling csm_allocation_query_active_all"
+check_return_flag_value $? 0 "Test Case 11: Calling csm_allocation_query_active_all"
+
+# Additional tests to handle multiple records returned from csm_allocation_step_query_details
+echo "------------------------------------------------------------" >> ${LOG}
+echo "             Additional Basic Bucket Tests Set #2"            >> ${LOG}
+echo "  CSM Allocation Step Query Details (multiple same steps)"    >> ${LOG}
+echo "------------------------------------------------------------" >> ${LOG}
+
+#-----------------------------------------------------------------
+# Functions for allocation_step_begin & allocation_step_end
+#-----------------------------------------------------------------
+
+function allocation_step_begin()
+{
+${CSM_PATH}/csm_allocation_step_begin --step_id $@ --allocation_id ${allocation_id} --executable "my_executable" --working_directory "my_workding_directory" --argument "my_argument" --environment_variable "my_environment_variable" --num_processors 1 --num_gpus 1 --projected_memory 512 --num_tasks 1 --compute_nodes ${SINGLE_COMPUTE}
+}
+
+function allocation_step_end()
+{
+${CSM_PATH}/csm_allocation_step_end -a ${allocation_id} -s $@ -e 1 -E "error" -c "cpu_good" -t 0.0 -T 1.5 -n "t_num_threads_good" -G "gpu_s_good" -m "mem_sts_good" -M 512 -i "io_sts_good"
+}
+
+# Test Case 12: Calling csm_allocation_create
+${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 12: Calling csm_allocation_create                    (allocation_id: created     )"
+
+# Grab & Store Allocation ID from csm_allocation_create.log
+allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
+
+# Test Case 13: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 13: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 14: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 14: Calling csm_allocation_step_query_active_all"
+
+# Test Case 15: Calling csm_allocation_step_end
+allocation_step_end ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 15: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 16: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 16: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 17: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 17: Calling csm_allocation_step_query_active_all"
+
+# Test Case 18: Calling csm_allocation_step_end
+allocation_step_end ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 18: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 19: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 19: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 20: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 20: Calling csm_allocation_step_query_active_all"
+
+# Test Case 21: Calling csm_allocation_step_end
+allocation_step_end ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 21: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+#-------------------------------------------------------------------------------------------------------------------------
+# Creating an additional step to handle the edge case.
+#-------------------------------------------------------------------------------------------------------------------------
+
+# Test Case 22: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 22: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 23: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 23: Calling csm_allocation_step_query_active_all"
+
+# Test Case 24: Calling csm_allocation_step_end
+allocation_step_end ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 24: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 25: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 25: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 26: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 26: Calling csm_allocation_step_query_active_all"
+
+# Test Case 27: Calling csm_allocation_step_end
+allocation_step_end ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 27: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 28: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_all_output "No matching records found."
+check_return_flag_value $? 0 "Test Case 28: Calling csm_allocation_step_query_active_all"
+
+# Test Case 29: Calling csm_allocation_step_query
+${CSM_PATH}/csm_allocation_step_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 29: Calling csm_allocation_step_query"
+
+# Test Case 30: Calling csm_allocation_step_query_details
+${CSM_PATH}/csm_allocation_step_query_details -a ${allocation_id} -s 1  > ${TEMP_LOG} 2>&1 
+check_return_flag_value $? 1 "Test Case 30: Calling csm_allocation_step_query_details        (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 31: Check csm_allocation_step_query_details record count
+rcount_1=`grep Total_Records: ${TEMP_LOG} | awk -F': ' '{print $2}'`
+csm_step_hist_ct_1=`psql -qtA -U $DB_USER -d $DB_NAME -c "select count(*) from csm_step_history where step_id=1 and allocation_id=${allocation_id}"`
+
+    if [[ "$csm_step_hist_ct_1" -eq "$rcount_1" ]]; then
+        check_return_flag_value $? 0 "Test Case 31: Check   csm_allocation_step_query_details        (Total_Records:${rcount_1})"
+    else
+        check_return_exit $? 0 "Test Case 31: Check   csm_allocation_step_query_details        (Total_Records:${rcount_1})"
+    fi
+
+# Test Case 32: Calling csm_allocation_step_query_details
+${CSM_PATH}/csm_allocation_step_query_details -a ${allocation_id} -s 2  > ${TEMP_LOG} 2>&1 
+check_return_flag_value $? 1 "Test Case 32: Calling csm_allocation_step_query_details        (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 33: Check csm_allocation_step_query_details record count
+rcount_1a=`grep Total_Records: ${TEMP_LOG} | awk -F': ' '{print $2}'`
+csm_step_hist_ct_1a=`psql -qtA -U $DB_USER -d $DB_NAME -c "select count(*) from csm_step_history where step_id=2 and allocation_id=${allocation_id}"`
+
+    if [[ "$csm_step_hist_ct_1a" -eq "$rcount_1a" ]]; then
+        check_return_flag_value $? 0 "Test Case 33: Check   csm_allocation_step_query_details        (Total_Records:${rcount_1a})"
+    else
+        check_return_exit $? 0 "Test Case 33: Check   csm_allocation_step_query_details        (Total_Records:${rcount_1a})"
+    fi
+
+# Test Case 34: Calling csm_allocation_delete
+${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 34: Calling csm_allocation_delete"
+
+# Test Case 35: Calling csm_allocation_query_active_all
+${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
+check_all_output "No matching records found"
+check_return_flag_value $? 0 "Test Case 35: Calling csm_allocation_query_active_all"
+
+# Additional tests #3 to handle multiple records returned from csm_allocation_step_query_details
+echo "------------------------------------------------------------" >> ${LOG}
+echo "             Additional Basic Bucket Tests Set #3"            >> ${LOG}
+echo "  CSM Allocation Step Query Details (multiple same steps)"    >> ${LOG}
+echo "------------------------------------------------------------" >> ${LOG}
+
+# Test Case 36: Calling csm_allocation_create
+${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 36: Calling csm_allocation_create                    (allocation_id: created     )"
+
+# Grab & Store Allocation ID from csm_allocation_create.log
+allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
+
+# Test Case 37: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 37: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 38: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 38: Calling csm_allocation_step_query_active_all"
+
+# Test Case 39: Calling csm_allocation_step_end
+allocation_step_end ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 39: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 40: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 40: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 41: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 41: Calling csm_allocation_step_query_active_all"
+
+# Test Case 42: Calling csm_allocation_step_end
+allocation_step_end ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 42: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 43: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_3} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 43: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_3})"
+
+# Test Case 44: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 44: Calling csm_allocation_step_query_active_all"
+
+# Test Case 45: Calling csm_allocation_step_end
+allocation_step_end ${sid_3} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 45: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_3})"
+
+# Test Case 46: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 46: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 47: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 47: Calling csm_allocation_step_query_active_all"
+
+# Test Case 48: Calling csm_allocation_step_end
+allocation_step_end ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 48: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 49: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 49: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 50: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 50: Calling csm_allocation_step_query_active_all"
+
+# Test Case 51: Calling csm_allocation_step_end
+allocation_step_end ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 51: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 52: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_3} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 52: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_3})"
+
+# Test Case 53: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 53: Calling csm_allocation_step_query_active_all"
+
+# Test Case 54: Calling csm_allocation_step_end
+allocation_step_end ${sid_3} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 54: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_3})"
+
+# Test Case 55: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 55: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 56: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 56: Calling csm_allocation_step_query_active_all"
+
+# Test Case 57: Calling csm_allocation_step_end
+allocation_step_end ${sid_1} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 57: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 58: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 58: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 59: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 59: Calling csm_allocation_step_query_active_all"
+
+# Test Case 60: Calling csm_allocation_step_end
+allocation_step_end ${sid_2} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 60: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 61: Calling csm_allocation_step_begin
+allocation_step_begin ${sid_3} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 61: Calling csm_allocation_step_begin                (allocation_id: ${allocation_id} step_id: ${sid_3})"
+
+# Test Case 62: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 62: Calling csm_allocation_step_query_active_all"
+
+# Test Case 63: Calling csm_allocation_step_end
+allocation_step_end ${sid_3} > ${TEMP_LOG} 2>&1
+check_return_exit $? 0 "Test Case 63: Calling csm_allocation_step_end                  (allocation_id: ${allocation_id} step_id: ${sid_3})"
+
+# Test Case 64: Calling csm_allocation_step_query_active_all
+${CSM_PATH}/csm_allocation_step_query_active_all -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_all_output "No matching records found."
+check_return_flag_value $? 0 "Test Case 64: Calling csm_allocation_step_query_active_all"
+
+# Test Case 65: Calling csm_allocation_step_query
+${CSM_PATH}/csm_allocation_step_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 65: Calling csm_allocation_step_query"
+
+# Test Case 66: Calling csm_allocation_step_query_details
+${CSM_PATH}/csm_allocation_step_query_details -a ${allocation_id} -s 1  > ${TEMP_LOG} 2>&1 
+check_return_flag_value $? 1 "Test Case 66: Calling csm_allocation_step_query_details        (allocation_id: ${allocation_id} step_id: ${sid_1})"
+
+# Test Case 67: Check csm_allocation_step_query_details record count
+rcount_2=`grep Total_Records: ${TEMP_LOG} | awk -F': ' '{print $2}'`
+csm_step_hist_ct_2=`psql -qtA -U $DB_USER -d $DB_NAME -c "select count(*) from csm_step_history where step_id=1 and allocation_id=${allocation_id}"`
+    
+    if [[ "$csm_step_hist_ct_2" -eq "$rcount_2" ]]; then
+        check_return_flag_value $? 0 "Test Case 67: Check   csm_allocation_step_query_details        (Total_Records:${rcount_2})"
+    else
+        check_return_exit $? 0 "Test Case 67: Check   csm_allocation_step_query_details        (Total_Records:${rcount_2})"
+    fi
+
+# Test Case 68: Calling csm_allocation_step_query_details
+${CSM_PATH}/csm_allocation_step_query_details -a ${allocation_id} -s 2  > ${TEMP_LOG} 2>&1 
+check_return_flag_value $? 1 "Test Case 68: Calling csm_allocation_step_query_details        (allocation_id: ${allocation_id} step_id: ${sid_2})"
+
+# Test Case 69: Check csm_allocation_step_query_details record count
+rcount_3=`grep Total_Records: ${TEMP_LOG} | awk -F': ' '{print $2}'`
+csm_step_hist_ct_3=`psql -qtA -U $DB_USER -d $DB_NAME -c "select count(*) from csm_step_history where step_id=2 and allocation_id=${allocation_id}"`
+    
+    if [[ "$csm_step_hist_ct_3" -eq "$rcount_3" ]]; then
+        check_return_flag_value $? 0 "Test Case 69: Check   csm_allocation_step_query_details        (Total_Records:${rcount_3})"
+    else
+        check_return_exit $? 0 "Test Case 69: Check   csm_allocation_step_query_details        (Total_Records:${rcount_3})"
+    fi
+
+# Test Case 70: Calling csm_allocation_step_query_details
+${CSM_PATH}/csm_allocation_step_query_details -a ${allocation_id} -s 3  > ${TEMP_LOG} 2>&1 
+check_return_flag_value $? 1 "Test Case 70: Calling csm_allocation_step_query_details        (allocation_id: ${allocation_id} step_id: ${sid_3})"
+
+# Test Case 71: Check csm_allocation_step_query_details record count
+rcount_4=`grep Total_Records: ${TEMP_LOG} | awk -F': ' '{print $2}'`
+csm_step_hist_ct_4=`psql -qtA -U $DB_USER -d $DB_NAME -c "select count(*) from csm_step_history where step_id=3 and allocation_id=${allocation_id}"`
+    
+    if [[ "$csm_step_hist_ct_4" -eq "$rcount_4" ]]; then
+        check_return_flag_value $? 0 "Test Case 71: Check   csm_allocation_step_query_details        (Total_Records:${rcount_4})"
+    else
+        check_return_exit $? 0 "Test Case 71: Check   csm_allocation_step_query_details        (Total_Records:${rcount_4})"
+    fi
+
+# Test Case 72: Calling csm_allocation_delete
+${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 72: Calling csm_allocation_delete"
+
+# Test Case 73: Calling csm_allocation_query_active_all
+${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
+check_all_output "No matching records found"
+check_return_flag_value $? 0 "Test Case 73: Calling csm_allocation_query_active_all"
 
 # Remove temp log
 rm -f ${TEMP_LOG}
@@ -100,7 +437,7 @@ rm -f ${TEMP_LOG}
 if [ -z ${FLAGS+x} ];
 then
 	echo "------------------------------------------------------------" >> ${LOG}
-	echo "             RAS Basic Bucket PASSED" >> ${LOG}
+	echo "             Step Basic Bucket PASSED" >> ${LOG}
 	echo "------------------------------------------------------------" >> ${LOG}
 	echo "Additional Flags:" >> ${LOG}
 	echo -e "${FLAGS}" >> ${LOG}
@@ -108,7 +445,7 @@ then
 	exit 0
 else
 	echo "------------------------------------------------------------" >> ${LOG}
-	echo "             RAS Basic Bucket FAILED" >> ${LOG}
+	echo "             Step Basic Bucket FAILED" >> ${LOG}
 	echo "------------------------------------------------------------" >> ${LOG}
 	echo "Additional Flags:" >> ${LOG}
 	echo -e "${FLAGS}" >> ${LOG}


### PR DESCRIPTION
# Purpose
To fix issue https://github.com/IBM/CAST/issues/770 but not having the cmd line api seg fault. 

# Approach
I decided to go with: 
- don't leave out any data from the user.
- show them all records that matched the query, even if there are multiple steps with the same step id in that allocation. which will probably never happen in production.

# Origin
https://github.com/IBM/CAST/issues/770

@fpizzano  found an issue. very rare edge case. will probably never happen in production. where if there are multiple steps with a matching id under the same allocation, then allocation step query details cmd line interface will segfault. 

# How to Test
_This section will help the regression tester._
1. manually create the situation in a test database.
2. run the api.
3. see if the seg fault still happens. 
4. you can look at https://github.com/IBM/CAST/issues/770 for an example

# Screenshots
screen shots of terminal output are in https://github.com/IBM/CAST/issues/770
