### PR TITLE
Updated csm_api.cfg file to contain more appropriate default values

### DIFF
--- a/csmconf/csm_api.cfg
+++ b/csmconf/csm_api.cfg
@@ -1,12 +1,12 @@
 {
    "#comment_1" : "This will be ignored",
-   "csm_allocation_create" : 160,
-   "csm_allocation_delete" : 160,
-   "csm_allocation_update_state" : 160,
+   "csm_allocation_create" : 300,
+   "csm_allocation_delete" : 300,
+   "csm_allocation_update_state" : 300,
    "csm_allocation_step_end" : 120,
    "csm_allocation_step_begin" : 120,
    "csm_allocation_query" : 120,
-   "csm_bb_cmd" : 120,
+   "csm_bb_cmd" : 480,
    "csm_jsrun_cmd" : 60,
    "csm_soft_failure_recovery" : 240
 }

--- a/csmtest/include/prologs/privileged_epilog_timeout
+++ b/csmtest/include/prologs/privileged_epilog_timeout
@@ -204,7 +204,7 @@ def main():
     ''' Parse the user and system flags supplied to this script. '''
     logger.info( "Epilog script begin." )
    
-    time.sleep(125)
+    time.sleep(245)
  
     #: The return code of this script.
     ret_code = 0

--- a/csmtest/include/prologs/privileged_prolog_timeout
+++ b/csmtest/include/prologs/privileged_prolog_timeout
@@ -204,7 +204,7 @@ def main():
     ''' Parse the user and system flags supplied to this script. '''
     logger.info( "Prolog script begin." )
 
-    time.sleep(125)    
+    time.sleep(245)    
 
     #: The return code of this script.
     ret_code = 0


### PR DESCRIPTION
The previous default values in csm_api.cfg can sometimes lead to premature timeouts in some situations. This PR increases the default timeouts of several CSM APIs to safer default values. 

These values may still require tuning in a production system based on cluster specific timings.
For example, worst case times for prolog and epilog script completion need to be factored in to the overall csm_allocation_create, csm_allocation_delete, and csm_allocation_update_state timeouts.

After adjusting the time out values, two FVT test cases failed due to sleeping for an insufficient length of time to trigger the csm_allocation_create and csm_allocation_delete time outs:
```
/test/results/buckets/error_injection/allocation.log:Test Case 6: csm_allocation_create prolog error timeout:                                               FAILED

/test/results/buckets/error_injection/allocation.log:Test Case 46: csm_allocation_delete epilog timeout error:                                              FAILED
```

I also repaired the two test cases above so those tests now pass with the new default values.