### PR TITLE
BSCFS_start fork change to work in tcsh (csh) and bash shells

### DIFF
--- a/bb/scripts/BSCFS_start.pl
+++ b/bb/scripts/BSCFS_start.pl
@@ -70,7 +70,7 @@ foreach $HOST (@HOSTLIST_ARRAY)
     push(@args, $PRE_INSTALL_OPTION);
     $cmd = join(" ", @args);
     my $tmpfile = "/tmp/bscfs.$$.$HOST";
-    forkcmd("ssh $HOST \" $env $cmd \" &> $tmpfile");
+    forkcmd("ssh $HOST \"/bin/env $env $cmd \" &> $tmpfile");
     $PIDMETA{$LASTPID}{"output"} = $tmpfile;
     $NODE++;
 }


### PR DESCRIPTION
BSCFS_start change to run the agent in csh or bash remotely by ssh and set the job env correctly.