### PR TITLE
Ensure /etc/ibm created on computes and bbserver nodes

### DIFF
--- a/bb/ansible/certificates.yml
+++ b/bb/ansible/certificates.yml
@@ -48,7 +48,7 @@
         dest: /etc/ibm/key.pem
         owner: root
         group: root
-        mode: '0644'
+        mode: '0600'
         backup: no
       any_errors_fatal: true  
 

--- a/bb/ansible/certificates.yml
+++ b/bb/ansible/certificates.yml
@@ -30,6 +30,16 @@
       command: ls -l {{FQP_CERTFILE}} 
       any_errors_fatal: true     
  
+- hosts: server compute
+  tasks:
+    - name: Create /etc/ibm directory if it does not exist
+      file:   
+        path: /etc/ibm
+        state: directory
+        mode: '0755'
+        owner: root
+        group: root
+
 - hosts: server
   tasks:
     - name: Copy private key to bbserver nodes
@@ -39,7 +49,7 @@
         owner: root
         group: root
         mode: '0644'
-        backup: yes
+        backup: no
       any_errors_fatal: true  
 
 - hosts: server compute
@@ -51,6 +61,6 @@
         owner: root
         group: root
         mode: '0644'
-        backup: yes  
+        backup: no  
     any_errors_fatal: true        
 


### PR DESCRIPTION
Unit testing was against certificates.yaml with a pause inserted to avoid damaging certificates in place
sudo ansible-playbook -i /u/tgooding/hosts_rhel7 /u/meaho/CAST/bb/ansible/certificates.yml 

(1) Unit tested on p25 for existing directories on servers and computes.  Passed test.

(2) Moved /etc/ibm/ to /etc/ibm2 on p25
/etc/ibm was created with correct permissions and owner/group of root/root
ansible noted a change on p25 "changed: [c650f06p25]" 
Moved /etc/ibm2 back to /etc/ibm to restore environment 
Removed pause in certificates.yaml for running scoped test 

Also set backup to no for replacing certificates and keys.