### PR TITLE
Csm ssl coms

### DIFF
--- a/csmnet/src/CPP/endpoint_ptp.h
+++ b/csmnet/src/CPP/endpoint_ptp.h
@@ -279,6 +279,11 @@ protected:
       VersionMsg::ConvertToBytes( VersionMsg::Get() ) );
 
     LOG( csmnet, debug ) << "ConnectPost: Sending version message to peer: " << _RemoteAddr->Dump() << ": " << Msg;
+
+    // Sending the version message. 
+    // Version verification
+    // This is the daemon to daemon com check that says "Hey. I'm running csm 1.8, What version are you running?"
+    // Note: Message is sent in the if statement
     if( Send( Msg ) <= 0 )
     {
       throw csm::network::ExceptionFatal("Failed to send version message. Can't continue.");

--- a/csmnet/src/CPP/endpoint_ptp_sec.cc
+++ b/csmnet/src/CPP/endpoint_ptp_sec.cc
@@ -2,7 +2,7 @@
 
     csmnet/src/CPP/endpoint_ptp_sec.cc
 
-  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -429,22 +429,36 @@ void csm::network::EndpointPTP_sec_base::SetupSSLContext( const csm::network::SS
 
   if( _LocalAddr->GetAddrType() == csm::network::AddressType::CSM_NETWORK_TYPE_AGGREGATOR )
   {
-    // We had "SSLv23_method" pre RH8. 
-    // Lars suggest that we change to TLS. I'm not sure why, but he knows more about it than me. 
-    // Leaving here incase it breaks again in the future and we have to debug around this. 
-    // This might be a note of different methods to investigate. 
-
-    //_gSSLContext = SSL_CTX_new( SSLv23_method() );
-    _gSSLContext = SSL_CTX_new( TLS_method() );
+    #ifdef TLS_method
+      // Use the recommended TLS_method if it is available (RHEL 8)
+      _gSSLContext = SSL_CTX_new( TLS_method() );
+    #else
+      // Otherwise fallback to the old behavior and use SSLv23_method (RHEL 7)
+      _gSSLContext = SSL_CTX_new( SSLv23_method() );
+    #endif
   }
   else
   {
     if( IsServerEndpoint() )
-      //_gSSLContext = SSL_CTX_new( SSLv23_server_method() );
-      _gSSLContext = SSL_CTX_new( TLS_server_method() );
+    {
+      #ifdef TLS_server_method
+        // Use the recommended TLS_server_method if it is available (RHEL 8)
+        _gSSLContext = SSL_CTX_new( TLS_server_method() );
+      #else
+        // Otherwise fallback to the old behavior and use SSLv23_server_method (RHEL 7)
+        _gSSLContext = SSL_CTX_new( SSLv23_server_method() );
+      #endif
+    }
     else
-      //_gSSLContext = SSL_CTX_new( SSLv23_client_method() );
-      _gSSLContext = SSL_CTX_new( TLS_client_method() );
+    {
+      #ifdef TLS_client_method
+        // Use the recommended TLS_client_method if it is available (RHEL 8)
+        _gSSLContext = SSL_CTX_new( TLS_client_method() );
+      #else
+        // Otherwise fallback to the old behavior and use SSLv23_client_method (RHEL 7)
+        _gSSLContext = SSL_CTX_new( SSLv23_client_method() );
+      #endif
+    }
   }
 
   if( _gSSLContext == nullptr )

--- a/csmnet/src/CPP/endpoint_ptp_sec.cc
+++ b/csmnet/src/CPP/endpoint_ptp_sec.cc
@@ -316,11 +316,6 @@ csm::network::EndpointPTP_sec_base::Recv( csm::network::Message &aMsg )
           {
             // The operation did not complete and can be retried later.
 
-            // I beleive here we have a case of a potential loop to be added to our code.
-            // we can keep retrying until we make a successful read, or stop after X attempts.
-
-            // fall into default
-
             // logically this would be the same path as:
             /*
             if (BIO_should_retry( _BIO ) )
@@ -328,7 +323,10 @@ csm::network::EndpointPTP_sec_base::Recv( csm::network::Message &aMsg )
             */
 
             // So I'll also return 0.
-            // But after my reading of the man page, I think there could be room for improvement here. 
+            
+            // Lars: return 0 is the correct behavior for the endpoint::recv call because 
+            // it means that currently there's not more data to receive so we shouldn't block on another recv call 
+            // and instead see if any other endpoint has inbound data or any outbound work is to be done.
 
             return 0;
           }

--- a/csmnet/src/CPP/multi_endpoint.cc
+++ b/csmnet/src/CPP/multi_endpoint.cc
@@ -107,9 +107,15 @@ csm::network::Endpoint* csm::network::MultiEndpoint::NewEndpoint( const csm::net
       break;
     case CSM_NETWORK_TYPE_AGGREGATOR:
       if( std::dynamic_pointer_cast<csm::network::EndpointOptionsPTP<csm::network::AddressAggregator>>(aOptions)->HasSSLInfo() )
+      {
+        LOG( csmnet, trace ) << "MultiEndpoint::NewEndpoint(): AGG attempting to connect sec";
         nEP = new csm::network::EndpointAggregator_sec( aAddr, aOptions );
+        LOG( csmnet, trace ) << "MultiEndpoint::NewEndpoint(): AGG sec complete";
+      }
       else
+      {
         nEP = new csm::network::EndpointAggregator_plain( aAddr, aOptions );
+      }
       break;
     case CSM_NETWORK_TYPE_UNKNOWN:
     case CSM_NETWORK_TYPE_ABSTRACT:


### PR DESCRIPTION
# Purpose
With the move to RH8, SSL coms for csm daemons wasn't working. This pull request and code change fixes SSL coms for CSM daemons. 

# Origin
https://github.ibm.com/CSM/team_process/issues/71

# How to Test
testing is described in https://github.ibm.com/CSM/team_process/issues/71

# Screenshots
results of testing and code screenshots are in https://github.ibm.com/CSM/team_process/issues/71
