### PR TITLE
CSM RHEL 8: updated rpm install script to change ordering of libcsmpam.so session entry in /etc/pam.d/sshd

### DIFF
--- a/csmd/rpmscripts/csmd.post.install
+++ b/csmd/rpmscripts/csmd.post.install
@@ -8,25 +8,39 @@ if [ -f /etc/pam.d/sshd ]
 then
     mv -f /etc/pam.d/sshd /etc/pam.d/.sshd.bak
     IFS=$'\n'
-    line_found="FALSE"
+    account_line_found="FALSE"
+    session_line_found="FALSE"
 
-    # Iterate over sshd and insert the account before the account password authentication.
+    # Iterate over sshd and insert the account before the account password authentication
+    # and session before session postlogin
     for line in `cat /etc/pam.d/.sshd.bak`
     do
         if [ "account    include      password-auth" == ${line} ]
         then
             echo "#account    required     libcsmpam.so" >> /etc/pam.d/sshd
-            line_found="TRUE"
+            account_line_found="TRUE"
         fi
+
+        if [ "session    include      postlogin" == ${line} ]
+        then
+            echo "#session    required     libcsmpam.so" >> /etc/pam.d/sshd
+            session_line_found="TRUE"
+        fi
+
         echo ${line} >> /etc/pam.d/sshd
     done
 
-    # If the account wasn't written write it. 
-    if [ ${line_found} == "FALSE" ]
+    # If the account wasn't written write it.
+    if [ ${account_line_found} == "FALSE" ]
     then
         echo "#account    required     libcsmpam.so" >> /etc/pam.d/sshd
     fi
-    echo "#session    required     libcsmpam.so" >> /etc/pam.d/sshd
+
+    # If the session wasn't written write it.
+    if [ ${session_line_found} == "FALSE" ]
+    then
+        echo "#session    required     libcsmpam.so" >> /etc/pam.d/sshd
+    fi
 
     # Initialize the csm directory.
     mkdir -p /etc/pam.d/csm


### PR DESCRIPTION
This PR addresses https://github.com/IBM/CAST/issues/946 by altering the suggested order of these two lines in `/etc/pam.d/sshd`:
```
#session    required     libcsmpam.so
session    include      postlogin
```

Prior to this change, the `ibm-csm-core` rpm postinstall script was inserting the libcsmpam.so lines into `/etc/pam.d/sshd` like this:
```
# cat /etc/pam.d/sshd
#%PAM-1.0
auth       substack     password-auth
auth       include      postlogin
account    required     pam_sepermit.so
account    required     pam_nologin.so
#account    required     libcsmpam.so
account    include      password-auth
password   include      password-auth
# pam_selinux.so close should be the first session rule
session    required     pam_selinux.so close
session    required     pam_loginuid.so
# pam_selinux.so open should only be followed by sessions to be executed in the user context
session    required     pam_selinux.so open env_params
session    required     pam_namespace.so
session    optional     pam_keyinit.so force revoke
session    optional     pam_motd.so
session    include      password-auth
session    include      postlogin
#session    required     libcsmpam.so
```

The change included in this PR reverses the last two lines, so the file now looks like this after install:
```
[root@c650f99p36 ~]# cat /etc/pam.d/sshd
#%PAM-1.0
auth       substack     password-auth
auth       include      postlogin
account    required     pam_sepermit.so
account    required     pam_nologin.so
#account    required     libcsmpam.so
account    include      password-auth
password   include      password-auth
# pam_selinux.so close should be the first session rule
session    required     pam_selinux.so close
session    required     pam_loginuid.so
# pam_selinux.so open should only be followed by sessions to be executed in the user context
session    required     pam_selinux.so open env_params
session    required     pam_namespace.so
session    optional     pam_keyinit.so force revoke
session    optional     pam_motd.so
session    include      password-auth
#session    required     libcsmpam.so
session    include      postlogin
```

I then confirmed that user ssh sessions were placed into the correct allocation cgroup after uncommenting the lines above, creating an allocation, and sshing to one of the compute nodes in the allocation:
```
[root@c650f99p06 c650mnp05]# /opt/ibm/csm/bin/csm_allocation_create -n c650f99p36 -j 111 -u besawn --isolated_cores 2
---
allocation_id: 1
num_nodes: 1
- compute_nodes: c650f99p36
user_name: besawn
user_id: 8260035
state: running
type: user-managed
job_submit_time: 2020-08-27 14:58:11
...

[root@c650f99p06 c650mnp05]# su - besawn -c "ssh c650f99p36"
Last login: Thu Aug 27 13:50:53 2020 from 10.7.99.6

[besawn@c650f99p36 ~]$ cat /proc/self/cgroup | egrep "allocation|csm"
12:cpuset:/allocation_1
9:devices:/allocation_1
3:cpu,cpuacct:/allocation_1
2:memory:/allocation_1
```
