### PR TITLE
Modified the cmake files to reflect the schema version 19.0 changes.

### DIFF
--- a/csmdb/sql/CMakeLists.txt
+++ b/csmdb/sql/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmdb/sql/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -23,7 +23,7 @@ file(GLOB INSTALL_PROGRAMS
   "csm_db_stats.sh"
   "csm_db_connections_script.sh"
   "csm_db_ras_type_script.sh"
-  "csm_db_schema_version_upgrade_18_0.sh"
+  "csm_db_schema_version_upgrade_19_0.sh"
   "csm_db_backup_script_v1.sh"
   "csm_db_history_archive.py"
   "csm_db_history_delete.py"

--- a/csmdb/sql/csm_db_migration_scripts/CMakeLists.txt
+++ b/csmdb/sql/csm_db_migration_scripts/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #    csmdb/sql/csm_db_migration_scripts/CMakeLists.txt
 #
-#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -28,5 +28,6 @@ file(GLOB INSTALL_FILES
   "csm_db_schema_updates_16_2_ms.sql"
   "csm_db_schema_updates_17_0_ms.sql"
   "csm_db_schema_updates_18_0_ms.sql"
+  "csm_db_schema_updates_19_0_ms.sql"
 )
 install(FILES ${INSTALL_FILES} COMPONENT ${DB_RPM_NAME} DESTINATION ${DB_BASE_NAME}/${SUBDIR})


### PR DESCRIPTION
# Purpose
_This change will include the schema 19.0 files (csmdb/sql/CMakeLists.txt) & (csmdb/sql/csm_db_migration_scripts/CMakeLists.txt )_

# How to Test
We have to respin a build to reflect the changes and confirm all files are included in the release.

# IST
I gave an immediate fix to the IST team so they can continue their testing.