### PR TITLE
Updated CSM SSD inventory collection to look for the ssd size in a new location for RHEL 8

### DIFF
--- a/csmi/src/wm/cmd/allocation_step_end.c
+++ b/csmi/src/wm/cmd/allocation_step_end.c
@@ -2,7 +2,7 @@
 
     csmi/src/wm/cmd/allocation_step_end.c
 
-  © Copyright IBM Corporation 2015,2016. All Rights Reserved
+  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 
     This program is licensed under the terms of the Eclipse Public License
     v1.0 as published by the Eclipse Foundation and available at
@@ -116,6 +116,7 @@ int main(int argc, char *argv[])
 	
 	/*Set up test data*/
     API_PARAMETER_INPUT_TYPE input;
+	csm_init_struct(API_PARAMETER_INPUT_TYPE, input);
 	csm_init_struct_ptr(csmi_allocation_step_history_t, input.history);
 	
 	/*Variables for checking cmd line args*/


### PR DESCRIPTION
This PR is a first pass at addressing https://github.com/IBM/CAST/issues/945. As progress is currently blocked in a customer environment, I implemented a quick and low risk fix for now. Long term it may be better to try to address this in a more future proof manner.

The root cause is a change in the path name that CSM is reading to determine the SSD size information between RHEL 7 and RHEL 8.

On RHEL 7, this information was retrieved from paths that looked like:
```
/sys/class/nvme/nvme0/nvme0n1/size
```
But on RHEL 8, these paths have changed to include some extra characters in the device name:
```
/sys/class/nvme/nvme0/nvme0c0n1/size
```

Note: this new name does not correspond to the device name reported by the `nvme-cli` utility:
```
# nvme list
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev  
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     S3RVNA0K400104       PCIe3 1.6TB NVMe Flash Adapter II x8     1           1.60  TB /   1.60  TB      4 KiB +  0 B   MN12MN12
```

Test output:

Before, without the fix on RHEL 8.2:
```
[root@c650f99p26 ~]#/opt/ibm/csm/bin/csm_node_attributes_query_details -n c650f99p26 | tail -n 13
  ssds_count:                   1
  ssds:
    - serial_number:                 S3RVNA0K400104
      update_time:                   2020-08-17 11:07:49.865951
      device_name:                   PCIe3 1.6TB NVMe Flash Adapter II x8
      fw_ver:                        MN12MN12
      pci_bus_id:                    0030:01:00.0
      size:                          -1
      wear_lifespan_used:            0.000000
      wear_total_bytes_read:         4817353728000
      wear_total_bytes_written:      3748815360000
      wear_percent_spares_remaining: 100.000000
...
```

After, with the fix contained in this PR on RHEL 8.2:
```
[root@c650f99p26 ~]# /opt/ibm/csm/bin/csm_node_attributes_query_details -n c650f99p26 | tail -n 13
  ssds_count:                   1
  ssds:
    - serial_number:                 S3RVNA0K400104
      update_time:                   2020-08-17 15:53:34.40598
      device_name:                   PCIe3 1.6TB NVMe Flash Adapter II x8
      fw_ver:                        MN12MN12
      pci_bus_id:                    0030:01:00.0
      size:                          1600321314816
      wear_lifespan_used:            0.000000
      wear_total_bytes_read:         4817353728000
      wear_total_bytes_written:      3748815360000
      wear_percent_spares_remaining: 100.000000
...
```
