### PR TITLE
Bump version number to 1.8.1 to prepare to rebuild with datacenter-gpu-manager-2.0.10-1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (ibm)
 
 set(BUILDID_RELEASE    1)
 set(BUILDID_CUMULFIXID 8)
-set(BUILDID_EFIXID     0)
+set(BUILDID_EFIXID     1)
 
 execute_process(
   COMMAND git rev-list --count HEAD


### PR DESCRIPTION
Changes in the GA version of NVIDIA datacenter-gpu-manager-2.0.10-1 require CSM 1.8.0 to be rebuilt against the updated header files in included in datacenter-gpu-manager-2.0.10-1 for successful integration of the two products.

This pull request bumps the CAST rpm version number to prepare for the rebuild.

Note: The DCGM rpm name is `datacenter-gpu-manager-2.0.10-1`, but it reports the version number as `datacenter-gpu-manager-2.0.8-1` via rpm commands once it is installed.