### PR TITLE
Add RHEL 8 csm-api python library support

### DIFF
--- a/csmi/src/CMakeLists.txt
+++ b/csmi/src/CMakeLists.txt
@@ -83,22 +83,32 @@ file(GLOB csmi_python_boot
 # The Python Libraries:
 if(${EXPLICIT_PYTHON_VERSION})
     # RHEL 8
-    message("CSM python API build disabled")
+    find_package(PythonLibs 3.6)
+    set(CSM_BOOST_PYTHON python3)
 else()
     # RHEL 7
     find_package(PythonLibs 2.7)
+    set(CSM_BOOST_PYTHON python)
 endif()
 
 message("Python Include: ${PYTHON_INCLUDE_DIRS}")
+message("CSM Boost Python: ${CSM_BOOST_PYTHON}")
 if (EXISTS ${PYTHON_INCLUDE_DIRS} )
     message("BUILDING PYTHON LIBRARIES")
 
     include_directories( SYSTEM ${PYTHON_INCLUDE_DIRS} )
+
+    set(Boost_DEBUG ON)
+    set(Boost_DETAILED_FAILURE_MSG ON)
     
     # The Boost Python Libraries:
-    find_package( Boost COMPONENTS python REQUIRED )
+    find_package( Boost COMPONENTS ${CSM_BOOST_PYTHON} REQUIRED )
     include_directories( SYSTEM ${Boost_INCLUDE_DIR} )
     
+    message("Boost_INCLUDE_DIR=${Boost_INCLUDE_DIR}")
+    message("Boost_LIBRARY_DIR_RELEASE=${Boost_LIBRARY_DIR_RELEASE}")
+    message("Boost_LIBRARY_DIR_DEBUG=${Boost_LIBRARY_DIR_DEBUG}")
+
     # Link the library
     #add_library(_csm_py SHARED ${csmi_python})
     #target_link_libraries( _csm_py ${Boost_LIBRARIES} csmi)

--- a/csmi/src/CMakeLists.txt
+++ b/csmi/src/CMakeLists.txt
@@ -98,17 +98,10 @@ if (EXISTS ${PYTHON_INCLUDE_DIRS} )
 
     include_directories( SYSTEM ${PYTHON_INCLUDE_DIRS} )
 
-    set(Boost_DEBUG ON)
-    set(Boost_DETAILED_FAILURE_MSG ON)
-    
     # The Boost Python Libraries:
     find_package( Boost COMPONENTS ${CSM_BOOST_PYTHON} REQUIRED )
     include_directories( SYSTEM ${Boost_INCLUDE_DIR} )
     
-    message("Boost_INCLUDE_DIR=${Boost_INCLUDE_DIR}")
-    message("Boost_LIBRARY_DIR_RELEASE=${Boost_LIBRARY_DIR_RELEASE}")
-    message("Boost_LIBRARY_DIR_DEBUG=${Boost_LIBRARY_DIR_DEBUG}")
-
     # Link the library
     #add_library(_csm_py SHARED ${csmi_python})
     #target_link_libraries( _csm_py ${Boost_LIBRARIES} csmi)

--- a/csmi/src/CMakeLists.txt
+++ b/csmi/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmi/src/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -79,17 +79,18 @@ file(GLOB csmi_python_boot
     "ras/src/lib_csm_ras_py.py"
 )
 
-# GENERAL NOTE: This section is under construction. commented out
-# Reason: python wasn't linking correctly
-# - wasn't critical path. we comment out to get a build up so IST can make an allocation and move fwd.
-
 # python
 # The Python Libraries:
-# find_package(PythonLibs 2.7 )
-# message("Python Include: ${PYTHON_INCLUDE_DIRS}")
-#if (EXISTS ${PYTHON_INCLUDE_DIRS} )
-# WORK AROUND COMMENT
-if (EXISTS ${PYTHON_INCLUDE_DISABLE_DIRS} )
+if(${EXPLICIT_PYTHON_VERSION})
+    # RHEL 8
+    message("CSM python API build disabled")
+else()
+    # RHEL 7
+    find_package(PythonLibs 2.7)
+endif()
+
+message("Python Include: ${PYTHON_INCLUDE_DIRS}")
+if (EXISTS ${PYTHON_INCLUDE_DIRS} )
     message("BUILDING PYTHON LIBRARIES")
 
     include_directories( SYSTEM ${PYTHON_INCLUDE_DIRS} )

--- a/csmtest/buckets/basic/fvt_allocation_create_and_delete.py
+++ b/csmtest/buckets/basic/fvt_allocation_create_and_delete.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python2
+#!/bin/sh
 # encoding: utf-8
 #================================================================================
 #
 #    allocation_create.py   
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -14,6 +14,17 @@
 #    restricted by GSA ADP Schedule Contract with IBM Corp.
 #
 #================================================================================
+
+# The beginning of this script is both valid shell and valid python,
+# such that the script starts with the shell and is reexecuted with
+# the right python.
+#
+# On RHEL 7, CSM uses a version of boost-python dependent on python2
+# On RHEL 8, CSM uses a version of boost-python dependent on python3
+# The intent is to run as python3 on RHEL8 and python2 on RHEL7
+#
+'''which' python3 > /dev/null 2>&1 && exec python3 "$0" "$@" || exec python2 "$0" "$@"
+'''
 
 import sys
 sys.path.append('/opt/ibm/csm/lib')

--- a/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
+++ b/csmtest/buckets/basic/fvt_node_attributes_query_and_update.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python2
+#!/bin/sh
 # encoding: utf-8
 #================================================================================
 #
 #    node_attributes_query.py
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -14,6 +14,17 @@
 #    restricted by GSA ADP Schedule Contract with IBM Corp.
 #
 #================================================================================
+
+# The beginning of this script is both valid shell and valid python,
+# such that the script starts with the shell and is reexecuted with
+# the right python.
+#
+# On RHEL 7, CSM uses a version of boost-python dependent on python2
+# On RHEL 8, CSM uses a version of boost-python dependent on python3
+# The intent is to run as python3 on RHEL8 and python2 on RHEL7
+#
+'''which' python3 > /dev/null 2>&1 && exec python3 "$0" "$@" || exec python2 "$0" "$@"
+'''
 
 import sys
 


### PR DESCRIPTION
CSM provides CSM API python libraries implemented via boost-python. This pull request contains changes needed to fix regressions in the CSM API python libraries on RHEL 8 caused by changes in the underlying boost and python packages shipped on RHEL 8. This PR also maintains the ability to build CSM on RHEL7.

On RHEL 7, the CSM API python libraries require python2 (due to underlying dependencies).

On RHEL 8, the CSM API python libraries require python3 (due to underlying dependencies).

Note: see the changes to the CSM FVT scripts contained in this PR for a solution for detecting whether to invoke python2 or python3.

**RHEL7 CSM API python libraries**

_Build environment requirements_
```
# rpm -q --whatprovides /usr/lib64/libboost_python.so.1.60.0 
cast-boost-python-1.60.0-4.el7a.ppc64le

# rpm -q --whatprovides /usr/lib64/libboost_python.so
cast-boost-devel-1.60.0-4.el7a.ppc64le

# python -V
Python 2.7.5
```

_Runtime environment_
```
# rpm -q --whatprovides /usr/lib64/libboost_python.so.1.60.0 
cast-boost-python-1.60.0-4.el7a.ppc64le

# python -V
Python 2.7.5
```


**RHEL8 CSM API python libraries**
_Build environment_
```
# rpm -q --whatprovides /usr/lib64/libboost_python3.so.1.66.0 
boost-python3-1.66.0-6.el8.ppc64le

# rpm -q --whatprovides /usr/lib64/libboost_python3.so
boost-python3-devel-1.66.0-6.el8.ppc64le

# python3 -V
Python 3.6.8
```

_Runtime environment_
```
# rpm -q --whatprovides /usr/lib64/libboost_python3.so.1.66.0 
boost-python3-1.66.0-6.el8.ppc64le

# python3 -V
Python 3.6.8
```