### PR TITLE
Updated CAST RPM version numbers to 1.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project (ibm)
 
 set(BUILDID_RELEASE    1)
 set(BUILDID_CUMULFIXID 8)
-set(BUILDID_EFIXID     0)
+set(BUILDID_EFIXID     2)
 
 execute_process(
   COMMAND git rev-list --count HEAD


### PR DESCRIPTION
Bump the rpm version number in the master branch to 1.8.2 in preparation for the upcoming release. 
Note: we may merge `master` into the `cast_1_8_x ` branch prior to generating any final build for this release.