### PR TITLE
For page fixup in fh.cc, if remaining length is 0, do not add extent

### DIFF
--- a/bb/src/fh.cc
+++ b/bb/src/fh.cc
@@ -1006,7 +1006,9 @@ int filehandle::protect(off_t start, size_t len, bool writing, Extent& input, ve
             }
 
             // Lookup location(s) in LVM
-            lookup.translate(tmp, result);
+            if (tmp.len) {
+              lookup.translate(tmp, result);
+            }
             LOG(bb,debug) << "lookup.translate returned for extent #" << x;
         }
     }


### PR DESCRIPTION
Handle case after fixup where the remaining length is zero for doing extents.