### PR TITLE
Csm elk 6 8 1 compatibility

### DIFF
--- a/csm_big_data/beats/config/filebeat.yml
+++ b/csm_big_data/beats/config/filebeat.yml
@@ -1,7 +1,7 @@
 filebeat.inputs:
 - type: log
   enabled: true
-  close_removed: 1h
+  close_removed: true
   close_inactive: 1h
   paths:
     - /var/log/ibm/csm/csm_transaction.log.*
@@ -9,7 +9,7 @@ filebeat.inputs:
 
 - type: log
   enabled: true
-  close_removed: 1h
+  close_removed: true
   close_inactive: 1h
   paths:
     - /var/log/ibm/csm/csm_allocation_metrics.log.*
@@ -17,7 +17,7 @@ filebeat.inputs:
 
 - type: log 
   enabled: true
-  close_removed: 1h
+  close_removed: true
   close_inactive: 1h
   paths:
     - "/var/log/ibm/csm/archive/*.json"
@@ -25,7 +25,7 @@ filebeat.inputs:
 
 - type: log 
   enabled: true
-  close_removed: 1h
+  close_removed: true
   close_inactive: 1h
   paths:
     - /var/log/ibm/csm/csm_ras_events.log

--- a/csm_big_data/logstash/patches/csm_logstash_6-8-1_patch.sh
+++ b/csm_big_data/logstash/patches/csm_logstash_6-8-1_patch.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+#================================================================================
+#
+#    csm_logstash_6-8-1_patch.sh
+#
+#    © Copyright IBM Corporation 2015-2019. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+
+
+#=================
+#
+# Reason for this patch: 
+#
+# When the JRuby Application (logstash) is loaded a LoadError is thrown by ffi/ffi. The bubbled error message is somewhat vague (to a user ignorant to JRuby).
+#
+# [2019-05-03T10:41:38,701][ERROR][org.logstash.Logstash    ] 
+# java.lang.IllegalStateException: Logstash stopped processing because of an error: 
+# (LoadError) load error: ffi/ffi -- java.lang.NullPointerException: null
+#
+# I was able to trace the bug to jruby/lib/ruby/stdlib/ffi/platform/powerpc64-linux/. It looks
+# as though the platform.conf file was not created for this platform. Copying the types.conf file to platform.conf appears to resolve the problem.
+#
+# GitHub Issue: https://github.com/elastic/logstash/issues/10755
+#
+#==================
+
+
+STARTDIR=$(pwd)
+JARDIR="/usr/share/logstash/logstash-core/lib/jars"
+JAR="jruby-complete-9.2.7.0.jar"
+
+JRUBYDIR="${JAR}-dir"
+PLATDIR="META-INF/jruby.home/lib/ruby/stdlib/ffi/platform/powerpc64le-linux"
+
+cd ${JARDIR}
+unzip -d ${JRUBYDIR} ${JAR}
+cd "${JRUBYDIR}/${PLATDIR}"
+cp -n types.conf platform.conf
+cd "${JARDIR}/${JRUBYDIR}"
+
+zip -r jruby-complete-9.2.7.0.jar *
+mv  -f jruby-complete-9.2.7.0.jar ..
+cd ${JARDIR}
+rm -rf ${JRUBYDIR}
+
+sync
+sync
+cd ${STARTDIR}


### PR DESCRIPTION
# Purpose
Provide CSM nov release with comatibility for ELK 6.8.1

# Approach
Discussed with team members and long hours of trial and error testing. 
