### PR TITLE
added in an additional check for the s/n while calling csm_bb_vg_create

### DIFF
--- a/csmtest/buckets/basic/bb.sh
+++ b/csmtest/buckets/basic/bb.sh
@@ -62,7 +62,8 @@ else
 fi
 
 # Test Case 2: Calling csm_bb_vg_create
-${CSM_PATH}/csm_bb_vg_create -a 500 -n ${SINGLE_COMPUTE} -s ssd_01 -c t -S 500 -t 500 -V vg_01 > ${TEMP_LOG} 2>&1
+ssd_serial_number=`su -c "psql -t -q -U csmdb -d csmdb -c 'select * from csm_ssd ;'" | grep c650f99p18 | awk '{print $1}'`
+${CSM_PATH}/csm_bb_vg_create -a 500 -n ${SINGLE_COMPUTE} -s $ssd_serial_number -c t -S 500 -t 500 -V vg_01 > ${TEMP_LOG} 2>&1
 check_return_exit $? 0 "Test Case 2: Calling csm_bb_vg_create"
 
 # Test Case 3: Calling csm_bb_vg_query using vg name

--- a/csmtest/buckets/basic/bb.sh
+++ b/csmtest/buckets/basic/bb.sh
@@ -62,7 +62,7 @@ else
 fi
 
 # Test Case 2: Calling csm_bb_vg_create
-ssd_serial_number=`su -c "psql -t -q -U csmdb -d csmdb -c 'select * from csm_ssd ;'" | grep c650f99p18 | awk '{print $1}'`
+ssd_serial_number=$(/opt/ibm/csm/bin/csm_node_attributes_query_details -n "${SINGLE_COMPUTE}" | egrep -A 10 ssds_count | grep serial_number | awk '{print $3}')
 ${CSM_PATH}/csm_bb_vg_create -a 500 -n ${SINGLE_COMPUTE} -s $ssd_serial_number -c t -S 500 -t 500 -V vg_01 > ${TEMP_LOG} 2>&1
 check_return_exit $? 0 "Test Case 2: Calling csm_bb_vg_create"
 


### PR DESCRIPTION
# Purpose
_To fix an issue related to a test case which was calling `csm_bb_vg_create`_

The issue was that the "hard coded" s/n value was using "ssd_01" instead of the s/n collected during inventory. This was carried over from the previous update I made on `Test Case 1: Checking ssd data in the csmdb`

# How to Test
Run the bb.sh bucket again

# Screenshots
```
------------------------------------------------------------
                 Starting BB API Bucket
------------------------------------------------------------
Thu Sep 10 15:40:25 EDT 2020
------------------------------------------------------------
[2020-09-10 15:40:25.2194] Test Case 1: Checking ssd data in the csmdb if already populated from the inventory collection:                    PASS
[2020-09-10 15:40:25.4157] Test Case 2: Calling csm_bb_vg_create:                                                                             PASS
[2020-09-10 15:40:25.4304] Test Case 3: Calling csm_bb_vg_query using vg name:                                                                PASS
[2020-09-10 15:40:25.4389] Test Case 4: Validating csm_bb_vg_query output:                                                                    PASS
[2020-09-10 15:40:25.4533] Test Case 5: Calling csm_bb_vg_query using node name:                                                              PASS
[2020-09-10 15:40:25.4618] Test Case 6: Validating csm_bb_vg_query output:                                                                    PASS
[2020-09-10 15:40:25.7736] Test Case 7: Create lv_01:                                                                                         PASS
[2020-09-10 15:40:25.7879] Test Case 8: Calling csm_bb_lv_query using allocation ID:                                                          PASS
[2020-09-10 15:40:25.7936] Test Case 9: Validating csm_bb_lv_query_output:                                                                    PASS
[2020-09-10 15:40:25.8081] Test Case 10: Calling csm_bb_lv_query using logical volume name:                                                   PASS
[2020-09-10 15:40:25.8137] Test Case 11: Validating csm_bb_lv_query output:                                                                   PASS
[2020-09-10 15:40:25.8281] Test Case 12: Calling csm_bb_lv_query using node name:                                                             PASS
[2020-09-10 15:40:25.8336] Test Case 13: Validating csm_bb_lv_query output:                                                                   PASS
[2020-09-10 15:40:25.8566] Test Case 14: Calling csm_bb_lv_delete:                                                                            PASS
[2020-09-10 15:40:26.0732] Test Case 15: calling csm_allocation_delete:                                                                       PASS
[2020-09-10 15:40:26.3586] Test Case 16: Cascading allocation/LV delete - create allocation:                                                  PASS
[2020-09-10 15:40:26.3816] Test Case 16: Cascading allocation/LV delete - create lv_02:                                                       PASS
[2020-09-10 15:40:26.3958] Test Case 16: Cascading allocation/LV delete - query lv_02:                                                        PASS
[2020-09-10 15:40:26.6897] Test Case 16: Cascading allocation/LV delete - delete allocation:                                                  PASS
[2020-09-10 15:40:26.7041] Test Case 16: Cascading allocation/LV delete - verify lv_02 deleted:                                               PASS
[2020-09-10 15:40:26.7341] Test Case 16; Cascading allocation/LV delete - verify lv_02 in history table:                                      PASS
[2020-09-10 15:40:26.7647] Test Case 17: Calling csm_bb_vg_delete:                                                                            PASS
------------------------------------------------------------
           Basic Burst Buffer  Bucket Passed
------------------------------------------------------------
```
## Open Questions and Pre-Merge TODOs

- [ ] Assign @besawn to review (check code)
