### PR TITLE
Team process 80

### DIFF
--- a/csmi/src/diag/cmd/diag_run_end.c
+++ b/csmi/src/diag/cmd/diag_run_end.c
@@ -32,6 +32,8 @@
 
 #define EXPECTED_NUMBER_OF_ARGUMENTS 3
 
+#define API_PARAMETER_INPUT_TYPE csm_diag_run_end_input_t
+
 ///< For use as the usage variable in the input parsers.
 #define USAGE help
 
@@ -92,12 +94,11 @@ int main(int argc, char *argv[])
 	int opt;
 	int indexptr = 0;
 	int parameterCounter = 0;
-	
+
 	/*Set up data*/
-	csm_diag_run_end_input_t runEndData;
-	
-	csmutil_logging(debug, "%s-%d:", __FILE__, __LINE__);
-	csmutil_logging(debug, "  runEndData address: %p", &runEndData);
+	API_PARAMETER_INPUT_TYPE* input = NULL;
+	/* CSM API initialize and malloc function*/
+    csm_init_struct_ptr(API_PARAMETER_INPUT_TYPE, input);
 	
 	/*check optional args*/
 	while ((opt = getopt_long(argc, argv, "hv:i:r:s:", longopts, &indexptr)) != -1) {
@@ -115,7 +116,7 @@ int main(int argc, char *argv[])
 
 				if( optarg[0] == 't' || optarg[0] == '1' || optarg[0] == 'f' || optarg[0] == '0')
                 {
-					runEndData.inserted_ras = optarg[0];
+					input->inserted_ras = optarg[0];
 				}
                 else
                 {
@@ -129,13 +130,13 @@ int main(int argc, char *argv[])
             }
 			case 'r':
                 csm_optarg_test( "-r, --run_id", optarg, USAGE )
-                csm_str_to_int64( runEndData.run_id, optarg, arg_check, "-r, --run_id", USAGE) ;
+                csm_str_to_int64( input->run_id, optarg, arg_check, "-r, --run_id", USAGE) ;
 				parameterCounter++;
 				break;
 			case 's':
                 csm_optarg_test( "-s, --status", optarg, USAGE )
-                strncpy(runEndData.status, optarg,16);
-				runEndData.status[15] = '\0';
+                strncpy(input->status, optarg,16);
+				input->status[15] = '\0';
 				parameterCounter++;
 				break;
 			default:
@@ -171,11 +172,11 @@ int main(int argc, char *argv[])
 	//This will print out the contents of the struct that we will pass to the api
 	csmutil_logging(debug, "%s-%d:", __FILE__, __LINE__);
 	csmutil_logging(debug, "  csm_diag_run_end_input_t contains the following:");
-	csmutil_logging(debug, "    run_id:         %"PRId64, runEndData.run_id);
-	csmutil_logging(debug, "    diag_status:    %s", runEndData.status);
-	csmutil_logging(debug, "    inserted_ras:   %c", runEndData.inserted_ras);
+	csmutil_logging(debug, "    run_id:         %"PRId64, input->run_id);
+	csmutil_logging(debug, "    diag_status:    %s", input->status);
+	csmutil_logging(debug, "    inserted_ras:   %c", input->inserted_ras);
 	
-	return_value = csm_diag_run_end(&csm_obj, &runEndData);
+	return_value = csm_diag_run_end(&csm_obj, input);
     switch(return_value)
     {
         case CSMI_SUCCESS:

--- a/csmi/src/diag/cmd/diag_run_end.c
+++ b/csmi/src/diag/cmd/diag_run_end.c
@@ -182,6 +182,7 @@ int main(int argc, char *argv[])
         case CSMI_SUCCESS:
 			// this is only need in debug mode. commenting until we implement the debug print we discussed. 
             // printf("csm_diag_run_end has completed successfully!\n");
+        	printf("---\n# csm_diag_run_end has completed successfully!\n...\n");
             break;
 
         default:

--- a/csmi/src/diag/src/csmi_diag_run_end.c
+++ b/csmi/src/diag/src/csmi_diag_run_end.c
@@ -73,6 +73,9 @@ int csm_diag_run_end(csm_api_object **csm_obj, API_PARAMETER_INPUT_TYPE* input)
         return CSMERR_INVALID_PARAM;
     }
 
+    // Clamp the inserted_ras boolean.
+    input->inserted_ras = input->inserted_ras ? CSM_TRUE : CSM_FALSE;
+
     // EARLY RETURN
     // Construct the buffer.
     csm_serialize_struct(API_PARAMETER_INPUT_TYPE, input, &buffer, &buffer_length);


### PR DESCRIPTION
# Purpose
one of the diag test cases failed. it pointed to a fault in the daig run end api. after investigation we concluded that diag run api was not working correctly. this pull requests fixes the issue with diag run end. 

## Details
A struct was not properly initialized during an early phase of the api. This was not detected. got past a few levels into the api guts. and eventually caused a null buffer, which was causing the api to fail serialization and data packing. the issue was resolved and the struct was initialized.  

# Origin
https://github.ibm.com/CSM/team_process/issues/80

# How to Test
after the patch was applied
1. I ran a successful diag run end from the cmd line (could not do before)
2. I reproduced the original error case and then re ran and passed

# Screenshots
Before:
```
[root@c650f99p06 csmtest]# /opt/ibm/csm/hcdiag/bin/hcdiag_run.py --test ppping --target c650f99p36
INFO: xcat seems to be installed in /opt/xcat/bin. Running in Management mode
Health Check Diagnostics version 1.8.0, running on Linux 4.18.0-147.5.1.el8_1.ppc64le, c650f99p06 machine.
Using configuration file /opt/ibm/csm/hcdiag/etc/hcdiag.properties.
Using tests configuration file /opt/ibm/csm/hcdiag/etc/test.properties.
Health Check Diagnostics, run id 200430174558271501, initializing...
Validating command argument test.
Validating command argument target.
Allocation request successful, id= 1
Preparing to run ppping.
ppping started on 1 node(s) at 2020-04-30 17:46:00.650555. It might take up to 200s.
.
ppping ended on 1 node(s) at 2020-04-30 17:46:04.297983, rc= 0, elapsed time: 0:00:03.647428
ppping PASS on node c650f99p06, serial number: 1318C6A.
Request csmd to release the allocation 1.
Allocation 1 delete request successful.
Error invoking csmi csm_diag_run_end, rc= 99.
Health Check Diagnostics ended, exit code 0.
```

After fix: 

```
[root@c650f99p06 bin]# ./csm_node_attributes_update -n c650f99p18,c650f99p26,c650f99p28,c650f99p36 -s IN_SERVICE
---
# All 4 record(s) successfully updated.
...
[root@c650f99p06 bin]# 
[root@c650f99p06 bin]# cd ..
[root@c650f99p06 csm]# cd hcdiag/
bin/     etc/     README   samples/ tests/   
[root@c650f99p06 csm]# cd hcdiag/bin/
[root@c650f99p06 bin]# 
[root@c650f99p06 bin]# 
[root@c650f99p06 bin]# ./hcdiag_run.py --test ppping --target c650f99p36
INFO: xcat seems to be installed in /opt/xcat/bin. Running in Management mode
Health Check Diagnostics version 1.8.0, running on Linux 4.18.0-147.5.1.el8_1.ppc64le, c650f99p06 machine.
Using configuration file /opt/ibm/csm/hcdiag/etc/hcdiag.properties.
Using tests configuration file /opt/ibm/csm/hcdiag/etc/test.properties.
Health Check Diagnostics, run id 200514135617607265, initializing...
Validating command argument test.
Validating command argument target.
Allocation request successful, id= 1
Preparing to run ppping.
ppping started on 1 node(s) at 2020-05-14 13:56:20.041754. It might take up to 200s.
.
ppping ended on 1 node(s) at 2020-05-14 13:56:23.724430, rc= 0, elapsed time: 0:00:03.682676
ppping PASS on node c650f99p06, serial number: 1318C6A.
Request csmd to release the allocation 1.
Allocation 1 delete request successful.
Health Check Diagnostics ended, exit code 0.
[root@c650f99p06 bin]#
```
