### PR TITLE
Fix rmmod export_layout OOPs when in use by bbproxy

### DIFF
--- a/bb/src/bbproxy.cc
+++ b/bb/src/bbproxy.cc
@@ -4891,6 +4891,18 @@ int bb_main(std::string who)
     /* Perform any clean-up of existing logical volumes */
     logicalVolumeCleanup();
 
+    /* Seize /dev/export_layout so rmmod fails on in-use while daemon is running */
+    int inuse_fd = -1;
+    if(config.get(process_whoami+".use_export_layout", false)){
+        inuse_fd=open("/dev/export_layout", O_RDWR | O_CLOEXEC, 0);
+        if (inuse_fd<0){
+            LOG(bb,always) << "/dev/export_layout failure errno=" << errno;
+            throw runtime_error(string("Check export_layout module installation.  Open failed with errno=") + to_string(errno));
+        }
+          
+    }
+      
+
     rc = setupUnixConnections(process_whoami);
     if(rc)
     {

--- a/bb/src/bbproxy.cc
+++ b/bb/src/bbproxy.cc
@@ -4843,7 +4843,7 @@ int registerHandlers()
     return 0;
 }
 
-
+static  int inuse_fd = -1;
 char LVM_SUPPRESS[] = "LVM_SUPPRESS_FD_WARNINGS=1";  // note: ownership of this string is moved to ENV during putenv() call.
 int setupUnixConnections(string whoami);
 int bb_main(std::string who)
@@ -4892,7 +4892,6 @@ int bb_main(std::string who)
     logicalVolumeCleanup();
 
     /* Seize /dev/export_layout so rmmod fails on in-use while daemon is running */
-    int inuse_fd = -1;
     if(config.get(process_whoami+".use_export_layout", false)){
         inuse_fd=open("/dev/export_layout", O_RDWR | O_CLOEXEC, 0);
         if (inuse_fd<0){
@@ -4925,6 +4924,7 @@ int bb_exit(std::string who)
     ENTRY_NO_CLOCK(__FILE__,__FUNCTION__);
 
 //    printf("bb_exit: who = %s\n", who.c_str());
+    close(inuse_fd);
     if (!who.empty() )
     {
         try

--- a/bb/src/bbproxy.cc
+++ b/bb/src/bbproxy.cc
@@ -4924,7 +4924,7 @@ int bb_exit(std::string who)
     ENTRY_NO_CLOCK(__FILE__,__FUNCTION__);
 
 //    printf("bb_exit: who = %s\n", who.c_str());
-    close(inuse_fd);
+    if (inuse_fd>=0) close(inuse_fd);
     if (!who.empty() )
     {
         try

--- a/export_layout/src/export_layout.c
+++ b/export_layout/src/export_layout.c
@@ -57,9 +57,9 @@
 #endif
 
 #if (LINUX_VERSION_CODE >=  KERNEL_VERSION(4,18,0))
-#define EXP_VERSION "1.8.1.1.R8"
+#define EXP_VERSION "1.8.1.2.R8"
 #else
-#define EXP_VERSION "1.8.1.1.R7"
+#define EXP_VERSION "1.8.1.2.R7"
 #endif 
 
 MODULE_LICENSE("GPL");
@@ -235,7 +235,7 @@ static int export_layout_open(struct inode *inodep, struct file *filep)
 	if (!t)
 		return -ENOMEM;
 	filep->private_data = t;
-        __module_get(THIS_MODULE);
+        try_module_get(THIS_MODULE);
 	return 0;
 }
 

--- a/export_layout/src/export_layout.c
+++ b/export_layout/src/export_layout.c
@@ -57,9 +57,9 @@
 #endif
 
 #if (LINUX_VERSION_CODE >=  KERNEL_VERSION(4,18,0))
-#define EXP_VERSION "1.8.1.R8"
+#define EXP_VERSION "1.8.1.1.R8"
 #else
-#define EXP_VERSION "1.8.1.R7"
+#define EXP_VERSION "1.8.1.1.R7"
 #endif 
 
 MODULE_LICENSE("GPL");
@@ -235,6 +235,7 @@ static int export_layout_open(struct inode *inodep, struct file *filep)
 	if (!t)
 		return -ENOMEM;
 	filep->private_data = t;
+        __module_get(THIS_MODULE);
 	return 0;
 }
 
@@ -266,6 +267,7 @@ static int export_layout_release(struct inode *inodep, struct file *filep)
     	    printk(KERN_DEBUG "%s: completed fd=%d pid=%d mainpid=%d\n", __func__, t->fd, current->pid,current->tgid);
 	}
 	kfree(t);
+        module_put(THIS_MODULE);
 	return 0;
 }
 


### PR DESCRIPTION
export_layout is now marked in use when /dev/export_layout is opened.  If export_layout was removed after an open against /dev/export_layout, the close (release) would OOPs.  Other OOPs situations were possible.  The use count is incremented on open and decrement on release.

bbproxy was changed to do a dummy action of open export_layout early to seize it so it could not be removed.  If /dev/export_layout could not be opened, bbproxy quits on the early discovery.