### PR TITLE
Added csm_init_struct to csm_allocation_step_end to fix Message packing error after building with --type=Release

### DIFF
--- a/csmi/src/wm/cmd/allocation_step_end.c
+++ b/csmi/src/wm/cmd/allocation_step_end.c
@@ -2,7 +2,7 @@
 
     csmi/src/wm/cmd/allocation_step_end.c
 
-  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -116,6 +116,7 @@ int main(int argc, char *argv[])
 	
 	/*Set up test data*/
     API_PARAMETER_INPUT_TYPE input;
+	csm_init_struct(API_PARAMETER_INPUT_TYPE, input);
 	csm_init_struct_ptr(csmi_allocation_step_history_t, input.history);
 	
 	/*Variables for checking cmd line args*/


### PR DESCRIPTION
While testing the release build of CSM 1.8.1, the following problem was discovered via CSM FVT regression test:

```
/test/results/buckets/basic/step.log:Test Case 5:  Calling csm_allocation_step_end                  (allocation_id: 4 step_id: 1):          FAILED
/test/results/buckets/basic/step_tmp.log:(null) FAILED: errcode: 28 errmsg: Message packing error
```
The problem only occurs when building the release rpms using the following process on RHEL 8.X:
`scripts/configure.pl --type=Release --mincmake=3.6 --rpmbuild --parallel; scripts/rebuild noinstall package`
and does not reproduce when building without the `--type=Release` flag:
`scripts/configure.pl --mincmake=3.6 --rpmbuild --parallel; scripts/rebuild noinstall package`

This problem is due to allocation_step_end.c failing to explicitly initialize the version metadata in the `input` struct. The problem only manifests on RHEL 8.X when building with `--type=Release`. After explicitly initializing the `input` struct, the tests pass successfully.