### PR TITLE
CSM Mellanox Inventory Collection - Unhandled Exception

### DIFF
--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -278,8 +278,25 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			//std::cout << "error: " << error << std::endl;
 			//We ignore this error for now because we know we connected in an uncool way.
 			//If we correct the connection process, then this error will go away.
+		}else if(error.value() == 1){
+			//error: asio.ssl.stream:1
+			//stream truncated
+
+			std::cout << " " << std::endl;
+			std::cout << "error: " << error << std::endl;
+			std::cout << "error: " << "stream truncated" << std::endl;
+			std::cout << "error: " << "Possible that SSL connection was not properly closed." << std::endl;
+			std::cout << " " << std::endl;
+
+			//This error occured because of an improper close to the SSL connection.
+			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"
+			//std::cout << "error: " << error << std::endl;
+			//We ignore this error for now because we know we connected in an uncool way.
+			//If we correct the connection process, then this error will go away.
 		}else{
 			//Non expected. Non special case error code.
+			std::cout << "error: " << error << std::endl;
+			std::cout << "error.value: " << error.value() << std::endl;
 			throw boost::system::system_error(error);
 		}
 	

--- a/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_ib_connector_access.cc
@@ -282,11 +282,15 @@ int INV_IB_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address, std
 			//error: asio.ssl.stream:1
 			//stream truncated
 
+			// https://github.ibm.com/CSM/team_process/issues/70
+			// Un comment for investigation. 
+			/*
 			std::cout << " " << std::endl;
 			std::cout << "error: " << error << std::endl;
 			std::cout << "error: " << "stream truncated" << std::endl;
 			std::cout << "error: " << "Possible that SSL connection was not properly closed." << std::endl;
 			std::cout << " " << std::endl;
+			*/
 
 			//This error occured because of an improper close to the SSL connection.
 			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -380,11 +380,15 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 			//error: asio.ssl.stream:1
 			//stream truncated
 
+			// https://github.ibm.com/CSM/team_process/issues/70
+			// Un comment for investigation. 
+			/*
 			std::cout << " " << std::endl;
 			std::cout << "error: " << error << std::endl;
 			std::cout << "error: " << "stream truncated" << std::endl;
 			std::cout << "error: " << "Possible that SSL connection was not properly closed." << std::endl;
 			std::cout << " " << std::endl;
+			*/
 
 			//This error occured because of an improper close to the SSL connection.
 			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"

--- a/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
+++ b/csmd/src/inv/ib_and_switch/src/inv_switch_connector_access.cc
@@ -376,8 +376,25 @@ int INV_SWITCH_CONNECTOR_ACCESS::ExecuteDataCollection(std::string rest_address,
 			//std::cout << "error: " << error << std::endl;
 			//We ignore this error for now because we know we connected in an uncool way.
 			//If we correct the connection process, then this error will go away.
+		}else if(error.value() == 1){
+			//error: asio.ssl.stream:1
+			//stream truncated
+
+			std::cout << " " << std::endl;
+			std::cout << "error: " << error << std::endl;
+			std::cout << "error: " << "stream truncated" << std::endl;
+			std::cout << "error: " << "Possible that SSL connection was not properly closed." << std::endl;
+			std::cout << " " << std::endl;
+
+			//This error occured because of an improper close to the SSL connection.
+			//I believe related to the fact that above we connected via the "socket.set_verify_mode(ssl::verify_none);"
+			//std::cout << "error: " << error << std::endl;
+			//We ignore this error for now because we know we connected in an uncool way.
+			//If we correct the connection process, then this error will go away.
 		}else{
 			//Non expected. Non special case error code.
+			std::cout << "error: " << error << std::endl;
+			std::cout << "error.value: " << error.value() << std::endl;
 			throw boost::system::system_error(error);
 		}
 


### PR DESCRIPTION
# Purpose
The CSM FVT team found an unhandled exception in the standalone inv collection tool after upgrading to RH8. This exception broke the pipeline of getting inventory data from Mellanox devices into the CSM database. The purpose of this pull request is to restore the pipeline of getting the inv data into the CSM database. 

# Approach
- We did basic testing and investigation
- googling
- trial and error testing
- code review
- documentation of next/future steps

# Origin
https://github.ibm.com/CSM/team_process/issues/70

# How to Test
Run tthe CSM ib inventory collection tool on a RH8 machine. 

# Screenshots

Example of tool working again:
```
[root@c650f99p06 sbin]# ./standalone_ib_and_switch_collection -c /etc/ibm/csm/csm_master.cfg

UFM reported 133 IB records.
This report from UFM can be found in 'ufm_ib_cable_output_file.json' located at '/var/log/ibm/csm/inv'
WARNING: 14 IB cables were discovered, but are missing serial numbers and have been removed from CSM inventory collection data.
These records copied into 'bad_ib_cable_records.txt' located at '/var/log/ibm/csm/inv'
WARNING: 7 IB cables found with no 'cable_info' and have been removed from CSM inventory collection data.
These records copied into 'bad_ib_cable_records.txt' located at '/var/log/ibm/csm/inv'

UFM reported 7 switch records.
This report from UFM can be found in 'ufm_switch_output_file.json' located at '/var/log/ibm/csm/inv'
WARNING: 2 Switches found with 'N/A' serial numbers and have been removed from CSM inventory collection data.
These records copied into 'bad_switch_records.txt' located at '/var/log/ibm/csm/inv'

---
# ib inventory successful
...
# total ib inventory collected: 112
# new ib records inserted into database: 0
# old ib records updated in database: 112
# old ib records removed from the database: 0
---
# switch inventory successful
...
# total switch inventory collected: 5
# new switch records inserted into database: 0
# old switch records updated in database: 5
# old switch records removed from the database: 0
# old switch module records removed from the database because they were associated with the above removed switches: 0
---
# switch module inventory successful
...
# total switch module inventory collected: 49
# new switch module records inserted into database: 0
# old switch module records updated in database: 49
# old switch module records removed from the database: 0
[root@c650f99p06 sbin]# 
[root@c650f99p06 sbin]# 
[root@c650f99p06 sbin]# 
```

