### PR TITLE
CSM updates related to DCGM 2.0.4-1 regression testing

### DIFF
--- a/csmd/dcgm.cmake
+++ b/csmd/dcgm.cmake
@@ -36,7 +36,10 @@
 # CSM GA version:
 # datacenter-gpu-manager-1.4.0-1.ppc64le 
 # datacenter-gpu-manager-1.4.1-1.ppc64le
-set(REQUIRED_DCGM_VERSION "datacenter-gpu-manager-1.6")
+# set(REQUIRED_DCGM_VERSION "datacenter-gpu-manager-1.6")
+# CSM 1.8 version:
+# datacenter-gpu-manager-2.0.4-1.ppc64le
+set(REQUIRED_DCGM_VERSION "datacenter-gpu-manager")
 
 # Check if DCGM is installed
 execute_process(COMMAND "/usr/bin/rpm" "-q" "datacenter-gpu-manager"

--- a/csmd/src/inv/src/inv_dcgm_access.cc
+++ b/csmd/src/inv/src/inv_dcgm_access.cc
@@ -118,7 +118,7 @@ csm::daemon::INV_DCGM_ACCESS::~INV_DCGM_ACCESS()
      rc = (*dcgmDisconnect_ptr)(dcgm_handle);
      if (rc != DCGM_ST_OK)
      {
-        LOG(csmd, error) << "Error: dcgmDisconnect returned \"" << errorString(rc) << "(" << rc << ")\"";
+        LOG(csmd, error) << "Error: dcgmDisconnect returned " << rc;
      } else {
         LOG(csmd, debug) << "dcgmDisconnect was successful";
      }
@@ -126,7 +126,7 @@ csm::daemon::INV_DCGM_ACCESS::~INV_DCGM_ACCESS()
      rc = (*dcgmShutdown_ptr)();
      if (rc != DCGM_ST_OK)
      {
-	LOG(csmd, error) << "Error: dcgmShutdown returned \"" << errorString(rc) << "(" << rc << ")\"";
+	LOG(csmd, error) << "Error: dcgmShutdown returned " << rc;
      } else {
         LOG(csmd, debug) << "dcgmShutdown was successful";
      }
@@ -219,7 +219,7 @@ void csm::daemon::INV_DCGM_ACCESS::Init()
     rc = (*dcgmInit_ptr)();
     if (rc != DCGM_ST_OK)
     {
-	LOG(csmd, error) << "Error: dcgmInit returned \"" << errorString(rc) << "(" << rc << ")\"";
+	LOG(csmd, error) << "Error: dcgmInit returned " << rc;
         dcgm_init_flag = false;
         return;
     } else {
@@ -231,7 +231,7 @@ void csm::daemon::INV_DCGM_ACCESS::Init()
     free( ipAddress) ;
     if (rc != DCGM_ST_OK)
     {
-        LOG(csmd, error) << "Error: dcgmConnect returned \"" << errorString(rc) << "(" << rc << ")\"";
+        LOG(csmd, error) << "Error: dcgmConnect returned " << rc;
         dcgm_init_flag = false;
         return;
     } else {
@@ -241,7 +241,7 @@ void csm::daemon::INV_DCGM_ACCESS::Init()
     rc = (*dcgmGetAllDevices_ptr)(dcgm_handle, gpu_ids, &dcgm_gpu_count);
     if (rc != DCGM_ST_OK)
     {
-	LOG(csmd, error) << "Error: dcgmGetAllDevices returned \"" << errorString(rc) << "(" << rc << ")\"";
+	LOG(csmd, error) << "Error: dcgmGetAllDevices returned " << rc;
         dcgm_init_flag = false;
         return;
     } else {
@@ -325,7 +325,7 @@ void csm::daemon::INV_DCGM_ACCESS::Init()
       max_keep_age, max_keep_samples);
     if (rc != DCGM_ST_OK)
     {
-        LOG(csmenv, error) << "Error: dcgmWatchFields returned \"" << errorString(rc) << "(" << rc << ")\"";
+        LOG(csmenv, error) << "Error: dcgmWatchFields returned " << rc;
         dcgm_init_flag = false;
         return;
     }
@@ -338,7 +338,7 @@ void csm::daemon::INV_DCGM_ACCESS::Init()
     rc = (*dcgmWatchJobFields_ptr)(dcgm_handle, (dcgmGpuGrp_t) DCGM_GROUP_ALL_GPUS, update_frequency, max_keep_age, max_keep_samples);
     if (rc != DCGM_ST_OK)
     {
-        LOG(csmenv, error) << "Error: dcgmWatchJobFields returned \"" << errorString(rc) << "(" << rc << ")\"";
+        LOG(csmenv, error) << "Error: dcgmWatchJobFields returned " << rc;
         dcgm_init_flag = false;
         return;
     }
@@ -373,7 +373,7 @@ void csm::daemon::INV_DCGM_ACCESS::Init()
     rc = (*dcgmUpdateAllFields_ptr)(dcgm_handle, 1);
     if (rc != DCGM_ST_OK)
     {
-        LOG(csmenv, error) << "Error: dcgmUpdateAllFields returned \"" << errorString(rc) << "(" << rc << ")\"";
+        LOG(csmenv, error) << "Error: dcgmUpdateAllFields returned " << rc;
         dcgm_init_flag = false;
         return;
     }
@@ -704,7 +704,7 @@ bool csm::daemon::INV_DCGM_ACCESS::GetGPUsAttributes(){
     if (rc != DCGM_ST_OK)
     {
 	// the get gpu attributes for this gpu failed
-        LOG(csmd, error) << "Error: dcgmGetDeviceAttributes for gpu_id=" << gpu_ids[i] << " returned \"" << errorString(rc) << "(" << rc << ")\"";
+        LOG(csmd, error) << "Error: dcgmGetDeviceAttributes for gpu_id=" << gpu_ids[i] << " returned " << rc;
         return false;
 
     }
@@ -747,7 +747,7 @@ bool csm::daemon::INV_DCGM_ACCESS::ReadAllocationFields()
       rc = (*dcgmWatchFields_ptr)(dcgm_handle, (dcgmGpuGrp_t) DCGM_GROUP_ALL_GPUS, csm_allocation_field_group_handle, update_frequency, max_keep_age, max_keep_samples);
       if (rc != DCGM_ST_OK)
       {
-         LOG(csmenv, error) << "Error: dcgmWatchFields returned \"" << errorString(rc) << "(" << rc << ")\"";
+         LOG(csmenv, error) << "Error: dcgmWatchFields returned " << rc;
          return false;
       }
       else 
@@ -761,7 +761,7 @@ bool csm::daemon::INV_DCGM_ACCESS::ReadAllocationFields()
       rc = (*dcgmUpdateAllFields_ptr)(dcgm_handle, 1);
       if (rc != DCGM_ST_OK)
       {
-         LOG(csmenv, error) << "Error: dcgmUpdateAllFields returned \"" << errorString(rc) << "(" << rc << ")\"";
+         LOG(csmenv, error) << "Error: dcgmUpdateAllFields returned " << rc;
          return false;
       }
 
@@ -774,7 +774,7 @@ bool csm::daemon::INV_DCGM_ACCESS::ReadAllocationFields()
          rc = (*dcgmGetLatestValuesForFields_ptr)(dcgm_handle, gpu_ids[i], CSM_ALLOCATION_FIELDS, CSM_ALLOCATION_FIELD_COUNT, csm_allocation_field_values);
          if (rc != DCGM_ST_OK)
          {
-            LOG(csmenv, error) << "Error: dcgmGetLatestValuesForFields for gpu_id=" << gpu_ids[i] << " returned \"" << errorString(rc) << "(" << rc << ")\"";
+            LOG(csmenv, error) << "Error: dcgmGetLatestValuesForFields for gpu_id=" << gpu_ids[i] << " returned " << rc;
             return false;
          }
          else
@@ -807,7 +807,7 @@ bool csm::daemon::INV_DCGM_ACCESS::ReadAllocationFields()
       rc = (*dcgmUnwatchFields_ptr)(dcgm_handle, (dcgmGpuGrp_t) DCGM_GROUP_ALL_GPUS, csm_allocation_field_group_handle);
       if (rc != DCGM_ST_OK)
       {
-         LOG(csmenv, error) << "Error: dcgmUnwatchFields returned \"" << errorString(rc) << "(" << rc << ")\"";
+         LOG(csmenv, error) << "Error: dcgmUnwatchFields returned " << rc;
       }
       else 
       {
@@ -852,7 +852,7 @@ bool csm::daemon::INV_DCGM_ACCESS::CollectGpuData(std::list<boost::property_tree
          csm_environmental_field_values);
       if (rc != DCGM_ST_OK)
       {
-         LOG(csmenv, error) << "Error: dcgmGetLatestValuesForFields for gpu_id=" << gpu_ids[i] << " returned \"" << errorString(rc) << "(" << rc << ")\"";
+         LOG(csmenv, error) << "Error: dcgmGetLatestValuesForFields for gpu_id=" << gpu_ids[i] << " returned " << rc;
          return false;
       }
       else
@@ -954,7 +954,7 @@ bool csm::daemon::INV_DCGM_ACCESS::StartAllocationStats(const int64_t &i_allocat
    rc = (*dcgmJobStartStats_ptr)(dcgm_handle, (dcgmGpuGrp_t) DCGM_GROUP_ALL_GPUS, csm_job_stats_name);
    if (rc != DCGM_ST_OK)
    {
-      LOG(csmenv, error) << "Error: dcgmJobStartStats returned \"" << errorString(rc) << "(" << rc << ")\"";
+      LOG(csmenv, error) << "Error: dcgmJobStartStats returned " << rc;
       return false;
    }
    else 
@@ -987,7 +987,7 @@ bool csm::daemon::INV_DCGM_ACCESS::StopAllocationStats(const int64_t &i_allocati
    rc = (*dcgmJobStopStats_ptr)(dcgm_handle, csm_job_stats_name);
    if (rc != DCGM_ST_OK)
    {
-      LOG(csmenv, error) << "Error: dcgmJobStopStats returned \"" << errorString(rc) << "(" << rc << ")\"";
+      LOG(csmenv, error) << "Error: dcgmJobStopStats returned " << rc;
       return false;
    }
    else 
@@ -1001,7 +1001,7 @@ bool csm::daemon::INV_DCGM_ACCESS::StopAllocationStats(const int64_t &i_allocati
    rc = (*dcgmJobGetStats_ptr)(dcgm_handle, csm_job_stats_name, &dcgm_job_stats);
    if (rc != DCGM_ST_OK)
    {
-      LOG(csmenv, error) << "Error: dcgmJobGetStats returned \"" << errorString(rc) << "(" << rc << ")\"";
+      LOG(csmenv, error) << "Error: dcgmJobGetStats returned " << rc;
       return false;
    }
    else 
@@ -1075,7 +1075,7 @@ bool csm::daemon::INV_DCGM_ACCESS::StopAllocationStats(const int64_t &i_allocati
    rc = (*dcgmJobRemove_ptr)(dcgm_handle, csm_job_stats_name);
    if (rc != DCGM_ST_OK)
    {
-      LOG(csmenv, error) << "Error: dcgmJobRemove returned \"" << errorString(rc) << "(" << rc << ")\"";
+      LOG(csmenv, error) << "Error: dcgmJobRemove returned " << rc;
       return false;
    }
    else 
@@ -1121,7 +1121,7 @@ bool csm::daemon::INV_DCGM_ACCESS::CreateCsmFieldGroup(const uint32_t field_coun
    rc = (*dcgmFieldGroupCreate_ptr)(dcgm_handle, field_count, fields, field_group_name, field_group_handle);
    if (rc != DCGM_ST_OK)
    {
-      LOG(csmenv, error) << "Error: dcgmFieldGroupCreate returned \"" << errorString(rc) << "(" << rc << ")\"";
+      LOG(csmenv, error) << "Error: dcgmFieldGroupCreate returned " << rc;
       return false;
    }
    else 

--- a/csmtest/buckets/advanced/allocation_timing.py
+++ b/csmtest/buckets/advanced/allocation_timing.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python2
+#!/bin/sh
 # encoding: utf-8
 #================================================================================
 #
 #    allocation_timing.py 
 #
-#  © Copyright IBM Corporation 2015-2018. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -14,6 +14,17 @@
 #    restricted by GSA ADP Schedule Contract with IBM Corp.
 #
 #================================================================================
+
+# The beginning of this script is both valid shell and valid python,
+# such that the script starts with the shell and is reexecuted with
+# the right python.
+#
+# On RHEL 7, CSM uses a version of boost-python dependent on python2
+# On RHEL 8, CSM uses a version of boost-python dependent on python3
+# The intent is to run as python3 on RHEL8 and python2 on RHEL7
+#
+'''which' python3 > /dev/null 2>&1 && exec python3 "$0" "$@" || exec python2 "$0" "$@"
+'''
 
 import sys
 import os

--- a/hcdiag/src/tests/common/functions
+++ b/hcdiag/src/tests/common/functions
@@ -2,7 +2,7 @@
 #   
 #    hcdiag/src/tests/common/functions
 # 
-#  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -23,13 +23,16 @@ P9_PVR=( 004e 004f )
 # Firestone, Garrison, Witherspoon (GTC - air cooled and GTW) and Bostons 
 # 9006-22C: Management, Gateway, Big Data nodes
 # 5104-22C: ESS IO node
-SUPPORTED_MODELS=( 8335-GTA 8335-GTB 8335-GTC 8335-GTW 9006-22C 5104-22C 8335-GTX )
+# Firestone, Garrison, Witherspoon (GTC - air cooled and GTW) and Bostons
+# 9006-22C: Management, Gateway, Big Data nodes
+# 5104-22C: ESS IO node
+SUPPORTED_MODELS=( 8335-GTA 8335-GTB 8335-GTC 8335-GTW 9006-22C 5104-22C 8335-GTX 8335-GTH )
 FIRESTONE=( 8335-GTA )
 GARRISON=( 8335-GTB )
-WITHERSPOON=( 8335-GTC 8335-GTW 8335-GTX )
+WITHERSPOON=( 8335-GTC 8335-GTW 8335-GTX 8335-GTH )
 BOSTON=( 9006-22C 5104-22C )
-AIR_COOLED=( 8335-GTC ) 
-WATER_COOLED=( 8335-GTW )
+AIR_COOLED=( 8335-GTC 8335-GTH )
+WATER_COOLED=( 8335-GTW 8335-GTX )
 
 # ====================================================================================
 # This function check what type of the processor the machine has, using /proc/cpuinfo file

--- a/hcdiag/src/tests/common/functions
+++ b/hcdiag/src/tests/common/functions
@@ -23,9 +23,6 @@ P9_PVR=( 004e 004f )
 # Firestone, Garrison, Witherspoon (GTC - air cooled and GTW) and Bostons 
 # 9006-22C: Management, Gateway, Big Data nodes
 # 5104-22C: ESS IO node
-# Firestone, Garrison, Witherspoon (GTC - air cooled and GTW) and Bostons
-# 9006-22C: Management, Gateway, Big Data nodes
-# 5104-22C: ESS IO node
 SUPPORTED_MODELS=( 8335-GTA 8335-GTB 8335-GTC 8335-GTW 9006-22C 5104-22C 8335-GTX 8335-GTH )
 FIRESTONE=( 8335-GTA )
 GARRISON=( 8335-GTB )


### PR DESCRIPTION
This PR contains several small changes related to regression testing with datacenter-cpu-manager 2.0.

- Modified the REQUIRED_DCGM_VERSION to allow building against any installed version of DCGM.
- Removed references to the utility function errorString() provided by DCGM due to a change in the function signature between DCGM 1.X and 2.X that makes maintaining compatibility difficult.
- Updated the CSM FVT allocation_timing.py script so it will run with either python2 or python3, using whichever version is installed.
- Added a few additional models to the hcdiag supported models.