### PR TITLE
Additional fixes related to building with --type=Release

### DIFF
--- a/csmdb/sql/csm_db_script.sh
+++ b/csmdb/sql/csm_db_script.sh
@@ -1,8 +1,9 @@
+#!/bin/bash
 #--------------------------------------------------------------------------------
 #   
 #    csm_db_script.sh
 # 
-#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at

--- a/csmi/src/wm/cmd/allocation_query_details.c
+++ b/csmi/src/wm/cmd/allocation_query_details.c
@@ -82,10 +82,11 @@ int main(int argc, char *argv[])
 	/*CSM Variables*/
 	csm_api_object *csm_obj = NULL;
 	/*API Variables*/
-    API_PARAMETER_INPUT_TYPE   input;
-    input.allocation_id = 0;
+	API_PARAMETER_INPUT_TYPE input;
+	API_PARAMETER_OUTPUT_TYPE *output = NULL;
 
-    API_PARAMETER_OUTPUT_TYPE *output = NULL;
+	csm_init_struct(API_PARAMETER_INPUT_TYPE, input);
+    	input.allocation_id = 0;
 	
 	while ((opt = getopt_long(argc, argv, "hv:a:", longopts, &indexptr)) != -1) {
 		switch (opt) {

--- a/hcdiag/samples/gpu-health/CMakeLists.txt
+++ b/hcdiag/samples/gpu-health/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    hcdiag/samples/gpu-health/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -15,15 +15,10 @@
 
 set(HCDIAG_SAMPLE gpu-health)
 
-file(GLOB SAMPLE_PROGRAM
-  "makefile"
-)
-
 file(GLOB SAMPLE_FILE
+  "makefile"
   "gpu-health.cu"
 )
 
-
-install(PROGRAMS ${SAMPLE_PROGRAM} COMPONENT ${HCDIAG_RPM_NAME} DESTINATION csm/hcdiag/samples/${HCDIAG_SAMPLE})
 install(FILES ${SAMPLE_FILE} COMPONENT ${HCDIAG_RPM_NAME} DESTINATION csm/hcdiag/samples/${HCDIAG_SAMPLE})
 


### PR DESCRIPTION
Found and fixed some additional problems related to release builds (`--type=Release`).

```
scripts/configure.pl --type=Release --mincmake=3.6 --rpmbuild --parallel
scripts/rebuild noinstall package
```

**1.) csm_db_script.sh is shipped without execute permission**
During build:
`*** WARNING: ./opt/ibm/csm/db/csm_db_script.sh is executable but has empty or no shebang, removing executable bit`

After install:
`/opt/ibm/csm/db/csm_db_script.sh: Permission denied`

Fixed by adding `#!/bin/bash` to the top of the script.

**2.) hcdiag makefile is incorrectly shipped with execute permission**
`*** WARNING: ./opt/ibm/csm/hcdiag/samples/gpu-health/makefile is executable but has empty or no shebang, removing executable bit`

Fixed by making the makefile non-executable.

make still works as expected:
```
# pwd
/opt/ibm/csm/hcdiag/samples/gpu-health

# ls -l
total 12
-rw-r--r-- 1 root root 7764 Apr 15 13:34 gpu-health.cu
-rw-r--r-- 1 root root  897 Apr 15 13:34 makefile

# make clean
rm -f gpu-health
```

**3.) csm_allocation_query_details runtime error**
```
/opt/ibm/csm/bin/csm_allocation_query_details -a 1
[csmapi][error]	Failed to pack arguments, make sure version is set!
/opt/ibm/csm/bin/csm_allocation_query_details FAILED: errcode: 28 errmsg: Message packing error
```
Missing structure initialization call leads to the error above, fixed by adding a struct init call.

With the fixes in this PR, the release build is now passing the same set of regression tests as development builds.
