### PR TITLE
Fix RHEL7 install break

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,15 @@ list(REMOVE_ITEM TOPLEVELS ${DOUT})
 set(CMAKE_C_FLAGS   "-g -Wall -Werror -m64 -fPIC")
 set(CMAKE_CXX_FLAGS "-g -Wall -Werror -m64 -fPIC -std=c++11")
 
+if(${CMAKE_SYSTEM} STRGREATER "Linux-4.15")
+  set(EXPLICIT_PYTHON_VERSION 1)
+else()
+  set(EXPLICIT_PYTHON_VERSION 0)
+endif()
+
+message("System: ${CMAKE_SYSTEM}")
+message("Explicit python version: ${EXPLICIT_PYTHON_VERSION}")
+
 if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU"  AND  ${CMAKE_C_COMPILER_VERSION} VERSION_GREATER "7.0.0")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=format-truncation= -Wno-error=format-overflow= -Wno-error=stringop-truncation")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=format-truncation= -Wno-error=format-overflow= -Wno-error=stringop-truncation")

--- a/csm_big_data/setupRPM.cmake
+++ b/csm_big_data/setupRPM.cmake
@@ -18,7 +18,11 @@ set( CPACK_RPM_csm-bds_POST_INSTALL_SCRIPT_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/csm_big_data/rpmscripts/cast-bds.post.install" )
 set( CPACK_RPM_csm-bds_PRE_UNINSTALL_SCRIPT_FILE
     "${CMAKE_CURRENT_SOURCE_DIR}/csm_big_data/rpmscripts/cast-bds.pre.uninstall" )
-set(CPACK_RPM_csm-bds_PACKAGE_REQUIRES "python2-psycopg2 >= 2.5.1")
+if(${EXPLICIT_PYTHON_VERSION})
+   set(CPACK_RPM_csm-bds_PACKAGE_REQUIRES "python2-psycopg2 >= 2.5.1")
+else()
+   set(CPACK_RPM_csm-bds_PACKAGE_REQUIRES "python-psycopg2 >= 2.5.1")
+endif()
 
 # Setup Kibana RPM
 SET(CPACK_RPM_csm-bds-kibana_PACKAGE_ARCHITECTURE "noarch")

--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -29,7 +29,11 @@ set( CPACK_RPM_csm-core_POST_INSTALL_SCRIPT_FILE
 
 # ibm-csm-db rpm settings
 set(CPACK_RPM_csm-db_PACKAGE_ARCHITECTURE "noarch")
-set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv,python2-psycopg2")
+if(${EXPLICIT_PYTHON_VERSION})
+    set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv,python2-psycopg2")
+else()
+    set(CPACK_RPM_csm-db_PACKAGE_REQUIRES "pv,python-psycopg2")
+endif()
 
 # ibm-csm-hcdiag rpm settings
 set(CPACK_RPM_csm-hcdiag_PACKAGE_ARCHITECTURE "noarch")


### PR DESCRIPTION
RHEL8 changes in csmd switched python-psycopg2 to python2-psycopg2, which breaks RHEL7 installs.  This change detects the build system and selects the right RPM require.  