### PR TITLE
CSM Error: "CONNECTOR_ACCESS failed" - 400, 403 - https and http issue in Mellanox 'gv.cfg' file - found by Than - UFM

### DIFF
--- a/csmd/src/inv/ib_and_switch/include/inv_ib_connector_access.h
+++ b/csmd/src/inv/ib_and_switch/include/inv_ib_connector_access.h
@@ -37,6 +37,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
+#include <boost/asio/io_service.hpp>
 
 class INV_IB_CONNECTOR_ACCESS
 {

--- a/csmd/src/inv/ib_and_switch/include/inv_ib_connector_access.h
+++ b/csmd/src/inv/ib_and_switch/include/inv_ib_connector_access.h
@@ -36,6 +36,7 @@
 //#include "../../include/inv_ib_guid.h"
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 
 class INV_IB_CONNECTOR_ACCESS
 {

--- a/csmd/src/inv/ib_and_switch/include/inv_ib_connector_access.h
+++ b/csmd/src/inv/ib_and_switch/include/inv_ib_connector_access.h
@@ -37,7 +37,6 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
-#include <boost/asio/io_service.hpp>
 
 class INV_IB_CONNECTOR_ACCESS
 {

--- a/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
+++ b/csmd/src/inv/ib_and_switch/include/inv_switch_connector_access.h
@@ -35,6 +35,7 @@
 //#include "../../include/inv_ib_guid.h"
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 
 class INV_SWITCH_CONNECTOR_ACCESS
 {

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -283,6 +283,8 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		{
 			throw boost::system::system_error(error);
 		}
+
+		std::cout << "checkpoint F " << std::endl;
 	
 		// vectors with the fields
 		std::size_t position_delimiter;
@@ -292,6 +294,8 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// opening input file
 		std::string input_file_name = output_file_name;
 		std::ifstream input_file(input_file_name.c_str(),std::ios::in);
+
+		std::cout << "checkpoint G " << std::endl;
 		
 		// checking if input file is open
 		if ( ! input_file.is_open() ){

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -93,17 +93,17 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		ctx.set_default_verify_paths();
 
 		// Open a socket and connect it to the remote host.
-		boost::asio::io_context io_context;
-		ssl_socket socket(io_context, ctx);
-		tcp::resolver resolver(io_context);
-		tcp::resolver::query query("host.name", "https");
+		boost::asio::io_service io_service;
+		ssl_socket socket(io_service, ctx);
+		tcp::resolver resolver(io_service);
+		tcp::resolver::query query(rest_address.c_str(), "https");
 		boost::asio::connect(socket.lowest_layer(), resolver.resolve(query));
 		socket.lowest_layer().set_option(tcp::no_delay(true));
 
 		// Perform SSL handshake and verify the remote host's
 		// certificate.
 		socket.set_verify_mode(ssl::verify_peer);
-		socket.set_verify_callback(ssl::rfc2818_verification("host.name"));
+		socket.set_verify_callback(ssl::rfc2818_verification(rest_address.c_str()));
 		socket.handshake(ssl_socket::client);
 
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -108,6 +108,12 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		boost::asio::read_until(socket, response, "\r\n");
 		boost::asio::streambuf::const_buffers_type buf_1 = response.data();
 		std::string response_copy_1(boost::asio::buffers_begin(buf_1), boost::asio::buffers_begin(buf_1) + response.size());
+
+		//IDK
+		std::cout << "The response_copy_1: " << std::endl;
+		// This is a pointer
+		std::cout << response_copy_1 << std::endl;
+		std::cout << " #=# END response_copy_1 #=# " << std::endl;
 	
 		// Check that response is OK.
 		std::istream response_stream(&response);
@@ -115,6 +121,12 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 
 		//IDK
 		std::cout << "The response stream: " << std::endl;
+		// This is a pointer
+		std::cout << response_stream << std::endl;
+		std::cout << " #=# END response stream #=# " << std::endl;
+
+		std::cout << "The response stream: " << std::endl;
+		// This is a pointer
 		std::cout << response_stream << std::endl;
 		std::cout << " #=# END response stream #=# " << std::endl;
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -244,10 +244,13 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		
 		// opening output file
 
+		std::cout << "checkpoint A " << std::endl;
+
         //TEMP 
         // ToDo: replace this buffer push to a config file update like error paths below. 
         std::string ufm_ib_cable_output_filename = "ufm_ib_cable_output_file.json";
 
+        std::cout << "checkpoint B " << std::endl;
 
 		std::string output_file_name = csm_inv_log_dir + "/" + ufm_ib_cable_output_filename;
 		std::ofstream output_file(output_file_name.c_str(),std::ios::out);

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -287,7 +287,10 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			//Fautso says ignore.
 			//Why?
 			//Nick doesn't know.	
-		}else if(error == asio.ssl:335544539){
+		}else if(error == 335544539){
+			//asio.ssl:335544539
+			//short read
+
 			//This error occured because of an improper close to the SSL connection.
 			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"
 			std::cout << "checkpoint EE " << std::endl;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -238,18 +238,12 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		
 		// opening output file
 
-		std::cout << "checkpoint A " << std::endl;
-
         //TEMP 
         // ToDo: replace this buffer push to a config file update like error paths below. 
         std::string ufm_ib_cable_output_filename = "ufm_ib_cable_output_file.json";
 
-        std::cout << "checkpoint B " << std::endl;
-
 		std::string output_file_name = csm_inv_log_dir + "/" + ufm_ib_cable_output_filename;
 		std::ofstream output_file(output_file_name.c_str(),std::ios::out);
-
-		std::cout << "checkpoint C " << std::endl;
 
 		// checking if output file is open
 		if ( ! output_file.is_open() )
@@ -258,8 +252,6 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			std::cout << "Output file " << output_file_name << " not open, return"  << std::endl;
 			return 1;
 		} 
-
-		std::cout << "checkpoint D " << std::endl;
 
 		boost::system::error_code error;
 		//while (boost::asio::read(socket, response, boost::asio::transfer_at_least(1), error))
@@ -271,8 +263,6 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 
 		// closing the output file
 		output_file.close();
-
-		std::cout << "checkpoint E " << std::endl;
 
 		// checking for errors
 		if (error == boost::asio::error::eof)
@@ -286,17 +276,13 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 
 			//This error occured because of an improper close to the SSL connection.
 			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"
-			std::cout << "checkpoint EE " << std::endl;
-			std::cout << "error: " << error << std::endl;
+			//std::cout << "error: " << error << std::endl;
 			//We ignore this error for now because we know we connected in an uncool way.
 			//If we correct the connection process, then this error will go away.
 		}else{
 			//Non expected. Non special case error code.
 			throw boost::system::system_error(error);
 		}
-
-
-		std::cout << "checkpoint F " << std::endl;
 	
 		// vectors with the fields
 		std::size_t position_delimiter;
@@ -306,8 +292,6 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// opening input file
 		std::string input_file_name = output_file_name;
 		std::ifstream input_file(input_file_name.c_str(),std::ios::in);
-
-		std::cout << "checkpoint G " << std::endl;
 		
 		// checking if input file is open
 		if ( ! input_file.is_open() ){

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -285,8 +285,11 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		if (error != boost::asio::error::eof)
 		{
 			//throw boost::system::system_error(error);
-			std::cout << "checkpoint E " << std::endl;
+			std::cout << "checkpoint EE " << std::endl;
+			std::cout << "error: " << error << std::endl;
 		}
+
+		std::cout << "checkpoint F " << std::endl;
 
 		std::cout << "error: " << error << std::endl;
 	

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -18,7 +18,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
-using boost::asio;
+using namespace boost::asio;
 
 INV_IB_CONNECTOR_ACCESS *INV_IB_CONNECTOR_ACCESS::_Instance = nullptr;
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -99,7 +99,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		boost::asio::io_service io_service;
 		ssl_socket socket(io_service, ctx);
 		tcp::resolver resolver(io_service);
-		tcp::resolver::query query(rest_address.c_str(), "https");
+		tcp::resolver::query query(rest_address.c_str(), "http");
 		boost::asio::connect(socket.lowest_layer(), resolver.resolve(query));
 		socket.lowest_layer().set_option(tcp::no_delay(true));
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -304,8 +304,6 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 
 
 		std::cout << "checkpoint F " << std::endl;
-
-		std::cout << "error: " << error << std::endl;
 	
 		// vectors with the fields
 		std::size_t position_delimiter;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -87,11 +87,8 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// if "ws_protocol = https" then csm will need to connect through boost via https.
 		// if "ws_protocol = http" then csm will need to connect through boost via http.
 
-		// We don't know how its configured, so we try one first, then the other.
-		// ufm has changed its default to https. so we try that one first.
-
-		// Well, that's what I thought at first. But now it seems that https works for both configs.
-		// so lets leave it at that for now and do less work.
+		// Well, that's what I thought at first. But it seems that a connection via boost below via https works for both configs.
+		// so lets leave it at that.
 
 		// Create a context that uses the default paths for
 		// finding CA certificates.

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -269,7 +269,9 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::cout << "checkpoint D " << std::endl;
 
 		boost::system::error_code error;
-		while (boost::asio::read(socket, response, boost::asio::transfer_at_least(1), error))
+		//while (boost::asio::read(socket, response, boost::asio::transfer_at_least(1), error))
+
+		while (boost::asio::read(socket, response, boost::asio::transfer_all(), error))
 		{
 			output_file << &response;
 		}

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -192,22 +192,10 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::istream response_stream(&response);
 		std::string http_version;
 
-		//IDK
-		std::cout << "The response stream: " << std::endl;
-		// This is a pointer
-		std::cout << response_stream << std::endl;
-		std::cout << " #=# END response stream #=# " << std::endl;
 
-		//IDK
-		std::cout << "The response stream: " << std::endl;
-		// This is a pointer
-		std::cout << &response_stream << std::endl;
-		std::cout << " #=# END response stream #=# " << std::endl;
 
-		std::cout << "The response stream: " << std::endl;
-		// This is a pointer
-		std::cout << response_stream << std::endl;
-		std::cout << " #=# END response stream #=# " << std::endl;
+
+
 
 
 		response_stream >> http_version;
@@ -227,6 +215,18 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		boost::asio::read_until(socket, response, "\r\n\r\n");
 		boost::asio::streambuf::const_buffers_type buf_2 = response.data();
 		std::string response_copy_2(boost::asio::buffers_begin(buf_2), boost::asio::buffers_begin(buf_2) + response.size());
+
+
+		//copy the buffer to the request data
+		boost::asio::streambuf::const_buffers_type nickTEST2 = response.data();
+
+		//nick printing debug info
+		std::string responseCOPY_TEST(boost::asio::buffers_begin(nickTEST2), boost::asio::buffers_begin(nickTEST2) + response.size());
+		//IDK
+		std::cout << "The responseCOPY_TEST: " << std::endl;
+		// This is a pointer
+		std::cout << responseCOPY_TEST.c_str() << std::endl;
+		std::cout << " #=# END responseCOPY_TEST #=# " << std::endl;
 		
 		// Process the response headers.
 		std::string header;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -261,7 +261,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		if ( ! output_file.is_open() )
 		{
 			// printing error and return
-			std::cout << "Output file " << :query << " not open, return"  << std::endl;
+			std::cout << "Output file " << output_file_name << " not open, return"  << std::endl;
 			return 1;
 		} 
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -80,7 +80,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// Get a list of endpoints corresponding to the server name.
 		boost::asio::io_service io_service;
 		tcp::resolver resolver(io_service);
-		tcp::resolver::query query(rest_address.c_str(),"http");
+		tcp::resolver::query query(rest_address.c_str(),"https");
 		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 		//tcp::resolver::iterator end; // End marker.
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -18,7 +18,7 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
-using boost::asio::ip::tcp;
+using boost::asio;
 
 INV_IB_CONNECTOR_ACCESS *INV_IB_CONNECTOR_ACCESS::_Instance = nullptr;
 
@@ -79,9 +79,9 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 	try
 	{
 		// Does the thing.
-	    boost::asio::io_service svc;
-	    boost::asio::ssl::context ctx(svc, ssl::context::method::sslv23_client);
-	    boost::asio::ssl::stream<ip::tcp::socket> ssock(svc, ctx);
+	    io_service svc;
+	    ssl::context ctx(svc, ssl::context::method::sslv23_client);
+	    ssl::stream<ip::tcp::socket> ssock(svc, ctx);
 	    ssock.lowest_layer().connect({ {}, 443 }); // http://localhost:8087 for test
 	    ssock.handshake(ssl::stream_base::handshake_type::client);
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -282,12 +282,23 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::cout << "checkpoint E " << std::endl;
 
 		// checking for errors
-		if (error != boost::asio::error::eof)
+		if (error == boost::asio::error::eof)
 		{
-			//throw boost::system::system_error(error);
+			//Fautso says ignore.
+			//Why?
+			//Nick doesn't know.	
+		}else if(error == asio.ssl:335544539){
+			//This error occured because of an improper close to the SSL connection.
+			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"
 			std::cout << "checkpoint EE " << std::endl;
 			std::cout << "error: " << error << std::endl;
+			//We ignore this error for now because we know we connected in an uncool way.
+			//If we correct the connection process, then this error will go away.
+		}else{
+			//Non expected. Non special case error code.
+			throw boost::system::system_error(error);
 		}
+
 
 		std::cout << "checkpoint F " << std::endl;
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -17,6 +17,7 @@
 #include "logging.h"
 
 #include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
 using boost::asio::ip::tcp;
 using namespace boost::asio;
 
@@ -126,7 +127,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 
 
 
-		
+
 
 		//copy the buffer to the request data
 		boost::asio::streambuf::const_buffers_type nickTEST = request.data();

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -168,21 +168,19 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		boost::asio::streambuf::const_buffers_type buf_1 = response.data();
 		std::string response_copy_1(boost::asio::buffers_begin(buf_1), boost::asio::buffers_begin(buf_1) + response.size());
 
-		//IDK
+
+		// I this is a print out of what we recieve back from the server as a response...
+		// If developers are having a trouble situation, then you can comment this section and see the data you recieve
+		// Could help put you on the right path to debug the situation
+		/*
 		std::cout << "#=# The response_copy_1: " << std::endl;
-		// This is a pointer
 		std::cout << response_copy_1.c_str() << std::endl;
 		std::cout << " #=# END response_copy_1 #=# " << std::endl;
+		*/
 	
 		// Check that response is OK.
 		std::istream response_stream(&response);
 		std::string http_version;
-
-
-
-
-
-
 
 		response_stream >> http_version;
 		unsigned int status_code;
@@ -193,10 +191,14 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		}
 		
 		if (status_code != 200){
+			// When we tried to connect to the server with http but the gv.cfg was configured
+			// to look for https, then we got some error codes in the 400s which placed
+			// the code in this block here.
+			//
+			// but now it seems when we connect to the server via https that we no longer
+			// get the error. regardless of the ws_protocol in the config file
+
 			std::cerr << "Response returned with status code " << status_code << "\n";
-
-			std::cout << "we did bad: " << std::endl;
-
 			return 1;
 		}
 	
@@ -206,9 +208,10 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::string response_copy_2(boost::asio::buffers_begin(buf_2), boost::asio::buffers_begin(buf_2) + response.size());
 
 
+		// I'm not sure why. but fautso had 2 response sections? 
+		/*
 		//copy the buffer to the request data
 		boost::asio::streambuf::const_buffers_type nickTEST2 = response.data();
-
 		//nick printing debug info
 		std::string responseCOPY_TEST(boost::asio::buffers_begin(nickTEST2), boost::asio::buffers_begin(nickTEST2) + response.size());
 		//IDK
@@ -216,6 +219,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// This is a pointer
 		std::cout << responseCOPY_TEST.c_str() << std::endl;
 		std::cout << " #=# END responseCOPY_TEST #=# " << std::endl;
+		*/
 		
 		// Process the response headers.
 		std::string header;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -80,7 +80,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// Get a list of endpoints corresponding to the server name.
 		boost::asio::io_service io_service;
 		tcp::resolver resolver(io_service);
-		tcp::resolver::query query(rest_address.c_str(),"http");
+		tcp::resolver::query query(rest_address.c_str(),"https");
 		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
 	
 		// Try each endpoint until we successfully establish a connection.

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -112,6 +112,13 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// Check that response is OK.
 		std::istream response_stream(&response);
 		std::string http_version;
+
+		//IDK
+		std::cout << "The response stream: " << std::endl;
+		std::cout << response_stream << std::endl;
+		std::cout << " #=# END response stream #=# " << std::endl;
+
+
 		response_stream >> http_version;
 		unsigned int status_code;
 		response_stream >> status_code;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -284,10 +284,11 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// checking for errors
 		if (error != boost::asio::error::eof)
 		{
-			throw boost::system::system_error(error);
+			//throw boost::system::system_error(error);
+			std::cout << "checkpoint E " << std::endl;
 		}
 
-		std::cout << "checkpoint F " << std::endl;
+		std::cout << "error: " << error << std::endl;
 	
 		// vectors with the fields
 		std::size_t position_delimiter;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -80,8 +80,18 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// Get a list of endpoints corresponding to the server name.
 		boost::asio::io_service io_service;
 		tcp::resolver resolver(io_service);
-		tcp::resolver::query query(rest_address.c_str(),"https");
+		tcp::resolver::query query(rest_address.c_str(),"http");
 		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+		//tcp::resolver::iterator end; // End marker.
+
+		// while (endpoint_iterator != end)
+		// {
+		//     tcp::endpoint endpoint = *endpoint_iterator++;
+		//     std::cout << endpoint << std::endl;
+		// }
+
+		tcp::endpoint endpoint = *endpoint_iterator;
+		std::cout << endpoint << std::endl;
 	
 		// Try each endpoint until we successfully establish a connection.
 		tcp::socket socket(io_service);
@@ -98,6 +108,15 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		request_stream << "Host: " << rest_address << " \r\n";
 		request_stream << "Connection: close\r\n\r\n";
 
+		boost::asio::streambuf::const_buffers_type nickTEST = request.data();
+		std::string requestCOPY_TEST(boost::asio::buffers_begin(nickTEST), boost::asio::buffers_begin(nickTEST) + request.size());
+
+		//IDK
+		std::cout << "The requestCOPY_TEST: " << std::endl;
+		// This is a pointer
+		std::cout << requestCOPY_TEST.c_str() << std::endl;
+		std::cout << " #=# END requestCOPY_TEST #=# " << std::endl;
+
 		// Send the request.
 		boost::asio::write(socket, request);
 		
@@ -112,7 +131,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		//IDK
 		std::cout << "The response_copy_1: " << std::endl;
 		// This is a pointer
-		std::cout << response_copy_1 << std::endl;
+		std::cout << response_copy_1.c_str() << std::endl;
 		std::cout << " #=# END response_copy_1 #=# " << std::endl;
 	
 		// Check that response is OK.
@@ -123,6 +142,12 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::cout << "The response stream: " << std::endl;
 		// This is a pointer
 		std::cout << response_stream << std::endl;
+		std::cout << " #=# END response stream #=# " << std::endl;
+
+		//IDK
+		std::cout << "The response stream: " << std::endl;
+		// This is a pointer
+		std::cout << &response_stream << std::endl;
 		std::cout << " #=# END response stream #=# " << std::endl;
 
 		std::cout << "The response stream: " << std::endl;

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -255,13 +255,17 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::string output_file_name = csm_inv_log_dir + "/" + ufm_ib_cable_output_filename;
 		std::ofstream output_file(output_file_name.c_str(),std::ios::out);
 
+		std::cout << "checkpoint C " << std::endl;
+
 		// checking if output file is open
 		if ( ! output_file.is_open() )
 		{
 			// printing error and return
-			std::cout << "Output file " << output_file_name << " not open, return"  << std::endl;
+			std::cout << "Output file " << :query << " not open, return"  << std::endl;
 			return 1;
 		} 
+
+		std::cout << "checkpoint D " << std::endl;
 
 		boost::system::error_code error;
 		while (boost::asio::read(socket, response, boost::asio::transfer_at_least(1), error))
@@ -271,6 +275,8 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 
 		// closing the output file
 		output_file.close();
+
+		std::cout << "checkpoint E " << std::endl;
 
 		// checking for errors
 		if (error != boost::asio::error::eof)

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -287,7 +287,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			//Fautso says ignore.
 			//Why?
 			//Nick doesn't know.	
-		}else if(error == 335544539){
+		}else if(error.value() == 335544539){
 			//asio.ssl:335544539
 			//short read
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -226,7 +226,9 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		while (std::getline(response_stream, header) && header != "\r")
 		{
 			// ???
-			std::cout << "Header: " << header << std::endl;
+			// I'mnot sure what is going on here. 
+			// It seems similar to the response back from the server. but not exact match.
+			// std::cout << "Header: " << header << std::endl;
 		}
 	
 		// Write whatever content we already have to output.

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -158,7 +158,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		//nick printing debug info
 		std::string requestCOPY_TEST(boost::asio::buffers_begin(nickTEST), boost::asio::buffers_begin(nickTEST) + request.size());
 		//IDK
-		std::cout << "The requestCOPY_TEST: " << std::endl;
+		std::cout << "#=# The requestCOPY_TEST: " << std::endl;
 		// This is a pointer
 		std::cout << requestCOPY_TEST.c_str() << std::endl;
 		std::cout << " #=# END requestCOPY_TEST #=# " << std::endl;
@@ -183,7 +183,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		std::string response_copy_1(boost::asio::buffers_begin(buf_1), boost::asio::buffers_begin(buf_1) + response.size());
 
 		//IDK
-		std::cout << "The response_copy_1: " << std::endl;
+		std::cout << "#=# The response_copy_1: " << std::endl;
 		// This is a pointer
 		std::cout << response_copy_1.c_str() << std::endl;
 		std::cout << " #=# END response_copy_1 #=# " << std::endl;
@@ -223,7 +223,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		//nick printing debug info
 		std::string responseCOPY_TEST(boost::asio::buffers_begin(nickTEST2), boost::asio::buffers_begin(nickTEST2) + response.size());
 		//IDK
-		std::cout << "The responseCOPY_TEST: " << std::endl;
+		std::cout << "#=# The responseCOPY_TEST: " << std::endl;
 		// This is a pointer
 		std::cout << responseCOPY_TEST.c_str() << std::endl;
 		std::cout << " #=# END responseCOPY_TEST #=# " << std::endl;
@@ -233,6 +233,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		while (std::getline(response_stream, header) && header != "\r")
 		{
 			// ???
+			std::cout << "Header: " << header << std::endl;
 		}
 	
 		// Write whatever content we already have to output.

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -19,7 +19,6 @@
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 using boost::asio::ip::tcp;
-using namespace boost::asio;
 
 INV_IB_CONNECTOR_ACCESS *INV_IB_CONNECTOR_ACCESS::_Instance = nullptr;
 
@@ -81,8 +80,8 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 	{
 		// Does the thing.
 	    boost::asio::io_service svc;
-	    ssl::context ctx(svc, ssl::context::method::sslv23_client);
-	    ssl::stream<ip::tcp::socket> ssock(svc, ctx);
+	    boost::asio::ssl::context ctx(svc, ssl::context::method::sslv23_client);
+	    boost::asio::ssl::stream<ip::tcp::socket> ssock(svc, ctx);
 	    ssock.lowest_layer().connect({ {}, 443 }); // http://localhost:8087 for test
 	    ssock.handshake(ssl::stream_base::handshake_type::client);
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -106,9 +106,9 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// Perform SSL handshake and verify the remote host's
 		// certificate.
 		//example says
-		socket.set_verify_mode(ssl::verify_peer);
+		//socket.set_verify_mode(ssl::verify_peer);
 		//Nate said -k in curl is fine. We know the server and trust it. So maybe its fine here too. 
-		//socket.set_verify_mode(ssl::verify_none);
+		socket.set_verify_mode(ssl::verify_none);
 		socket.set_verify_callback(ssl::rfc2818_verification(rest_address.c_str()));
 		socket.handshake(ssl_socket::client);
 	

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -90,6 +90,9 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// We don't know how its configured, so we try one first, then the other.
 		// ufm has changed its default to https. so we try that one first.
 
+		// Well, that's what I thought at first. But now it seems that https works for both configs.
+		// so lets leave it at that for now and do less work.
+
 		// Create a context that uses the default paths for
 		// finding CA certificates.
 		ssl::context ctx(ssl::context::sslv23);
@@ -99,7 +102,7 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		boost::asio::io_service io_service;
 		ssl_socket socket(io_service, ctx);
 		tcp::resolver resolver(io_service);
-		tcp::resolver::query query(rest_address.c_str(), "http");
+		tcp::resolver::query query(rest_address.c_str(), "https");
 		boost::asio::connect(socket.lowest_layer(), resolver.resolve(query));
 		socket.lowest_layer().set_option(tcp::no_delay(true));
 

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -106,9 +106,9 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		// Perform SSL handshake and verify the remote host's
 		// certificate.
 		//example says
-		//socket.set_verify_mode(ssl::verify_peer);
+		socket.set_verify_mode(ssl::verify_peer);
 		//Nate said -k in curl is fine. We know the server and trust it. So maybe its fine here too. 
-		socket.set_verify_mode(ssl::verify_none);
+		//socket.set_verify_mode(ssl::verify_none);
 		socket.set_verify_callback(ssl::rfc2818_verification(rest_address.c_str()));
 		socket.handshake(ssl_socket::client);
 	

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -18,6 +18,7 @@
 
 #include <boost/asio.hpp>
 using boost::asio::ip::tcp;
+using namespace boost::asio;
 
 INV_IB_CONNECTOR_ACCESS *INV_IB_CONNECTOR_ACCESS::_Instance = nullptr;
 
@@ -77,11 +78,22 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 {
 	try
 	{
+		// Does the thing.
+	    boost::asio::io_service svc;
+	    ssl::context ctx(svc, ssl::context::method::sslv23_client);
+	    ssl::stream<ip::tcp::socket> ssock(svc, ctx);
+	    ssock.lowest_layer().connect({ {}, 443 }); // http://localhost:8087 for test
+	    ssock.handshake(ssl::stream_base::handshake_type::client);
+
+
+		//=========
+		//Begin old fautso
 		// Get a list of endpoints corresponding to the server name.
-		boost::asio::io_service io_service;
+		/*boost::asio::io_service io_service;
 		tcp::resolver resolver(io_service);
 		tcp::resolver::query query(rest_address.c_str(),"https");
-		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
+		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);*/
+		//end old fautso
 		//tcp::resolver::iterator end; // End marker.
 
 		// while (endpoint_iterator != end)
@@ -90,12 +102,13 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		//     std::cout << endpoint << std::endl;
 		// }
 
-		tcp::endpoint endpoint = *endpoint_iterator;
-		std::cout << endpoint << std::endl;
+		// Nick trying to print out some extra stuff.
+		// tcp::endpoint endpoint = *endpoint_iterator;
+		// std::cout << endpoint << std::endl;
 	
 		// Try each endpoint until we successfully establish a connection.
-		tcp::socket socket(io_service);
-		boost::asio::connect(socket, endpoint_iterator);
+		// tcp::socket socket(io_service);
+		// boost::asio::connect(socket, endpoint_iterator);
 	
 		// Form the request. We specify the "Connection: close" header so that the
 		// server will close the socket after transmitting the response. This will
@@ -108,14 +121,31 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 		request_stream << "Host: " << rest_address << " \r\n";
 		request_stream << "Connection: close\r\n\r\n";
 
-		boost::asio::streambuf::const_buffers_type nickTEST = request.data();
-		std::string requestCOPY_TEST(boost::asio::buffers_begin(nickTEST), boost::asio::buffers_begin(nickTEST) + request.size());
 
+
+
+
+
+		
+
+		//copy the buffer to the request data
+		boost::asio::streambuf::const_buffers_type nickTEST = request.data();
+
+		//nick printing debug info
+		std::string requestCOPY_TEST(boost::asio::buffers_begin(nickTEST), boost::asio::buffers_begin(nickTEST) + request.size());
 		//IDK
 		std::cout << "The requestCOPY_TEST: " << std::endl;
 		// This is a pointer
 		std::cout << requestCOPY_TEST.c_str() << std::endl;
 		std::cout << " #=# END requestCOPY_TEST #=# " << std::endl;
+
+
+
+
+
+
+
+
 
 		// Send the request.
 		boost::asio::write(socket, request);

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -102,7 +102,10 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 
 		// Perform SSL handshake and verify the remote host's
 		// certificate.
-		socket.set_verify_mode(ssl::verify_peer);
+		//example says
+		//socket.set_verify_mode(ssl::verify_peer);
+		//Nate said -k in curl is fine. We know the server and trust it. So maybe its fine here too. 
+		socket.set_verify_mode(ssl::verify_none);
 		socket.set_verify_callback(ssl::rfc2818_verification(rest_address.c_str()));
 		socket.handshake(ssl_socket::client);
 

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -193,11 +193,8 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		// if "ws_protocol = https" then csm will need to connect through boost via https.
 		// if "ws_protocol = http" then csm will need to connect through boost via http.
 
-		// We don't know how its configured, so we try one first, then the other.
-		// ufm has changed its default to https. so we try that one first.
-
-		// Well, that's what I thought at first. But now it seems that https works for both configs.
-		// so lets leave it at that for now and do less work.
+		// Well, that's what I thought at first. But it seems that a connection via boost below via https works for both configs.
+		// so lets leave it at that.
 
 		// Create a context that uses the default paths for
 		// finding CA certificates.

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -223,7 +223,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		socket.handshake(ssl_socket::client);
 		//==END NEW===================
 
-		
+
 
 		// Form the request. We specify the "Connection: close" header so that the
 		// server will close the socket after transmitting the response. This will
@@ -235,6 +235,24 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		request_stream << "Authorization: Basic " << authentication_string_for_the_http_request << " \r\n";
 		request_stream << "Host: " << rest_address << " \r\n";
 		request_stream << "Connection: close\r\n\r\n";
+
+
+
+		//copy the buffer to the request data
+		boost::asio::streambuf::const_buffers_type nickTEST = request.data();
+
+		//nick printing debug info
+		std::string requestCOPY_TEST(boost::asio::buffers_begin(nickTEST), boost::asio::buffers_begin(nickTEST) + request.size());
+		//IDK
+		std::cout << "#=# The requestCOPY_TEST: " << std::endl;
+		// This is a pointer
+		std::cout << requestCOPY_TEST.c_str() << std::endl;
+		std::cout << " #=# END requestCOPY_TEST #=# " << std::endl;
+
+
+
+
+
 		
 		// Send the request.
 		boost::asio::write(socket, request);
@@ -246,6 +264,17 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		boost::asio::read_until(socket, response, "\r\n");
 		boost::asio::streambuf::const_buffers_type buf_1 = response.data();
 		std::string response_copy_1(boost::asio::buffers_begin(buf_1), boost::asio::buffers_begin(buf_1) + response.size());
+
+
+		//IDK
+		std::cout << "#=# The response_copy_1: " << std::endl;
+		// This is a pointer
+		std::cout << response_copy_1.c_str() << std::endl;
+		std::cout << " #=# END response_copy_1 #=# " << std::endl;
+
+
+
+
 
 		// Check that response is OK.
 		std::istream response_stream(&response);
@@ -268,6 +297,16 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		boost::asio::read_until(socket, response, "\r\n\r\n");
 		boost::asio::streambuf::const_buffers_type buf_2 = response.data();
 		std::string response_copy_2(boost::asio::buffers_begin(buf_2), boost::asio::buffers_begin(buf_2) + response.size());
+
+		//nick printing debug info
+		std::string responseCOPY_TEST(boost::asio::buffers_begin(nickTEST2), boost::asio::buffers_begin(nickTEST2) + response.size());
+		//IDK
+		std::cout << "#=# The responseCOPY_TEST: " << std::endl;
+		// This is a pointer
+		std::cout << responseCOPY_TEST.c_str() << std::endl;
+		std::cout << " #=# END responseCOPY_TEST #=# " << std::endl;
+
+		
 
 		// Process the response headers.
 		std::string header;

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -184,22 +184,20 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 {
 	try
 	{	
-		//OLD FAUTSO
-		/*
-		// Get a list of endpoints corresponding to the server name.
-		boost::asio::io_service io_service;
-		tcp::resolver resolver(io_service);
-		tcp::resolver::query query(rest_address,"http");
-		tcp::resolver::iterator endpoint_iterator = resolver.resolve(query);
-		
-		// Try each endpoint until we successfully establish a connection.
-		tcp::socket socket(io_service);
-		boost::asio::connect(socket, endpoint_iterator);
-		
-		
-		*/
+		// I believe this is the boost C++ library trying to connect to the ufm daemon on the server.
+		// Connecting to the ufm daemon is via the protocol configured in ufm's config file.
+		// The config file is called "gv.cfg"
+		// it should be found in the ufm directory on the server running ufmd
+		// the specfic field in the config file for the connection is "ws_protocol"
 
-		//====NEW WAY========
+		// if "ws_protocol = https" then csm will need to connect through boost via https.
+		// if "ws_protocol = http" then csm will need to connect through boost via http.
+
+		// We don't know how its configured, so we try one first, then the other.
+		// ufm has changed its default to https. so we try that one first.
+
+		// Well, that's what I thought at first. But now it seems that https works for both configs.
+		// so lets leave it at that for now and do less work.
 
 		// Create a context that uses the default paths for
 		// finding CA certificates.
@@ -222,13 +220,14 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		socket.set_verify_mode(ssl::verify_none);
 		socket.set_verify_callback(ssl::rfc2818_verification(rest_address.c_str()));
 		socket.handshake(ssl_socket::client);
-		//==END NEW===================
-
-
-
+		
 		// Form the request. We specify the "Connection: close" header so that the
 		// server will close the socket after transmitting the response. This will
 		// allow us to treat all data up until the EOF as the content.
+
+		// Even though CSM is connecting to the server through boost using http above. 
+		// the rest api and request stream stays with HTTP in the string.
+		// i don't know why.
 		
 		boost::asio::streambuf request;
 		std::ostream request_stream(&request);
@@ -237,27 +236,35 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		request_stream << "Host: " << rest_address << " \r\n";
 		request_stream << "Connection: close\r\n\r\n";
 
+		// I this is a print out of what we will be sending to the server as a request...
+		// If developers are having a trouble situation, then you can comment this section and see the data you send
+		// Could help put you on the right path to debug the situation
+		// It should match the data above. 
 
-
+		/*
 		//copy the buffer to the request data
-		boost::asio::streambuf::const_buffers_type nickTEST = request.data();
+		boost::asio::streambuf::const_buffers_type requestDebugPrint = request.data();
+		//grab the data/string from the buffer?
+		std::string requestDebug_TEST(boost::asio::buffers_begin(requestDebugPrint), boost::asio::buffers_begin(requestDebugPrint) + request.size());
+		//printing debug info
+		std::cout << "#=# BEGIN requestDebug_TEST: " << std::endl;
+		std::cout << requestDebug_TEST.c_str() << std::endl;
+		std::cout << "#=# END requestDebug_TEST " << std::endl;
+		*/
 
-		//nick printing debug info
-		std::string requestCOPY_TEST(boost::asio::buffers_begin(nickTEST), boost::asio::buffers_begin(nickTEST) + request.size());
-		//IDK
-		std::cout << "#=# The requestCOPY_TEST: " << std::endl;
-		// This is a pointer
-		std::cout << requestCOPY_TEST.c_str() << std::endl;
-		std::cout << " #=# END requestCOPY_TEST #=# " << std::endl;
-
-
-
-
-
-		
-		// Send the request.
+		// Use the boost libarary to send our request to the server.
 		boost::asio::write(socket, request);
 
+		// We have now sent off our request to the server.
+
+		// END REQUEST PART OF THE CODE. 
+		// ==============================
+		// BEGIN RESPOSE PART OF THE CODE.
+
+
+		// Below is our response back from the server to our request. 
+
+		
 		// Read the response status line. The response streambuf will automatically
 		// grow to accommodate the entire line. The growth may be limited by passing
 		// a maximum size to the streambuf constructor.
@@ -266,16 +273,14 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		boost::asio::streambuf::const_buffers_type buf_1 = response.data();
 		std::string response_copy_1(boost::asio::buffers_begin(buf_1), boost::asio::buffers_begin(buf_1) + response.size());
 
-
-		//IDK
+		// I this is a print out of what we recieve back from the server as a response...
+		// If developers are having a trouble situation, then you can comment this section and see the data you recieve
+		// Could help put you on the right path to debug the situation
+		/*
 		std::cout << "#=# The response_copy_1: " << std::endl;
-		// This is a pointer
 		std::cout << response_copy_1.c_str() << std::endl;
 		std::cout << " #=# END response_copy_1 #=# " << std::endl;
-
-
-
-
+		*/
 
 		// Check that response is OK.
 		std::istream response_stream(&response);
@@ -290,6 +295,12 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		}
 		if (status_code != 200)
 		{
+			// When we tried to connect to the server with http but the gv.cfg was configured
+			// to look for https, then we got some error codes in the 400s which placed
+			// the code in this block here.
+			//
+			// but now it seems when we connect to the server via https that we no longer
+			// get the error. regardless of the ws_protocol in the config file
 			std::cout << "Response returned with status code " << status_code << "\n";
 			return 1;
 		}
@@ -302,6 +313,10 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		//copy the buffer to the request data
 		boost::asio::streambuf::const_buffers_type nickTEST2 = response.data();
 
+		// I'm not sure why. but fautso had 2 response sections? 
+		/*
+		//copy the buffer to the request data
+		boost::asio::streambuf::const_buffers_type nickTEST2 = response.data();
 		//nick printing debug info
 		std::string responseCOPY_TEST(boost::asio::buffers_begin(nickTEST2), boost::asio::buffers_begin(nickTEST2) + response.size());
 		//IDK
@@ -309,8 +324,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		// This is a pointer
 		std::cout << responseCOPY_TEST.c_str() << std::endl;
 		std::cout << " #=# END responseCOPY_TEST #=# " << std::endl;
-
-
+		*/
 
 		// Process the response headers.
 		std::string header;
@@ -362,8 +376,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 
 			//This error occured because of an improper close to the SSL connection.
 			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"
-			std::cout << "checkpoint EE " << std::endl;
-			std::cout << "error: " << error << std::endl;
+			//std::cout << "error: " << error << std::endl;
 			//We ignore this error for now because we know we connected in an uncool way.
 			//If we correct the connection process, then this error will go away.
 		}else{

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -299,6 +299,9 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		boost::asio::streambuf::const_buffers_type buf_2 = response.data();
 		std::string response_copy_2(boost::asio::buffers_begin(buf_2), boost::asio::buffers_begin(buf_2) + response.size());
 
+		//copy the buffer to the request data
+		boost::asio::streambuf::const_buffers_type nickTEST2 = response.data();
+
 		//nick printing debug info
 		std::string responseCOPY_TEST(boost::asio::buffers_begin(nickTEST2), boost::asio::buffers_begin(nickTEST2) + response.size());
 		//IDK
@@ -307,7 +310,7 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		std::cout << responseCOPY_TEST.c_str() << std::endl;
 		std::cout << " #=# END responseCOPY_TEST #=# " << std::endl;
 
-		
+
 
 		// Process the response headers.
 		std::string header;

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -351,8 +351,23 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 		output_file.close();
 
 		// checking for errors
-		if (error != boost::asio::error::eof)
+		if (error == boost::asio::error::eof)
 		{
+			//Fautso says ignore.
+			//Why?
+			//Nick doesn't know.	
+		}else if(error.value() == 335544539){
+			//asio.ssl:335544539
+			//short read
+
+			//This error occured because of an improper close to the SSL connection.
+			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"
+			std::cout << "checkpoint EE " << std::endl;
+			std::cout << "error: " << error << std::endl;
+			//We ignore this error for now because we know we connected in an uncool way.
+			//If we correct the connection process, then this error will go away.
+		}else{
+			//Non expected. Non special case error code.
 			throw boost::system::system_error(error);
 		}
 

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -16,8 +16,9 @@
 #include "../include/inv_switch_connector_access.h"
 #include "logging.h"
 
-#include <boost/asio.hpp>
 using boost::asio::ip::tcp;
+namespace ssl = boost::asio::ssl;
+typedef ssl::stream<tcp::socket> ssl_socket;
 
 INV_SWITCH_CONNECTOR_ACCESS *INV_SWITCH_CONNECTOR_ACCESS::_Instance = nullptr;
 

--- a/docs/source/csm/csm-inventory/Network.rst
+++ b/docs/source/csm/csm-inventory/Network.rst
@@ -26,6 +26,8 @@ Switches
 
 CSM can collect information about a physical switch and store it the the :ref:`CSM_Database` inside the :ref:`csm_switch_table` table.
 
+.. _CSM_Network_Inventory_Switch_Module:
+
 Switch Modules
 ^^^^^^^^^^^^^^
 

--- a/docs/source/csm/tools.rst
+++ b/docs/source/csm/tools.rst
@@ -193,6 +193,7 @@ Example:
     protocol = http
     port = 80
 
+Improper communication settings could result in some of the issues presented in the :ref:`CSM_standalone_inventory_collection_FAQ`.
 
 Using the Tool
 **************

--- a/docs/source/csm/tools.rst
+++ b/docs/source/csm/tools.rst
@@ -179,11 +179,13 @@ Output
 
 All output information for this tool is printed to the console. The ``-d, --details`` flag can be used to turn on extra information. If there are bad or incomplete records for hardware inventory they will not be copied into the :ref:`CSM_Database` and instead placed into the `bad_records` files specified in the ``csm_master.cfg`` file.
 
+.. _CSM_standalone_inventory_collection_FAQ:
+
 FAQ - Frequently Asked Questions
 ********************************
 
-'N/A' Serial Numbers
-^^^^^^^^^^^^^^^^^^^^
+Why 'bad record' and N/A' Serial Numbers?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes CSM can detect a switch in your system that is incomplete. It is missing a serial number, which CSM will consider invalid data, and therefor not insert it into the :ref:`CSM_Database`.
 
@@ -537,7 +539,30 @@ Good case - as you can see the module array is populated. :
         }
     ]
 
-Modules will sometimes not be reported via UFM. One of the most common causes of this is a communication issue with the ufm daemon, ``ufmd``. If :ref:`CSM_standalone_inventory_collection` reports an error connecting to the ``ufmd`` or an error in the 400s range, then it may be a communication issue. CSM tries to anticipate the multiple forms of communication, but sometimes a system admin will need to tweak the configuration file for ufm and restart the ``ufmd``. 
+Modules will sometimes not be reported via UFM. One of the most common causes of this is a communication issue with the ufm daemon, ``ufmd``. See :ref:`CSM_standalone_inventory_collection_FAQ_CONNECTOR_ACCESS_fail` for more information.
+
+.. _CSM_standalone_inventory_collection_FAQ_CONNECTOR_ACCESS_fail:
+
+What is a `CONNECTOR_ACCESS fail`?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If :ref:`CSM_standalone_inventory_collection` reports a ``connector_access fail`` then it probably failed to connect to the ``ufmd``. 
+
+For example, a system administrator may see:
+
+.. code-block:: none
+
+    Response returned with status code 403
+    INV_IB_CONNECTOR_ACCESS failed
+
+or 
+
+.. code-block:: none
+
+    Response returned with status code 400
+    INV_SWITCH_CONNECTOR_ACCESS failed
+
+If :ref:`CSM_standalone_inventory_collection` reports an error connecting to the ``ufmd`` or an error in the 400s range, then it may be a communication issue. CSM tries to anticipate the multiple forms of communication, but sometimes a system admin will need to tweak the configuration file for ufm and restart the ``ufmd``. 
 
 On the server running ``ufmd`` the system administrator should look to find the ufm config file, ``gv.cfg``. It should be located at ``/opt/ufm/conf``. In that file the system administrator may need to configure a few fields. 
 

--- a/docs/source/csm/tools.rst
+++ b/docs/source/csm/tools.rst
@@ -179,5 +179,397 @@ Output
 
 All output information for this tool is printed to the console. The ``-d, --details`` flag can be used to turn on extra information. If there are bad or incomplete records for hardware inventory they will not be copied into the :ref:`CSM_Database` and instead placed into the `bad_records` files specified in the ``csm_master.cfg`` file.
 
+FAQ - Frequently Asked Questions
+********************************
+
+'N/A' Serial Numbers
+^^^^^^^^^^^^^^^^^^^^
+
+Sometimes CSM can detect a switch in your system that is incomplete. It is missing a serial number, which CSM will consider invalid data, and therefor not insert it into the :ref:`CSM_Database`.
+
+Example:
+
+.. code-block:: none
+
+    UFM reported 7 switch records.
+    This report from UFM can be found in 'ufm_switch_output_file.json' located at '/var/log/ibm/csm/inv'
+    WARNING: 2 Switches found with 'N/A' serial numbers and have been removed from CSM inventory collection data.
+    These records copied into 'bad_switch_records.txt' located at '/var/log/ibm/csm/inv'
+
+This is usually caused by switches not correctly reporting :ref:`_CSM_Network_Inventory_Switch_Module`. If the system module is not found, then CSM can not collect the serial number.
+
+Below is an example of JSON data returned from UFM. The first is one missing modules, the second is what we expect in a good case. 
+
+Bad case - as you can see the module array is NOT populated. :
+
+.. code-block:: json
+
+    [
+        {
+            "cpus_number": 0,
+            "ip": "10.7.3.2",
+            "ram": 0,
+            "fw_version": "15.2000.2626",
+            "mirroring_template": false,
+            "cpu_speed": 0,
+            "is_manual_ip": true,
+            "technology": "EDR",
+            "psid": "MT_2630110032",
+            "guid": "248a070300fcccd0",
+            "severity": "Warning",
+            "script": "N/A",
+            "capabilities": [
+                "Provisioning"
+            ],
+            "state": "active",
+            "role": "tor",
+            "type": "switch",
+            "sm_mode": "noSM",
+            "vendor": "Mellanox",
+            "description": "MSB7800",
+            "has_ufm_agent": false,
+            "server_operation_mode": "Switch",
+            "groups": [
+                "Alarmed_Devices"
+            ],
+            "total_alarms": 1,
+            "temperature": "N/A",
+            "system_name": "c650f03ib-root01-M",
+            "sw_version": "N/A",
+            "system_guid": "248a070300fcccd0",
+            "name": "248a070300fcccd0",
+            "url": "",
+            "modules": [],
+            "cpu_type": "any",
+            "is_managed": true,
+            "model": "MSB7800",
+                        "ports": [
+                "248a070300fcccd0_9",
+                "248a070300fcccd0_8",
+                "248a070300fcccd0_7",
+                "248a070300fcccd0_6",
+                "248a070300fcccd0_5",
+                "248a070300fcccd0_4",
+                "248a070300fcccd0_3",
+                "248a070300fcccd0_2",
+                "248a070300fcccd0_1",
+                "248a070300fcccd0_28",
+                "248a070300fcccd0_29",
+                "248a070300fcccd0_26",
+                "248a070300fcccd0_27",
+                "248a070300fcccd0_24",
+                "248a070300fcccd0_25",
+                "248a070300fcccd0_22",
+                "248a070300fcccd0_23",
+                "248a070300fcccd0_20",
+                "248a070300fcccd0_21",
+                "248a070300fcccd0_37",
+                "248a070300fcccd0_36",
+                "248a070300fcccd0_16",
+                "248a070300fcccd0_15",
+                "248a070300fcccd0_10",
+                "248a070300fcccd0_31",
+                "248a070300fcccd0_30",
+                "248a070300fcccd0_33",
+                "248a070300fcccd0_32",
+                "248a070300fcccd0_35",
+                "248a070300fcccd0_34",
+                "248a070300fcccd0_19",
+                "248a070300fcccd0_18"
+            ]
+        }
+    ]
+
+How you would see this JSON represented in the `bad_records` files of CSM. Notice the missing modules section.
+
+.. code-block:: none
+
+    CSM switch inventory collection
+    File created: Fri Feb 28 13:40:59 2020
+
+    The following records are incomplete and can not be inserted into CSM database.
+
+    Switch: 2
+    ip:                    10.7.3.2
+    fw_version:            15.2000.2626
+    total_alarms:          1
+    psid:                  MT_2630110032
+    guid:                  248a070300fcccd0
+    state:                 active
+    role:                  tor
+    type:                  switch
+    vendor:                Mellanox
+    description:           MSB7800
+    has_ufm_agent:         false
+    server_operation_mode: Switch
+    sm_mode:               noSM
+    system_name:           c650f03ib-root01-M
+    sw_version:            N/A
+    system_guid:           248a070300fcccd0
+    name:                  248a070300fcccd0
+    modules:               ???
+    serial_number:         N/A
+    model:                 MSB7800
+
+Good case - as you can see the module array is populated. :
+
+.. code-block:: json
+
+    [
+        {
+            "cpus_number": 0, 
+            "ip": "10.7.4.2", 
+            "ram": 0, 
+            "fw_version": "15.2000.2626", 
+            "mirroring_template": false, 
+            "cpu_speed": 0, 
+            "is_manual_ip": true, 
+            "technology": "EDR", 
+            "psid": "MT_2630110032", 
+            "guid": "248a070300fd6100", 
+            "severity": "Info", 
+            "script": "N/A", 
+            "capabilities": [
+                "ssh", 
+                "sysinfo", 
+                "reboot", 
+                "mirroring", 
+                "sw_upgrade", 
+                "Provisioning"
+            ], 
+            "state": "active", 
+            "role": "tor", 
+            "type": "switch", 
+            "sm_mode": "noSM", 
+            "vendor": "Mellanox", 
+            "description": "MSB7800", 
+            "has_ufm_agent": false, 
+            "server_operation_mode": "Switch", 
+            "groups": [], 
+            "total_alarms": 0, 
+            "temperature": "56", 
+            "system_name": "c650f04ib-leaf02-M", 
+            "sw_version": "3.8.2102-X86_64", 
+            "system_guid": "248a070300fd6100", 
+            "name": "248a070300fd6100", 
+            "url": "", 
+            "modules": [
+                {
+                    "status": "OK", 
+                    "sw_version": "N/A", 
+                    "hw_version": "MSB7800-ES2F", 
+                    "name": "248a070300fd6100_4000_01", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "MGMT - 1", 
+                    "max_ib_ports": 0, 
+                    "module_index": 1, 
+                    "temperature": "N/A", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X02692", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / MGMT 1", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "MGMT", 
+                    "severity": "Info"
+                }, 
+                {
+                    "status": "OK", 
+                    "sw_version": "N/A", 
+                    "hw_version": "MTEF-PSF-AC-A", 
+                    "name": "248a070300fd6100_2005_01", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "PS - 1", 
+                    "max_ib_ports": 0, 
+                    "module_index": 1, 
+                    "temperature": "N/A", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X07347", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / PS 1", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "PS", 
+                    "severity": "Info"
+                }, 
+                {
+                    "status": "OK", 
+                    "sw_version": "3.8.2102-X86_64", 
+                    "hw_version": "MSB7800-ES2F", 
+                    "name": "248a070300fd6100_1007_01", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "SYSTEM", 
+                    "max_ib_ports": 0, 
+                    "module_index": 1, 
+                    "temperature": "56", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X02692", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / system 1", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "SYSTEM", 
+                    "severity": "Info"
+                }, 
+                {
+                    "status": "OK", 
+                    "sw_version": "N/A", 
+                    "hw_version": "MTEF-PSF-AC-A", 
+                    "name": "248a070300fd6100_2005_02", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "PS - 2", 
+                    "max_ib_ports": 0, 
+                    "module_index": 2, 
+                    "temperature": "N/A", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X07348", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / PS 2", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "PS", 
+                    "severity": "Info"
+                }, 
+                {
+                    "status": "OK", 
+                    "sw_version": "N/A", 
+                    "hw_version": "MTEF-FANF-A", 
+                    "name": "248a070300fd6100_4001_03", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "FAN - 3", 
+                    "max_ib_ports": 0, 
+                    "module_index": 3, 
+                    "temperature": "N/A", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X08121", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 3", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "FAN", 
+                    "severity": "Info"
+                }, 
+                {
+                    "status": "OK", 
+                    "sw_version": "N/A", 
+                    "hw_version": "MTEF-FANF-A", 
+                    "name": "248a070300fd6100_4001_02", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "FAN - 2", 
+                    "max_ib_ports": 0, 
+                    "module_index": 2, 
+                    "temperature": "N/A", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X08119", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 2", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "FAN", 
+                    "severity": "Info"
+                }, 
+                {
+                    "status": "OK", 
+                    "sw_version": "N/A", 
+                    "hw_version": "MTEF-FANF-A", 
+                    "name": "248a070300fd6100_4001_01", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "FAN - 1", 
+                    "max_ib_ports": 0, 
+                    "module_index": 1, 
+                    "temperature": "N/A", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X08117", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 1", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "FAN", 
+                    "severity": "Info"
+                }, 
+                {
+                    "status": "OK", 
+                    "sw_version": "N/A", 
+                    "hw_version": "MTEF-FANF-A", 
+                    "name": "248a070300fd6100_4001_04", 
+                    "hosting_system_guid": "248a070300fd6100", 
+                    "number_of_chips": 0, 
+                    "description": "FAN - 4", 
+                    "max_ib_ports": 0, 
+                    "module_index": 4, 
+                    "temperature": "N/A", 
+                    "device_type": "Switch", 
+                    "serial_number": "MT1706X08120", 
+                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 4", 
+                    "device_name": "c650f04ib-leaf02-M", 
+                    "type": "FAN", 
+                    "severity": "Info"
+                }
+            ], 
+            "cpu_type": "any", 
+            "is_managed": true, 
+            "model": "MSB7800", 
+            "ports": [
+                "248a070300fd6100_33", 
+                "248a070300fd6100_1", 
+                "248a070300fd6100_3", 
+                "248a070300fd6100_2", 
+                "248a070300fd6100_5", 
+                "248a070300fd6100_4", 
+                "248a070300fd6100_7", 
+                "248a070300fd6100_6", 
+                "248a070300fd6100_9", 
+                "248a070300fd6100_8", 
+                "248a070300fd6100_15", 
+                "248a070300fd6100_14", 
+                "248a070300fd6100_17", 
+                "248a070300fd6100_16", 
+                "248a070300fd6100_11", 
+                "248a070300fd6100_10", 
+                "248a070300fd6100_13", 
+                "248a070300fd6100_12", 
+                "248a070300fd6100_37", 
+                "248a070300fd6100_19", 
+                "248a070300fd6100_18", 
+                "248a070300fd6100_36", 
+                "248a070300fd6100_35", 
+                "248a070300fd6100_34", 
+                "248a070300fd6100_20", 
+                "248a070300fd6100_21", 
+                "248a070300fd6100_23", 
+                "248a070300fd6100_24", 
+                "248a070300fd6100_26", 
+                "248a070300fd6100_27"
+            ]
+        }
+    ]
+
+Modules will sometimes not be reported via UFM. One of the most common causes of this is a communication issue with the ufm daemon, ``ufmd``. If :ref:`_CSM_standalone_inventory_collection` reports an error connecting to the ``ufmd`` or an error in the 400s range, then it may be a communication issue. CSM tries to anticipate the multiple forms of communication, but sometimes a system admin will need to tweak the configuration file for ufm and restart the ``ufmd``. 
+
+On the server running ``ufmd`` the system administrator should look to find the ufm config file, ``gv.cfg``. It should be located at ``/opt/ufm/conf``. In that file the system administrator may need to configure a few fields. 
+
+The first field to check is ``ws_protocol``. This is how external programs, like CSM, communicate with ``ufmd``. It should be set to ``https`` by default. But if it isn't working, then try setting it to ``http``. 
+
+Example:
+
+.. code-block:: none
+
+    ws_protocol = http
+
+If CSM seems to be communicating with the ``ufmd`` fine, but some of the managed switches are still not reporting modules, then the system administrator needs to look at another section of the ufm config file, ``gv.cfg``. The next section to look at is ``[MLNX_OS]``. This section deals with the OS that runs on managed switches. 
+
+.. code-block:: none
+
+    # default MLNX-OS access point for all Mellanox switches
+    # important: this section parameters are used for ufm initialization only !!!
+    #            Please use ufm GUI/API for editing parameters values.
+    [MLNX_OS]
+    protocol = https
+    port = 443
+    user = admin
+    credentials = admin
+    timeout = 10
+
+It has two fields that deal with how ``ufmd`` communicates with the Mellanox OS. If , then try changing the protocol and port to ``http`` and ``80``. 
+
+.. code-block:: none
+
+    protocol = http
+    port = 80
+
+CSM should be able to openly communicate with UFM at this point. But as this is a system administrator and configuration issue, and not a CSM issue, please consult Mellanox and System Administrator support for resolution of this issue. 
 
 

--- a/docs/source/csm/tools.rst
+++ b/docs/source/csm/tools.rst
@@ -196,7 +196,7 @@ Example:
     WARNING: 2 Switches found with 'N/A' serial numbers and have been removed from CSM inventory collection data.
     These records copied into 'bad_switch_records.txt' located at '/var/log/ibm/csm/inv'
 
-This is usually caused by switches not correctly reporting :ref:`_CSM_Network_Inventory_Switch_Module`. If the system module is not found, then CSM can not collect the serial number.
+This is usually caused by switches not correctly reporting :ref:`CSM_Network_Inventory_Switch_Module`. If the system module is not found, then CSM can not collect the serial number.
 
 Below is an example of JSON data returned from UFM. The first is one missing modules, the second is what we expect in a good case. 
 
@@ -537,7 +537,7 @@ Good case - as you can see the module array is populated. :
         }
     ]
 
-Modules will sometimes not be reported via UFM. One of the most common causes of this is a communication issue with the ufm daemon, ``ufmd``. If :ref:`_CSM_standalone_inventory_collection` reports an error connecting to the ``ufmd`` or an error in the 400s range, then it may be a communication issue. CSM tries to anticipate the multiple forms of communication, but sometimes a system admin will need to tweak the configuration file for ufm and restart the ``ufmd``. 
+Modules will sometimes not be reported via UFM. One of the most common causes of this is a communication issue with the ufm daemon, ``ufmd``. If :ref:`CSM_standalone_inventory_collection` reports an error connecting to the ``ufmd`` or an error in the 400s range, then it may be a communication issue. CSM tries to anticipate the multiple forms of communication, but sometimes a system admin will need to tweak the configuration file for ufm and restart the ``ufmd``. 
 
 On the server running ``ufmd`` the system administrator should look to find the ufm config file, ``gv.cfg``. It should be located at ``/opt/ufm/conf``. In that file the system administrator may need to configure a few fields. 
 

--- a/docs/source/csm/tools.rst
+++ b/docs/source/csm/tools.rst
@@ -161,6 +161,39 @@ A system administrator can also configure this tool's output. CSM may detect som
 
         Relative to the ``csm_inv_log_dir``.
 
+.. note:: For CSM 1.7, this tool only supports an ``http`` connection to UFM. UFM's ``gv.cfg`` file must be configured for http connection. Specifically, ``ws_protocol = http``. And also the MLNX-OS section must be set to http. Specifically, ``protocol = http``, and ``port = 80``.
+
+Example:
+
+.. code-block:: none
+
+    ws_protocol = http
+
+and
+
+.. code-block:: none
+
+    # default MLNX-OS access point for all Mellanox switches
+    # important: this section parameters are used for ufm initialization only !!!
+    #            Please use ufm GUI/API for editing parameters values.
+    [MLNX_OS]
+    protocol = http
+    port = 80
+
+.. note:: For CSM 1.8, this tool supports http and https connection to the UFM daemon, but still requires the ufmd to communicate to a managed switch via http. Please ensure that the MLNX-OS section is set to http. Specifically, ``protocol = http``, and ``port = 80``.
+
+Example:
+
+.. code-block:: none
+
+    # default MLNX-OS access point for all Mellanox switches
+    # important: this section parameters are used for ufm initialization only !!!
+    #            Please use ufm GUI/API for editing parameters values.
+    [MLNX_OS]
+    protocol = http
+    port = 80
+
+
 Using the Tool
 **************
 

--- a/docs/source/csm/tools.rst
+++ b/docs/source/csm/tools.rst
@@ -218,7 +218,7 @@ All output information for this tool is printed to the console. The ``-d, --deta
 FAQ - Frequently Asked Questions
 ********************************
 
-Why 'bad record' and N/A' Serial Numbers?
+Why 'bad record' and 'N/A' Serial Numbers?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes CSM can detect a switch in your system that is incomplete. It is missing a serial number, which CSM will consider invalid data, and therefor not insert it into the :ref:`CSM_Database`.


### PR DESCRIPTION
# Purpose
This pull request will have CSM's ufm inventory collection tool be more reliable when collection ufm inventory by being more versatile on how it connects to the ufm daemon.

# Approach
- hours of debugging and configuration testing. 
- online research
- discussion with Mellanox team

# Origin
https://github.ibm.com/CORAL/bluecoral/issues/1030

# How to Test
- manual testing
  - new code works with both http and https protocols in the `gv.cfg` file for ufmd
- advanced FVT testing has been discussed with @williammorrison2. It may be implemented in Q2 of 2020.

# Documentation
- read the docs for CSM has been updated to include a FAQ about missing serial numbers and communication issues, along with notes on how to debug and configure. 


# Additional info

Sometimes CSM can detect a switch in your system that is incomplete. It is missing a serial number, which CSM will consider invalid data, and therefor not insert it into the [CSM Database](https://cast.readthedocs.io/en/latest/csmdb/index.html).

Example:

```
    UFM reported 7 switch records.
    This report from UFM can be found in 'ufm_switch_output_file.json' located at '/var/log/ibm/csm/inv'
    WARNING: 2 Switches found with 'N/A' serial numbers and have been removed from CSM inventory collection data.
    These records copied into 'bad_switch_records.txt' located at '/var/log/ibm/csm/inv'
```

This is usually caused by switches not correctly reporting [switch modules](https://cast.readthedocs.io/en/latest/csm-inventory/Network.html#switch-modules). If the system module is not found, then CSM can not collect the serial number.

Below is an example of JSON data returned from UFM. The first is one missing modules, the second is what we expect in a good case. 

Bad case - as you can see the module array is NOT populated. :

```
    [
        {
            "cpus_number": 0,
            "ip": "10.7.3.2",
            "ram": 0,
            "fw_version": "15.2000.2626",
            "mirroring_template": false,
            "cpu_speed": 0,
            "is_manual_ip": true,
            "technology": "EDR",
            "psid": "MT_2630110032",
            "guid": "248a070300fcccd0",
            "severity": "Warning",
            "script": "N/A",
            "capabilities": [
                "Provisioning"
            ],
            "state": "active",
            "role": "tor",
            "type": "switch",
            "sm_mode": "noSM",
            "vendor": "Mellanox",
            "description": "MSB7800",
            "has_ufm_agent": false,
            "server_operation_mode": "Switch",
            "groups": [
                "Alarmed_Devices"
            ],
            "total_alarms": 1,
            "temperature": "N/A",
            "system_name": "c650f03ib-root01-M",
            "sw_version": "N/A",
            "system_guid": "248a070300fcccd0",
            "name": "248a070300fcccd0",
            "url": "",
            "modules": [],
            "cpu_type": "any",
            "is_managed": true,
            "model": "MSB7800",
                        "ports": [
                "248a070300fcccd0_9",
                "248a070300fcccd0_8",
                "248a070300fcccd0_7",
                "248a070300fcccd0_6",
                "248a070300fcccd0_5",
                "248a070300fcccd0_4",
                "248a070300fcccd0_3",
                "248a070300fcccd0_2",
                "248a070300fcccd0_1",
                "248a070300fcccd0_28",
                "248a070300fcccd0_29",
                "248a070300fcccd0_26",
                "248a070300fcccd0_27",
                "248a070300fcccd0_24",
                "248a070300fcccd0_25",
                "248a070300fcccd0_22",
                "248a070300fcccd0_23",
                "248a070300fcccd0_20",
                "248a070300fcccd0_21",
                "248a070300fcccd0_37",
                "248a070300fcccd0_36",
                "248a070300fcccd0_16",
                "248a070300fcccd0_15",
                "248a070300fcccd0_10",
                "248a070300fcccd0_31",
                "248a070300fcccd0_30",
                "248a070300fcccd0_33",
                "248a070300fcccd0_32",
                "248a070300fcccd0_35",
                "248a070300fcccd0_34",
                "248a070300fcccd0_19",
                "248a070300fcccd0_18"
            ]
        }
    ]
```

How you would see this JSON represented in the `bad_records` files of CSM. Notice the missing modules section.

```
    CSM switch inventory collection
    File created: Fri Feb 28 13:40:59 2020

    The following records are incomplete and can not be inserted into CSM database.

    Switch: 2
    ip:                    10.7.3.2
    fw_version:            15.2000.2626
    total_alarms:          1
    psid:                  MT_2630110032
    guid:                  248a070300fcccd0
    state:                 active
    role:                  tor
    type:                  switch
    vendor:                Mellanox
    description:           MSB7800
    has_ufm_agent:         false
    server_operation_mode: Switch
    sm_mode:               noSM
    system_name:           c650f03ib-root01-M
    sw_version:            N/A
    system_guid:           248a070300fcccd0
    name:                  248a070300fcccd0
    modules:               ???
    serial_number:         N/A
    model:                 MSB7800
```

Good case - as you can see the module array is populated. :

```
    [
        {
            "cpus_number": 0, 
            "ip": "10.7.4.2", 
            "ram": 0, 
            "fw_version": "15.2000.2626", 
            "mirroring_template": false, 
            "cpu_speed": 0, 
            "is_manual_ip": true, 
            "technology": "EDR", 
            "psid": "MT_2630110032", 
            "guid": "248a070300fd6100", 
            "severity": "Info", 
            "script": "N/A", 
            "capabilities": [
                "ssh", 
                "sysinfo", 
                "reboot", 
                "mirroring", 
                "sw_upgrade", 
                "Provisioning"
            ], 
            "state": "active", 
            "role": "tor", 
            "type": "switch", 
            "sm_mode": "noSM", 
            "vendor": "Mellanox", 
            "description": "MSB7800", 
            "has_ufm_agent": false, 
            "server_operation_mode": "Switch", 
            "groups": [], 
            "total_alarms": 0, 
            "temperature": "56", 
            "system_name": "c650f04ib-leaf02-M", 
            "sw_version": "3.8.2102-X86_64", 
            "system_guid": "248a070300fd6100", 
            "name": "248a070300fd6100", 
            "url": "", 
            "modules": [
                {
                    "status": "OK", 
                    "sw_version": "N/A", 
                    "hw_version": "MSB7800-ES2F", 
                    "name": "248a070300fd6100_4000_01", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "MGMT - 1", 
                    "max_ib_ports": 0, 
                    "module_index": 1, 
                    "temperature": "N/A", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X02692", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / MGMT 1", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "MGMT", 
                    "severity": "Info"
                }, 
                {
                    "status": "OK", 
                    "sw_version": "N/A", 
                    "hw_version": "MTEF-PSF-AC-A", 
                    "name": "248a070300fd6100_2005_01", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "PS - 1", 
                    "max_ib_ports": 0, 
                    "module_index": 1, 
                    "temperature": "N/A", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X07347", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / PS 1", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "PS", 
                    "severity": "Info"
                }, 
                {
                    "status": "OK", 
                    "sw_version": "3.8.2102-X86_64", 
                    "hw_version": "MSB7800-ES2F", 
                    "name": "248a070300fd6100_1007_01", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "SYSTEM", 
                    "max_ib_ports": 0, 
                    "module_index": 1, 
                    "temperature": "56", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X02692", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / system 1", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "SYSTEM", 
                    "severity": "Info"
                }, 
                {
                    "status": "OK", 
                    "sw_version": "N/A", 
                    "hw_version": "MTEF-PSF-AC-A", 
                    "name": "248a070300fd6100_2005_02", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "PS - 2", 
                    "max_ib_ports": 0, 
                    "module_index": 2, 
                    "temperature": "N/A", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X07348", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / PS 2", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "PS", 
                    "severity": "Info"
                }, 
                {
                    "status": "OK", 
                    "sw_version": "N/A", 
                    "hw_version": "MTEF-FANF-A", 
                    "name": "248a070300fd6100_4001_03", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "FAN - 3", 
                    "max_ib_ports": 0, 
                    "module_index": 3, 
                    "temperature": "N/A", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X08121", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 3", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "FAN", 
                    "severity": "Info"
                }, 
                {
                    "status": "OK", 
                    "sw_version": "N/A", 
                    "hw_version": "MTEF-FANF-A", 
                    "name": "248a070300fd6100_4001_02", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "FAN - 2", 
                    "max_ib_ports": 0, 
                    "module_index": 2, 
                    "temperature": "N/A", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X08119", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 2", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "FAN", 
                    "severity": "Info"
                }, 
                {
                    "status": "OK", 
                    "sw_version": "N/A", 
                    "hw_version": "MTEF-FANF-A", 
                    "name": "248a070300fd6100_4001_01", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "FAN - 1", 
                    "max_ib_ports": 0, 
                    "module_index": 1, 
                    "temperature": "N/A", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X08117", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 1", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "FAN", 
                    "severity": "Info"
                }, 
                {
                    "status": "OK", 
                    "sw_version": "N/A", 
                    "hw_version": "MTEF-FANF-A", 
                    "name": "248a070300fd6100_4001_04", 
                    "hosting_system_guid": "248a070300fd6100", 
                    "number_of_chips": 0, 
                    "description": "FAN - 4", 
                    "max_ib_ports": 0, 
                    "module_index": 4, 
                    "temperature": "N/A", 
                    "device_type": "Switch", 
                    "serial_number": "MT1706X08120", 
                    "path": "default(86) / Switch: c650f04ib-leaf02-M / FAN 4", 
                    "device_name": "c650f04ib-leaf02-M", 
                    "type": "FAN", 
                    "severity": "Info"
                }
            ], 
            "cpu_type": "any", 
            "is_managed": true, 
            "model": "MSB7800", 
            "ports": [
                "248a070300fd6100_33", 
                "248a070300fd6100_1", 
                "248a070300fd6100_3", 
                "248a070300fd6100_2", 
                "248a070300fd6100_5", 
                "248a070300fd6100_4", 
                "248a070300fd6100_7", 
                "248a070300fd6100_6", 
                "248a070300fd6100_9", 
                "248a070300fd6100_8", 
                "248a070300fd6100_15", 
                "248a070300fd6100_14", 
                "248a070300fd6100_17", 
                "248a070300fd6100_16", 
                "248a070300fd6100_11", 
                "248a070300fd6100_10", 
                "248a070300fd6100_13", 
                "248a070300fd6100_12", 
                "248a070300fd6100_37", 
                "248a070300fd6100_19", 
                "248a070300fd6100_18", 
                "248a070300fd6100_36", 
                "248a070300fd6100_35", 
                "248a070300fd6100_34", 
                "248a070300fd6100_20", 
                "248a070300fd6100_21", 
                "248a070300fd6100_23", 
                "248a070300fd6100_24", 
                "248a070300fd6100_26", 
                "248a070300fd6100_27"
            ]
        }
    ]
```

Modules will sometimes not be reported via UFM. One of the most common causes of this is a communication issue with the ufm daemon, ``ufmd``. See below for more information.

## What is a `CONNECTOR_ACCESS fail`?

If [csm ufm standalone inventory collection](https://cast.readthedocs.io/en/latest/tools.html#csm-standalone-inventory-collection) reports a `connector_access fail` then it probably failed to connect to the `ufmd`. 

For example, a system administrator may see:

```
    Response returned with status code 403
    INV_IB_CONNECTOR_ACCESS failed
```

or 

```
    Response returned with status code 400
    INV_SWITCH_CONNECTOR_ACCESS failed
```

If [csm ufm standalone inventory collection](https://cast.readthedocs.io/en/latest/tools.html#csm-standalone-inventory-collection) reports an error connecting to the `ufmd` or an error in the 400s range, then it may be a communication issue. CSM tries to anticipate the multiple forms of communication, but sometimes a system admin will need to tweak the configuration file for ufm and restart the `ufmd`. 

On the server running `ufmd` the system administrator should look to find the ufm config file, `gv.cfg`. It should be located at `/opt/ufm/conf`. In that file the system administrator may need to configure a few fields. 

The first field to check is `ws_protocol`. This is how external programs, like CSM, communicate with `ufmd`. It should be set to `https` by default. But if it isn't working, then try setting it to `http`. 

Example:

```
    ws_protocol = http
```

If CSM seems to be communicating with the `ufmd` fine, but some of the managed switches are still not reporting modules, then the system administrator needs to look at another section of the ufm config file, `gv.cfg`. The next section to look at is `[MLNX_OS]`. This section deals with the OS that runs on managed switches. 

```
    # default MLNX-OS access point for all Mellanox switches
    # important: this section parameters are used for ufm initialization only !!!
    #            Please use ufm GUI/API for editing parameters values.
    [MLNX_OS]
    protocol = https
    port = 443
    user = admin
    credentials = admin
    timeout = 10
```

It has two fields that deal with how `ufmd` communicates with the Mellanox OS. If , then try changing the protocol and port to `http` and ``80``. 

```
    protocol = http
    port = 80
```

Also check the managed switch's `show web`. This should match how the `ufmd` is expecting to communicate with the managed switch in the `[MLNX_OS]` section of the `gv.cfg`.

CSM should be able to openly communicate with UFM at this point. But as this is a system administrator and configuration issue, and not a CSM issue, please consult Mellanox and System Administrator support for resolution of this issue. 

# Additional Testing:

Test:
1. edit config file
2. restart ufmd
3. run ufm inventory collection
4. EXPECT: see inventory inserted into csm database

test all combinations described in `CONNECTOR_ACCESS fail` section above, or selected combinations as you see fit. 


