### PR TITLE
team process 81

### DIFF
--- a/hcdiag/src/tests/chk-sys-firmware/chk-sys-firmware.pm
+++ b/hcdiag/src/tests/chk-sys-firmware/chk-sys-firmware.pm
@@ -115,7 +115,7 @@ sub checkFirmware {
    #   errors on no match at all
    #
    # check the firmware levels.
-   for my $node (sort keys $firmware) {
+   for my $node (sort keys %$firmware) {
       my $fnode = $firmware->{$node};
       my $err=0;
       my $nodeCfg = $Clustconf->findNodeCfg($node);
@@ -206,7 +206,7 @@ sub checkFirmware {
          $errNodes->{$node} = $node;
       }
    }
-   my @errNodesArray=sort(keys($errNodes));
+   my @errNodesArray=sort(keys(%$errNodes));
    return(\@errNodesArray, $errs);
 }
 


### PR DESCRIPTION
- working on https://github.ibm.com/CSM/team_process/issues/81

# Purpose
RHEL8.1FVT hcdiag Test Case 23: chk-sys-firmware was failing due to perl error. This pull request resolves that error on RH8. 

## Details

I believe the core issue was "keys" wasn't getting the input it was expecting. `sort(keys($errNodes))` is one of the 2 examples. we ended up de referencing the variable. `sort(keys(%$errNodes))` which resolved the issue on RH8. research, explainations, and thought process can be found in the main issue.

more details and the thought process can be found here: https://github.ibm.com/CSM/team_process/issues/81

# Approach
see: https://github.ibm.com/CSM/team_process/issues/81

# Origin
https://github.ibm.com/CSM/team_process/issues/81

# How to Test
- I re ran `buckets/basic/hcdiag.sh ` on RH8. and no longer saw the issues and logs @besawn documented. I also saw pass in the screenshot below. 

```
Test Case 22: chk-cpu-count:                                    PASS
Test Case 23: chk-sys-firmware:                                 PASS
Test Case 24: chk-memory:                                       FAILED
Test Case 25: chk-aslr:                                         PASS
```

test case 23 reports pass.

# ToDos:
- [x] run regression for this on the RH7 air machines (Nate)