### PR TITLE
Added missing rpm dependency on perl-YAML to ibm-csm-hcdiag rpm

### DIFF
--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -2,7 +2,7 @@
 #
 #    csmd/setupRPM.cmake
 #
-#  © Copyright IBM Corporation 2015-2019. All Rights Reserved
+#  © Copyright IBM Corporation 2015-2020. All Rights Reserved
 #
 #    This program is licensed under the terms of the Eclipse Public License
 #    v1.0 as published by the Eclipse Foundation and available at
@@ -37,6 +37,7 @@ endif()
 
 # ibm-csm-hcdiag rpm settings
 set(CPACK_RPM_csm-hcdiag_PACKAGE_ARCHITECTURE "noarch")
+set(CPACK_RPM_csm-hcdiag_PACKAGE_REQUIRES "perl-YAML")
 
 # ibm-csm-tools rpm settings
 set(CPACK_RPM_csm-tools_PACKAGE_ARCHITECTURE "noarch")


### PR DESCRIPTION
Several tests included with hcdiags require perl-YAML, add the required package to the ibm-csm-hcdiag rpm to improve the package installation experience.

Prior to this change, there are several hcdiags test cases that fail in the CSM FVT bucket with a similar error message. The failed tests include:
```
[root@c650f99p06 csmtest]# grep FAIL /test/results/buckets/basic/hcdiag.log 
Test Case 16: chk-temp:                                                                                FAILED
Test Case 21: chk-cpu:                                                                                 FAILED
Test Case 22: chk-cpu-count:                                                                           FAILED
Test Case 23: chk-sys-firmware:                                                                        FAILED
Test Case 24: chk-memory:                                                                              FAILED
Test Case 26: chk-os:                                                                                  FAILED
Test Case 27: chk-temp:                                                                                FAILED
```
The failures all look like this:
```
Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
```


<details><summary>Expand for Details</summary>
<p>

```
[root@c650f99p06 csmtest]# cat /tmp/200820100617256520/chk-temp/c650f99p18-2020-08-20-10_06_20.output
 Running chk-temp.sh on c650f99p18, machine type  8335-GTX.
 Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
 BEGIN failed--compilation aborted at ../common/ClustConf.pm line 27.
 Compilation failed in require at ./chk-temp.pm line 28.
 BEGIN failed--compilation aborted at ./chk-temp.pm line 28.
 Remote_command_rc = 2

[root@c650f99p06 csmtest]# cat /tmp/200820100642632950/chk-cpu/c650f99p18-2020-08-20-10_06_46.output
 Running chk-cpu.sh on c650f99p18, machine type  8335-GTX.
 Remote_command_rc = 2
 Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
 BEGIN failed--compilation aborted at ../common/ClustConf.pm line 27.
 Compilation failed in require at ./chk-cpu.pm line 39.
 BEGIN failed--compilation aborted at ./chk-cpu.pm line 39.

[root@c650f99p06 csmtest]# cat /tmp/200820100647747282/chk-cpu-count/c650f99p18-2020-08-20-10_06_51.output
 Running chk-cpu-count.sh on c650f99p18, machine type  8335-GTX.
 Remote_command_rc = 2
 Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
 BEGIN failed--compilation aborted at ../common/ClustConf.pm line 27.
 Compilation failed in require at ./chk-cpu-count.pm line 24.
 BEGIN failed--compilation aborted at ./chk-cpu-count.pm line 24.

[root@c650f99p06 csmtest]# cat /tmp/200820100652869215/chk-sys-firmware/c650f99p06-2020-08-20-10_06_55.output
 Running chk-sys-firmware.sh on c650f99p06, machine type  8335-GTW.
 Checking c650f99p18,c650f99p26,c650f99p28,c650f99p36 nodes.
 Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
 BEGIN failed--compilation aborted at ../common/ClustConf.pm line 27.
 Compilation failed in require at ./chk-sys-firmware.pm line 26.
 BEGIN failed--compilation aborted at ./chk-sys-firmware.pm line 26.
 Remote_command_rc = 2

[root@c650f99p06 csmtest]# cat /tmp/200820100656768575/chk-memory/c650f99p18-2020-08-20-10_07_00.output
 Running chk-memory.sh on c650f99p18, machine type  8335-GTX.
 Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
 BEGIN failed--compilation aborted at ../common/ClustConf.pm line 27.
 Compilation failed in require at ./chk-memory.pm line 26.
 BEGIN failed--compilation aborted at ./chk-memory.pm line 26.
 Remote_command_rc = 2

[root@c650f99p06 csmtest]# cat /tmp/200820100706860663/chk-os/c650f99p18-2020-08-20-10_07_10.output
 Running chk-os.sh on c650f99p18, machine type  8335-GTX.
 Remote_command_rc = 2
 Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
 BEGIN failed--compilation aborted at ../common/ClustConf.pm line 27.
 Compilation failed in require at ./chk-os.pm line 26.
 BEGIN failed--compilation aborted at ./chk-os.pm line 26.

[root@c650f99p06 csmtest]# cat /tmp/200820100711949787/chk-temp/c650f99p18-2020-08-20-10_07_15.output
 Running chk-temp.sh on c650f99p18, machine type  8335-GTX.
 Remote_command_rc = 2
 Can't locate YAML.pm in @INC (you may need to install the YAML module) (@INC contains: ./../common /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ../common/ClustConf.pm line 27.
 BEGIN failed--compilation aborted at ../common/ClustConf.pm line 27.
 Compilation failed in require at ./chk-temp.pm line 28.
 BEGIN failed--compilation aborted at ./chk-temp.pm line 28.
```

</p>
</details>

After the change in this PR, perl-YAML gets installed automatically when using yum or dnf to install ibm-csm-hcdiag:
```
[root@c650f99p18 rpms]# yum install -y -d 1 ./ibm-csm-hcdiag-1.8.0-3510.noarch.rpm 
...
Last metadata expiration check: 0:02:20 ago on Fri 28 Aug 2020 02:08:01 PM EDT.
Dependencies resolved.
===================================================================================================================================================================================================================
 Package                                       Architecture                          Version                                                              Repository                                          Size
===================================================================================================================================================================================================================
Installing:
 ibm-csm-hcdiag                                noarch                                1.8.0-3510                                                           @commandline                                       110 k
Installing dependencies:
 perl-YAML                                     noarch                                1.24-3.module+el8.1.0+2934+4e5567df                                  xCAT-rhels8.2-path0                                 93 k

Transaction Summary
===================================================================================================================================================================================================================
Install  2 Packages

Total size: 203 k
Total download size: 93 k
Installed size: 671 k
Downloading Packages:
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                              9.1 MB/s |  93 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
Installed products updated.

Installed:
  ibm-csm-hcdiag-1.8.0-3510.noarch                                                               perl-YAML-1.24-3.module+el8.1.0+2934+4e5567df.noarch                                                              

Complete!

[root@c650f99p18 rpms]# rpm -q ibm-csm-hcdiag
ibm-csm-hcdiag-1.8.0-3510.noarch

[root@c650f99p18 rpms]# rpm -q perl-YAML
perl-YAML-1.24-3.module+el8.1.0+2934+4e5567df.noarch
```

and the errors above no longer appears when running the hcdiag regression bucket.