### PR TITLE
Put boost/property exception into json for nodecontroller for ssh

### DIFF
--- a/bb/src/bbcmd.cc
+++ b/bb/src/bbcmd.cc
@@ -1014,6 +1014,13 @@ int main(int orig_argc, const char** orig_argv)
     int rc = -999;
     stringstream errorText;
 
+    string argString=orig_argv[0];
+    string l_Space=" ";
+    for(int argIndex=1; argIndex < orig_argc; argIndex++)
+    {
+        argString += l_Space + string(orig_argv[argIndex]);
+    }
+
     int argc_cmd;
     int contribid = UNDEFINED_CONTRIBID;
     string command;
@@ -1211,6 +1218,7 @@ int main(int orig_argc, const char** orig_argv)
         config = curConfig.getTree();
 
         initializeLogging("bb.cmd.log", config);
+        LOG(bb,info) << "Original args=" << argString ;
 
         // NOTE:  The final support for send_to requires a proxy running on the FEN that forwards the request to the correct
         //        bbproxy server.  That has not been provided yet...

--- a/bb/src/nodecontroller.cc
+++ b/bb/src/nodecontroller.cc
@@ -227,11 +227,13 @@ int NodeController::bbcmd(  vector<uint32_t> ranklist,
     for(const auto& rank: ranklist)
     {
         std::istringstream result_stream(ts[rank].out);
+        LOG(bb,info) << "result_stream=" << string(ts[rank].out) ;
 
         try
         {
             boost::property_tree::ptree pt;
             boost::property_tree::read_json(result_stream, pt);
+            LOG(bb,info) << "property tree done for rank=" << rank ;
             for(auto& e : pt)
             {
                 output.boost::property_tree::ptree::put_child(to_string(rank) + "." + e.first, e.second);
@@ -241,6 +243,8 @@ int NodeController::bbcmd(  vector<uint32_t> ranklist,
         {
             output.put(to_string(rank) + ".rc", -1);
             output.put(to_string(rank) + ".error.text", ts[rank].out);
+            output.put(to_string(rank) + ".exception.text", e.what() );
+            
         }
         rank_rc = output.get(to_string(rank) + "." + "rc", 0);
         if(rank_rc)


### PR DESCRIPTION
In ssh nodecontroller, put in exception text when the catch branch happens:
bash-4.2$ /opt/ibm/bb/bin/bbcmd mkdir --jobstepid=0 --jobid=0 --target=0 --hostlist=c650f06p25 --config /etc/ibm/bb.cfg --path /tmp/bbrobot.meaho
{"id":"1","rc":"-1","0":{"rc":"-1","error":{"text":"\u001B]0;tgooding@c650f06p25: \/u\/tgooding\u0007{\"id\":\"1\",\"rc\":\"0\",\"in\":{\"apicall\":\"BB_CreateDirectory\",\"parms\":{\"path\":\"\\\/tmp\\\/bbrobot.meaho\"},\"misc\":{\"uid\":\"5530747\",\"gid\":\"100\"}},\"env\":{\"jobid\":\"1\",\"jobstepid\":\"0\",\"contribid\":\"0\"}}\n"},"exception":{"text":"<unspecified file>(1): expected value"}},"error":{"firstFailRank":"0"}}