### PR TITLE
Coverity 348587 Handle bad RC from SSL_write in authenticate

### DIFF
--- a/bb/src/connections.cc
+++ b/bb/src/connections.cc
@@ -429,7 +429,10 @@ void connection_authenticate(txp::Id id, txp::Connex* conn, txp::Msg*& msg)
     txp::Attr_int32 resultcode(txp::resultCode, rc);
     response->addAttribute(&resultcode);
     if (rc) {addBBErrorToMsg(response);}
-    conn->write(response);
+    int rc_write=conn->write(response);
+    if (rc_write <= 0) {
+        conn->disconnect();
+    }
     delete msg;
     msg = NULL;
     delete response;


### PR DESCRIPTION
Minor bug:  Handle bad return code from implied SSL_write in SSL authenticate method.