### PR TITLE
Updated csmtest hcdiag clustconf.yaml template for RHEL 8.1 testing

### DIFF
--- a/csmtest/include/hcdiag/clustconf.yaml
+++ b/csmtest/include/hcdiag/clustconf.yaml
@@ -333,9 +333,9 @@ node_info:
       banks: 16
       bank_size:  8
     os:
-      pretty_name: "Red Hat Enterprise Linux Server 7.5 Beta (Maipo)"
+      pretty_name: "Red Hat Enterprise Linux 8.1 (Ootpa)"
     kernel:
-      release: "4.14.0-43.el7a.ppc64le"
+      release: "4.18.0-147.5.1.el8_1.ppc64le"
     software:
         - ibm-csm: 1.8.0-2974 
     temp:
@@ -369,9 +369,9 @@ node_info:
       banks: 16
       bank_size:  32
     os:
-      pretty_name: "Red Hat Enterprise Linux Server 7.5 Beta (Maipo)"
+      pretty_name: "Red Hat Enterprise Linux 8.1 (Ootpa)"
     kernel:
-      release: "4.14.0-43.el7a.ppc64le"
+      release: "4.18.0-147.5.1.el8_1.ppc64le"
     software:
         - ibm-csm: 1.8.0-2974 
     temp:
@@ -405,9 +405,9 @@ node_info:
       banks: 16
       bank_size:  32
     os:
-      pretty_name: "Red Hat Enterprise Linux Server 7.5 Beta (Maipo)"
+      pretty_name: "Red Hat Enterprise Linux 8.1 (Ootpa)"
     kernel:
-      release: "4.14.0-43.el7a.ppc64le"
+      release: "4.18.0-147.5.1.el8_1.ppc64le"
     software:
         - ibm-csm: 1.8.0-2974 
     temp:


### PR DESCRIPTION
After upgrading the CSM FVT regression environment to RHEL 8.1, the following test case failure was discovered:

```
# grep chk-os /test/archive/2020-04-29-hcdiag_3_rpower_and_perl-YAML/buckets/basic/hcdiag.log 
Test Case 26: chk-os:                                                                                  FAILED
```

More detailed data:
```
Test Case 26: chk-os
Health Check Diagnostics version 1.8.0, running on Linux 4.18.0-147.5.1.el8_1.ppc64le, c650f99p06 machine.
Using configuration file /opt/ibm/csm/hcdiag/etc/hcdiag.properties.
Using tests configuration file /opt/ibm/csm/hcdiag/etc/test.properties.
Health Check Diagnostics, run id 200429180610388094, initializing...
Validating command argument test.
Validating command argument target.
Allocation request successful, id= 71
Preparing to run chk-os.
Executable: /opt/ibm/csm/hcdiag/tests/chk-os/chk-os.sh exists on remote node(s).
chk-os started on 4 node(s) at 2020-04-29 18:06:12.838249. It might take up to 10s.
INFO: xcat seems to be installed in /opt/xcat/bin. Running in Management mode

chk-os ended on 4 node(s) at 2020-04-29 18:06:14.930650, rc= 4, elapsed time: 0:00:02.092401
chk-os FAIL on node c650f99p18, serial number: 787C40A, rc= 1. (details in /tmp/200429180610388094/chk-os/c650f99p18-2020-04-29-18_06_13.output)
A RAS event was created in the database for this message
chk-os FAIL on node c650f99p26, serial number: 787C48A, rc= 1. (details in /tmp/200429180610388094/chk-os/c650f99p26-2020-04-29-18_06_13.output)
A RAS event was created in the database for this message
chk-os FAIL on node c650f99p28, serial number: 787C3CA, rc= 1. (details in /tmp/200429180610388094/chk-os/c650f99p28-2020-04-29-18_06_13.output)
A RAS event was created in the database for this message
chk-os FAIL on node c650f99p36, serial number: 1318CBA, rc= 1. (details in /tmp/200429180610388094/chk-os/c650f99p36-2020-04-29-18_06_13.output)
A RAS event was created in the database for this message
Request csmd to release the allocation 71.
Allocation 71 delete request successful.
Error invoking csmi csm_diag_run_end, rc= 99.
Health Check Diagnostics ended, exit code 100.
```

```
# cat /tmp/200429180610388094/chk-os/c650f99p18-2020-04-29-18_06_13.output
 Running chk-os.sh on c650f99p18, machine type  8335-GTX.
 (ERROR) c650f99p18: invalid version, release: Red Hat Enterprise Linux 8.1 (Ootpa),4.18.0-147.5.1.el8_1.ppc64le; expected: Red Hat Enterprise Linux Server 7.5 Beta (Maipo), 4.14.0-43.el7a.ppc64le
 chk-os test FAIL, rc=1
 Remote_command_rc = 1
```


The root cause was due to a mismatch in the hcdiag clust.conf expected values for OS version and the actual OS version installed on the cluster. After making the changes contained in this PR, the test case now passes:
```
# ./setup/csm_install.sh 

# /u/besawn/bash/csm_set_all_in_service 

# ./buckets/basic/hcdiag.sh 

# grep chk-os /test/results/buckets/basic/hcdiag.log 
Test Case 26: chk-os:                                                                                    PASS
```

 