### PR TITLE
added in some logical checks related to allocations and core isolatio…

### DIFF
--- a/csmtest/buckets/advanced/allocation.sh
+++ b/csmtest/buckets/advanced/allocation.sh
@@ -80,7 +80,7 @@ check_return_exit $? 0 "Test Case 4:  (Section A) Calling csm_allocation_update_
 xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
 check_return_flag_value $? 0 "Test Case 4a: (Section A) SSH to node in the allocation, does get put into the CSM system cgroup"
 
-# Test Case 4b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+# Test Case 4b: SSH to a compute node in the allocation, does not get put into the allocation cgroup?
 xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
 check_return_flag_value $? 1 "Test Case 4b: (Section A) SSH to node in the allocation, does not get put into the allocation cgroup"
 
@@ -341,7 +341,7 @@ check_return_exit $? 0 "Test Case 1:  (Section E) Create first allocation"
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
-# Test Case 1a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
+# Test Case 1a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
 xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
 check_return_flag_value $? 0 "Test Case 1a: (Section E) SSH to node in the allocation, does get put into the CSM system cgroup"
 

--- a/csmtest/buckets/advanced/allocation.sh
+++ b/csmtest/buckets/advanced/allocation.sh
@@ -58,7 +58,7 @@ check_return_flag_value $? 0 "Restart and recover compute nodes"
 echo "Section A BEGIN" >> ${LOG}
 # Test Case 1: Calling csm_allocation_create at staging-in, no core isolation
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${COMPUTE_NODES} -s "staging-in" 2>&1 > ${TEMP_LOG}
-check_return_exit $? 0 "Test Case 1: Calling csm_allocation_create at staging-in, no core isolation"
+check_return_exit $? 0 "Test Case 1:  (Section A) Calling csm_allocation_create at staging-in, no core isolation"
 
 # Grab & Store Allocation ID from temp log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
@@ -66,50 +66,58 @@ allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 # Test Case 2: Validating allocation state staging-in
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "staging-in"
-check_return_flag_value $? 0 "Test Case 2: Validating allocation state staging-in"
+check_return_flag_value $? 0 "Test Case 2:  (Section A) Validating allocation state staging-in"
 
 # Test Case 3: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 3: Calling csm_allocation_query_active_all"
+check_return_exit $? 0 "Test Case 3:  (Section A) Calling csm_allocation_query_active_all"
 
 # Test Case 4: Calling csm_allocation_update_state -s running on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s "running" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 4: Calling csm_allocation_update_state -s running on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 4:  (Section A) Calling csm_allocation_update_state -s running on Allocation ID = ${allocation_id}"
+
+# Test Case 4a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 4a: (Section A) SSH to node in the allocation, does get put into the CSM system cgroup"
+
+# Test Case 4b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 4b: (Section A) SSH to node in the allocation, does not get put into the allocation cgroup"
 
 # Test Case 5: Validating allocation state running
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "running"
-check_return_flag_value $? 0 "Test Case 5: Validating allocation state running"
+check_return_flag_value $? 0 "Test Case 5:  (Section A) Validating allocation state running"
 
 # Test Case 6: Validating IRQ Balance daemon is active"
 xdsh ${COMPUTE_NODES} "ps -ef | grep 'irqbalanc[e]'" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 6: Validating IRQ Balance daemon is active"
+check_return_flag_value $? 0 "Test Case 6:  (Section A) Validating IRQ Balance daemon is active"
 
 # Test Case 7: Calling csm_allocation_query
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 7: Calling csm_allocation_query"
+check_return_exit $? 0 "Test Case 7:  (Section A) Calling csm_allocation_query"
 
 # Test Case 8: Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s "staging-out" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 8: Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 8:  (Section A) Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
 
 # Test Case 9: Checking allocation state staging-out
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "staging-out"
-check_return_flag_value $? 0 "Test Case 9: Checking allocation state staging-out"
+check_return_flag_value $? 0 "Test Case 9:  (Section A) Checking allocation state staging-out"
 
 # Test Case 10: Calling csm_allocation_delete on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 10: Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 10: (Section A) Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
 
 # Test Case 11: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 11: Calling csm_allocation_query_active_all"
+check_return_exit $? 4 "Test Case 11: (Section A) Calling csm_allocation_query_active_all"
 
 # Test Case 12: Checking allocation state complete
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "complete"
-check_return_flag_value $? 0 "Test Case 12: Checking allocation state complete"
+check_return_flag_value $? 0 "Test Case 12: (Section A) Checking allocation state complete"
 
 echo "Section A COMPLETED!" >> ${LOG}
 echo "------------------------------------------------------------" >> ${LOG}
@@ -118,60 +126,68 @@ echo "------------------------------------------------------------" >> ${LOG}
 echo "Section B BEGIN" >> ${LOG}
 
 # Test Case 1: Calling csm_allocation_create
-${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} --isolated_cores 1 --smt_mode 4 2>&1 > ${TEMP_LOG}
-check_return_exit $? 0 "Test Case 1: Calling csm_allocation_create"
+${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -u ${USER} --isolated_cores 1 --smt_mode 4 2>&1 > ${TEMP_LOG}
+check_return_exit $? 0 "Test Case 1:  (Section B) Calling csm_allocation_create"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
+# Test Case 1a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 1a: (Section B) SSH to node in the allocation, does not get put into the CSM system cgroup"
+
+# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 1b: (Section B) SSH to node in the allocation, does it get put into the allocation cgroup"
+
 # Test Case 2: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 2: Calling csm_allocation_query_active_all"
+check_return_exit $? 0 "Test Case 2:  (Section B) Calling csm_allocation_query_active_all"
 
 # Test Case 3: Validating allocation state running
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "running"
-check_return_flag_value $? 0 "Test Case 3: Validating allocation state running"
+check_return_flag_value $? 0 "Test Case 3:  (Section B) Validating allocation state running"
 
 # Test Case 4: Validating cgroup creation
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 4: Validating cgroup creation"
+check_return_flag_value $? 0 "Test Case 4:  (Section B) Validating cgroup creation"
 
 # Test Case 5: Validating cgroup assigned cpus correctly
 xdsh ${SINGLE_COMPUTE} "cat /sys/fs/cgroup/cpuset/allocation_${allocation_id}/cpuset.cpus" > ${TEMP_LOG} 2>&1
 check_all_output "4-87,92-175"
-check_return_flag_value $? 0 "Test Case 5: Validating cgroup assigned cpus correctly"
+check_return_flag_value $? 0 "Test Case 5:  (Section B) Validating cgroup assigned cpus correctly"
 
 # Test Case 6: Validating IRQ Balance daemon is not active"
 xdsh ${SINGLE_COMPUTE} "ps -ef | grep 'irqbalanc[e]'" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 1 "Test Case 6: Validating IRQ Balance daemon is not active"
+check_return_flag_value $? 1 "Test Case 6:  (Section B) Validating IRQ Balance daemon is not active"
 
 # Test Case 7: Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s "staging-out" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 7: Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 7:  (Section B) Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
 
 # Test Case 8: Validating allocation state staging-out
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "staging-out"
-check_return_flag_value $? 0 "Test Case 8: Validating allocation state staging-out"
+check_return_flag_value $? 0 "Test Case 8:  (Section B) Validating allocation state staging-out"
 
 # Test Case 9: Calling csm_allocation_delete on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 9: Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 9:  (Section B) Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
 
 # Test Case 10: Checking allocation state complete
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "complete"
-check_return_flag_value $? 0 "Test Case 10: Checking allocation state complete"
+check_return_flag_value $? 0 "Test Case 10: (Section B) Checking allocation state complete"
 
 # Test Case 11: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 11: Calling csm_allocation_query_active_all"
+check_return_exit $? 4 "Test Case 11: (Section B) Calling csm_allocation_query_active_all"
 
 # Test Case 12: Checking cgroup deletion
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
 check_all_output "No such file or directory"
-check_return_flag_value $? 0 "Test Case 12: Checking cgroup deletion"
+check_return_flag_value $? 0 "Test Case 12: (Section B) Checking cgroup deletion"
 
 echo "Section B COMPLETED!" >> ${LOG}
 echo "------------------------------------------------------------" >> ${LOG}
@@ -180,8 +196,8 @@ echo "------------------------------------------------------------" >> ${LOG}
 echo "Section C BEGIN" >> ${LOG}
 
 # Test Case 1: Calling csm_allocation_create at staging-in, with cgroup
-${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -s "staging-in" --isolated_cores 1 --smt_mode 1 2>&1 > ${TEMP_LOG}
-check_return_exit $? 0 "Test Case 1: Calling csm_allocation_create at staging-in, with cgroup"
+${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -u ${USER} -s "staging-in" --isolated_cores 1 --smt_mode 1 2>&1 > ${TEMP_LOG}
+check_return_exit $? 0 "Test Case 1:  (Section C) Calling csm_allocation_create at staging-in, with cgroup"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
@@ -189,61 +205,69 @@ allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 # Test Case 2: Checking allocation state staging-in
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "staging-in"
-check_return_flag_value $? 0 "Test Case 2: Checking allocation state staging-in"
+check_return_flag_value $? 0 "Test Case 2:  (Section C) Checking allocation state staging-in"
 
 # Test Case 3: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 3: Calling csm_allocation_query_active_all"
+check_return_exit $? 0 "Test Case 3:  (Section C) Calling csm_allocation_query_active_all"
 
 # Test Case 4: Validating cgroup not created yet
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
 check_all_output "No such file or directory"
-check_return_flag_value $? 0 "Test Case 4: Validating cgroup not created yet"
+check_return_flag_value $? 0 "Test Case 4:  (Section C) Validating cgroup not created yet"
 
 # Test Case 5: Calling csm_allocation_update_state -s running on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s running > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 5: Calling csm_allocation_update_state -s running on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 5:  (Section C) Calling csm_allocation_update_state -s running on Allocation ID = ${allocation_id}"
 
 # Test Case 6: Validating allocation state running
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "running"
-check_return_flag_value $? 0 "Test Case 6: Validating allocation state running"
+check_return_flag_value $? 0 "Test Case 6:  (Section C) Validating allocation state running"
+
+# Test Case 6a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 6a: (Section C) SSH to node in the allocation, does not get put into the CSM system cgroup"
+
+# Test Case 6b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 6b: (Section C) SSH to node in the allocation, does it get put into the allocation cgroup"
 
 # Test Case 7: Validating cgroup creation
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 7: Validating cgroup creation"
+check_return_flag_value $? 0 "Test Case 7:  (Section C) Validating cgroup creation"
 
 # Test Case 8: Validating cgroup assigned cpus correctly
 xdsh ${SINGLE_COMPUTE} "cat /sys/fs/cgroup/cpuset/allocation_${allocation_id}/cpuset.cpus" > ${TEMP_LOG} 2>&1
 check_all_output "84,92"
-check_return_flag_value $? 0 "Test Case 8: Validating cgroup assigned cpus correctly"
+check_return_flag_value $? 0 "Test Case 8:  (Section C) Validating cgroup assigned cpus correctly"
 
 # Test Case 9: Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s "staging-out" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 9: Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 9:  (Section C) Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
 
 # Test Case 10: Validating allocation state staging-out
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "staging-out"
-check_return_flag_value $? 0 "Test Case 10: Validating allocation state staging-out"
+check_return_flag_value $? 0 "Test Case 10: (Section C) Validating allocation state staging-out"
 
 # Test Case 11: Calling csm_allocation_delete on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 11: Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 11: (Section C) Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
 
 # Test Case 12: Checking cgroup deletion
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
 check_all_output "No such file or directory"
-check_return_flag_value $? 0 "Test Case 12: Checking cgroup deletion"
+check_return_flag_value $? 0 "Test Case 12: (Section C) Checking cgroup deletion"
 
 # Test Case 13: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 13: Calling csm_allocation_query_active_all"
+check_return_exit $? 4 "Test Case 13: (Section C) Calling csm_allocation_query_active_all"
 
 # Test Case 14: Validating allocation state complete
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "complete"
-check_return_flag_value $? 0 "Test Case 14: Validating allocation state complete"
+check_return_flag_value $? 0 "Test Case 14: (Section C) Validating allocation state complete"
 
 echo "Section C COMPLETED!" >> ${LOG}
 
@@ -253,48 +277,56 @@ echo "Section D BEGIN" >> ${LOG}
 
 # Test Case 1: Calling csm_allocation_create for user ${USER} at staging-in
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -s "staging-in" -u ${USER} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 1: Calling csm_allocation_create for user ${USER} at staging-in"
+check_return_exit $? 0 "Test Case 1:  (Section D) Calling csm_allocation_create for user ${USER} at staging-in"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
 # Test Case 2: Checking Allocation ${allocation_id} created for user ${USER}
 check_all_output "${USER}"
-check_return_exit $? 0 "Test Case 2: Checking Allocation ${allocation_id} created for user ${USER}"
+check_return_exit $? 0 "Test Case 2:  (Section D) Checking Allocation ${allocation_id} created for user ${USER}"
 
 # Test Case 3: Attempt csm_allocation_update_state as secondary non-root user (error expected)
 su -c "${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s running" ${SECOND_USER} > ${TEMP_LOG} 2>&1
-check_return_exit $? 16 "Test Case 3: Attempt csm_allocation_update_state as secondary non-root user (error expected)"
+check_return_exit $? 16 "Test Case 3:  (Section D) Attempt csm_allocation_update_state as secondary non-root user (error expected)"
 
 # Test Case 3: Attempt csm_allocation_update_state as owner
 su -c "${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s running" ${USER} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 3: Attempt csm_allocation_update_state as owner"
+check_return_exit $? 0 "Test Case 3:  (Section D) Attempt csm_allocation_update_state as owner"
+
+# Test Case 3a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 3a: (Section D) SSH to node in the allocation, does not get put into the CSM system cgroup"
+
+# Test Case 3b: SSH to a compute node in the allocation, does get put into the allocation cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 3b: (Section D) SSH to node in the allocation, does get put into the allocation cgroup"
 
 # Test Case 3: Validate state transitions in csm_allocation_query_details
 ${CSM_PATH}/csm_allocation_query_details -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "staging-in" "to-running" "running" "${USER}"
-check_return_flag_value $? 0 "Test Case 3: Validate state transitions in csm_allocation_query_details"
+check_return_flag_value $? 0 "Test Case 3:  (Section D) Validate state transitions in csm_allocation_query_details"
 
 # Test Case 4: Attempt csm_allocation_update_state as secondary non-root user (error expected)
 su -c "${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s staging-out" ${SECOND_USER} > ${TEMP_LOG} 2>&1
-check_return_exit $? 16 "Test Case 4: Attempt csm_allocation_update_state as secondary non-root user (error expected)"
+check_return_exit $? 16 "Test Case 4:  (Section D) Attempt csm_allocation_update_state as secondary non-root user (error expected)"
 
 # Test Case 4: Attempt csm_allocation_update_state as owner
 su -c "${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s staging-out" ${USER} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 4: Attempt csm_allocation_update_state as owner"
+check_return_exit $? 0 "Test Case 4:  (Section D) Attempt csm_allocation_update_state as owner"
 
 # Test Case 4: Validate state transitions in csm_allocation_query_details
 ${CSM_PATH}/csm_allocation_query_details -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "staging-in" "to-running" "running" "to-staging-out" "staging-out" "${USER}"
-check_return_flag_value $? 0 "Test Case 4: Validate state transitions in csm_allocation_query_details"
+check_return_flag_value $? 0 "Test Case 4:  (Section D) Validate state transitions in csm_allocation_query_details"
 
 # Test Case 5: Calling csm_allocation_delete as user ${USER}
 su -c "${CSM_PATH}/csm_allocation_delete -a ${allocation_id}" ${USER} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 5: Calling csm_allocation_delete as user ${USER}"
+check_return_exit $? 0 "Test Case 5:  (Section D) Calling csm_allocation_delete as user ${USER}"
 
 # Test Case 5: Checking allocation deleted
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 5: Checking allocation deleted"
+check_return_exit $? 4 "Test Case 5:  (Section D) Checking allocation deleted"
 
 echo "Section D COMPLETED!" >> ${LOG}
 
@@ -304,18 +336,26 @@ echo "Section E BEGIN" >> ${LOG}
 
 # Test Case 1: Create first allocation
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 1: Create first allocation"
+check_return_exit $? 0 "Test Case 1:  (Section E) Create first allocation"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
+# Test Case 1a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 1a: (Section E) SSH to node in the allocation, does get put into the CSM system cgroup"
+
+# Test Case 1b: SSH to a compute node in the allocation, does not get put into the allocation cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 1b: (Section E) SSH to node in the allocation, does not get put into the allocation cgroup"
+
 # Test Case 2: Update first allocation to staging-out
 ${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s "staging-out" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 2: Update first allocation to staging-out"
+check_return_exit $? 0 "Test Case 2:  (Section E) Update first allocation to staging-out"
 
 # Test Case 3: Create second allocation at staging-in
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -s "staging-in" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 3: Create second allocation at staging-in"
+check_return_exit $? 0 "Test Case 3:  (Section E) Create second allocation at staging-in"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 second_allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
@@ -323,24 +363,24 @@ second_allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 # Test Case 3: Validate 2 allocations active and in correct state with query
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
 check_all_output "num_allocations: 2" "allocation_id: ${allocation_id}" "allocation_id: ${second_allocation_id}" "staging-in" "staging-out"
-check_return_flag_value $? 0 "Validate 2 allocations active and in correct state with query"
+check_return_flag_value $? 0 "Test Case 3:  (Section E) Validate 2 allocations active and in correct state with query"
 
 # Test Case 4: Update second allocation to running
 ${CSM_PATH}/csm_allocation_update_state -a ${second_allocation_id} -s "running" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 4: Update second allocation to running"
+check_return_exit $? 0 "Test Case 4:  (Section E) Update second allocation to running"
 
 # Test Case 4: Validate 2 allocations active and in correct state with query
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
 check_all_output "num_allocations: 2" "allocation_id: ${allocation_id}" "allocation_id: ${second_allocation_id}" "running" "staging-out"
-check_return_flag_value $? 0 "Test Case 4: Validate 2 allocations active and in correct state with query"
+check_return_flag_value $? 0 "Test Case 4:  (Section E) Validate 2 allocations active and in correct state with query"
 
 # Test Case 5: Update second allocation to staging-out
 ${CSM_PATH}/csm_allocation_update_state -a ${second_allocation_id} -s "staging-out" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 5: Update second allocation to staging-out"
+check_return_exit $? 0 "Test Case 5:  (Section E) Update second allocation to staging-out"
 
 # Test Case 6: Create a third allocation at running
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 6: Create a third allocation at running"
+check_return_exit $? 0 "Test Case 6:  (Section E) Create a third allocation at running"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 third_allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
@@ -348,24 +388,24 @@ third_allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 # Test Case 6: Validate 3 allocations active and in correct state with query
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
 check_all_output "num_allocations: 3" "allocation_id: ${allocation_id}" "allocation_id: ${second_allocation_id}" "allocation_id: ${third_allocation_id}" "running" "staging-out"
-check_return_flag_value $? 0 "Test Case 6: Validate 3 allocations active and in correct state with query" 
+check_return_flag_value $? 0 "Test Case 6:  (Section E) Validate 3 allocations active and in correct state with query" 
 
 # Test Case 7: Update third allocation to staging-out
 ${CSM_PATH}/csm_allocation_update_state -a ${third_allocation_id} -s "staging-out" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 7: Update third allocation to staging-out"
+check_return_exit $? 0 "Test Case 7:  (Section E) Update third allocation to staging-out"
 
 # Clean up allocations
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Clean up Allocation ${allocation_id}"
+check_return_exit $? 0 "              (Section E) Clean up Allocation ${allocation_id}"
 
 ${CSM_PATH}/csm_allocation_delete -a ${second_allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Clean up Allocation ${second_allocation_id}"
+check_return_exit $? 0 "              (Section E) Clean up Allocation ${second_allocation_id}"
 
 ${CSM_PATH}/csm_allocation_delete -a ${third_allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Clean up Allocation ${third_allocation_id}"
+check_return_exit $? 0 "              (Section E) Clean up Allocation ${third_allocation_id}"
 
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 4 "Section E - All allocations cleaned up"
+check_return_flag_value $? 4 "              (Section E) All allocations cleaned up"
 
 echo "Section E COMPLETED!" >> ${LOG}
 
@@ -374,51 +414,59 @@ echo "------------------------------------------------------------" >> ${LOG}
 echo "Section F BEGIN" >> ${LOG}
 
 # Test Case 1: Calling csm_allocation_create with 1 isolated core and smt_mode 8"
-${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} --isolated_cores 1 --smt_mode 8 2>&1 > ${TEMP_LOG}
-check_return_exit $? 0 "Test Case 1: Calling csm_allocation_create with 1 isolated core and smt_mode 8"
+${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -u ${USER} --isolated_cores 1 --smt_mode 8 2>&1 > ${TEMP_LOG}
+check_return_exit $? 0 "Test Case 1:  (Section F) Calling csm_allocation_create with 1 isolated core and smt_mode 8"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
+# Test Case 1a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 1a: (Section F) SSH to node in the allocation, does not get put into the CSM system cgroup"
+
+# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 1b: (Section F) SSH to node in the allocation, does it get put into the allocation cgroup"
+
 # Test Case 2: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 2: Calling csm_allocation_query_active_all"
+check_return_exit $? 0 "Test Case 2:  (Section F) Calling csm_allocation_query_active_all"
 
 # Test Case 3: Validating allocation state running
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "running"
-check_return_flag_value $? 0 "Test Case 3: Validating allocation state running"
+check_return_flag_value $? 0 "Test Case 3:  (Section F) Validating allocation state running"
 
 # Test Case 4: Validating cgroup creation
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 4: Validating cgroup creation"
+check_return_flag_value $? 0 "Test Case 4:  (Section F) Validating cgroup creation"
 
 # Test Case 5: Validating cgroup assigned cpus correctly
 xdsh ${SINGLE_COMPUTE} "cat /sys/fs/cgroup/cpuset/allocation_${allocation_id}/cpuset.cpus" > ${TEMP_LOG} 2>&1
 check_all_output "4-87,92-175"
-check_return_flag_value $? 0 "Test Case 5: Validating cgroup assigned cpus correctly"
+check_return_flag_value $? 0 "Test Case 5:  (Section F) Validating cgroup assigned cpus correctly"
 
 # Test Case 6: Validating IRQ Balance daemon is not active"
 xdsh ${SINGLE_COMPUTE} "ps -ef | grep 'irqbalanc[e]'" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 1 "Test Case 6: Validating IRQ Balance daemon is not active"
+check_return_flag_value $? 1 "Test Case 6:  (Section F) Validating IRQ Balance daemon is not active"
 
 # Test Case 7: Calling csm_allocation_delete on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 7: Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 7:  (Section F) Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
 
 # Test Case 8: Checking allocation state complete
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "complete"
-check_return_flag_value $? 0 "Test Case 8: Checking allocation state complete"
+check_return_flag_value $? 0 "Test Case 8:  (Section F) Checking allocation state complete"
 
 # Test Case 9: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 9: Calling csm_allocation_query_active_all"
+check_return_exit $? 4 "Test Case 9:  (Section F) Calling csm_allocation_query_active_all"
 
 # Test Case 10: Checking cgroup deletion
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
 check_all_output "No such file or directory"
-check_return_flag_value $? 0 "Test Case 10: Checking cgroup deletion"
+check_return_flag_value $? 0 "Test Case 10: (Section F) Checking cgroup deletion"
 
 echo "Section F COMPLETED!" >> ${LOG}
 
@@ -427,51 +475,59 @@ echo "------------------------------------------------------------" >> ${LOG}
 echo "Section G BEGIN" >> ${LOG}
 
 # Test Case 1: Calling csm_allocation_create with no isolated cores and smt_mode 1"
-${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} --isolated_cores 0 --smt_mode 1 2>&1 > ${TEMP_LOG}
-check_return_exit $? 0 "Test Case 1: Calling csm_allocation_create with no isolated cores and smt_mode 1"
+${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -u ${USER} --isolated_cores 0 --smt_mode 1 2>&1 > ${TEMP_LOG}
+check_return_exit $? 0 "Test Case 1:  (Section G) Calling csm_allocation_create with no isolated cores and smt_mode 1"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
+# Test Case 1a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 1a: (Section G) SSH to node in the allocation, does not get put into the CSM system cgroup"
+
+# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 1b: (Section G) SSH to node in the allocation, does it get put into the allocation cgroup"
+
 # Test Case 2: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 2: Calling csm_allocation_query_active_all"
+check_return_exit $? 0 "Test Case 2:  (Section G) Calling csm_allocation_query_active_all"
 
 # Test Case 3: Validating allocation state running
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "running"
-check_return_flag_value $? 0 "Test Case 3: Validating allocation state running"
+check_return_flag_value $? 0 "Test Case 3:  (Section G) Validating allocation state running"
 
 # Test Case 4: Validating cgroup creation
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 4: Validating cgroup creation"
+check_return_flag_value $? 0 "Test Case 4:  (Section G) Validating cgroup creation"
 
 # Test Case 5: Validating cgroup assigned cpus correctly
 xdsh ${SINGLE_COMPUTE} "cat /sys/fs/cgroup/cpuset/allocation_${allocation_id}/cpuset.cpus" > ${TEMP_LOG} 2>&1
 check_all_output "0,4,8"
-check_return_flag_value $? 0 "Test Case 5: Validating cgroup assigned cpus correctly"
+check_return_flag_value $? 0 "Test Case 5:  (Section G) Validating cgroup assigned cpus correctly"
 
 # Test Case 6: Validating IRQ Balance daemon is active"
 xdsh ${SINGLE_COMPUTE} "ps -ef | grep 'irqbalanc[e]'" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 6: Validating IRQ Balance daemon is active"
+check_return_flag_value $? 0 "Test Case 6:  (Section G) Validating IRQ Balance daemon is active"
 
 # Test Case 7: Calling csm_allocation_delete on Allocation ID = ${allocation_id}
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 7: Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 7:  (Section G) Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
 
 # Test Case 8: Checking allocation state complete
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "complete"
-check_return_flag_value $? 0 "Test Case 8: Checking allocation state complete"
+check_return_flag_value $? 0 "Test Case 8:  (Section G) Checking allocation state complete"
 
 # Test Case 9: Calling csm_allocation_query_active_all
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 9: Calling csm_allocation_query_active_all"
+check_return_exit $? 4 "Test Case 9:  (Section G) Calling csm_allocation_query_active_all"
 
 # Test Case 10: Checking cgroup deletion
 xdsh ${SINGLE_COMPUTE} "ls /sys/fs/cgroup/cpuset/allocation_${allocation_id}" > ${TEMP_LOG} 2>&1
 check_all_output "No such file or directory"
-check_return_flag_value $? 0 "Test Case 10: Checking cgroup deletion"
+check_return_flag_value $? 0 "Test Case 10: (Section G) Checking cgroup deletion"
 
 echo "Section G COMPLETED!" >> ${LOG}
 rm -f ${TEMP_LOG}

--- a/csmtest/buckets/basic/allocation.sh
+++ b/csmtest/buckets/basic/allocation.sh
@@ -54,13 +54,13 @@ check_return_exit $? 0 "Test Case 2:   Calling csm_allocation_create"
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 
-# Test Case 1a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
+# Test Case 2a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
 xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 1a:  SSH to node in the allocation, does get put into the CSM system cgroup"
+check_return_flag_value $? 0 "Test Case 2a:  SSH to node in the allocation, does get put into the CSM system cgroup"
 
-# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+# Test Case 2b: SSH to a compute node in the allocation, does not get put into the allocation cgroup?
 xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 1 "Test Case 1b:  SSH to node in the allocation, does not get put into the allocation cgroup"
+check_return_flag_value $? 1 "Test Case 2b:  SSH to node in the allocation, does not get put into the allocation cgroup"
 
 rm -f ${TEMP_LOG}
 
@@ -137,13 +137,13 @@ ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "launch_node_name:               ${utility_node}"
 check_return_flag_value $? 0 "Test Case 13:  Validate launch node in csm_allocation_query"
 
-# Test Case 1a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
+# Test Case 13a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
 xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 1a:  SSH to node in the allocation, does get put into the CSM system cgroup"
+check_return_flag_value $? 0 "Test Case 13a:  SSH to node in the allocation, does get put into the CSM system cgroup"
 
-# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+# Test Case 13b: SSH to a compute node in the allocation, does not get put into the allocation cgroup?
 xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 1 "Test Case 1b:  SSH to node in the allocation, does not get put into the allocation cgroup"
+check_return_flag_value $? 1 "Test Case 13b:  SSH to node in the allocation, does not get put into the allocation cgroup"
 
 # Clean Up allocation
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1

--- a/csmtest/buckets/basic/allocation.sh
+++ b/csmtest/buckets/basic/allocation.sh
@@ -44,15 +44,23 @@ echo "------------------------------------------------------------" >> ${LOG}
 
 # Test Case 1: csm_allocation_query_active_all (failure expected)
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 1: Calling csm_allocation_query_active_all (failure expected)"
+check_return_exit $? 4 "Test Case 1:   Calling csm_allocation_query_active_all (failure expected)"
 
 rm -f ${TEMP_LOG}
 # Test Case 2: csm_allocation_create
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${COMPUTE_NODES} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 2: Calling csm_allocation_create"
+check_return_exit $? 0 "Test Case 2:   Calling csm_allocation_create"
 
 # Grab & Store Allocation ID from csm_allocation_create.log
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
+
+# Test Case 1a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 1a:  SSH to node in the allocation, does get put into the CSM system cgroup"
+
+# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 1b:  SSH to node in the allocation, does not get put into the allocation cgroup"
 
 rm -f ${TEMP_LOG}
 
@@ -68,72 +76,80 @@ check_return_flag_value $? 0 "Test Case 2.2: Validating cgroup assigned system c
 
 # Test Case 3: csm_allocation_query_active_all (success)
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 3: csm_allocation_query_active_all success"
+check_return_exit $? 0 "Test Case 3:   csm_allocation_query_active_all success"
 
 rm -f ${TEMP_LOG}
 # Test Case 4: csm_allocation_update_state staging out
 ${CSM_PATH}/csm_allocation_update_state -a ${allocation_id} -s "staging-out" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 4: Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 4:   Calling csm_allocation_update_state -s staging-out on Allocation ID = ${allocation_id}"
 
 rm -f ${TEMP_LOG}
 # Test Case 5: csm_allocation_query
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 5: Calling csm_allocation_query"
+check_return_exit $? 0 "Test Case 5:   Calling csm_allocation_query"
 
 rm -f ${TEMP_LOG}
 # Test Case 6: csm_allocation_resources_query
 ${CSM_PATH}/csm_allocation_resources_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 6: Calling csm_allocation_resources_query"
+check_return_exit $? 0 "Test Case 6:   Calling csm_allocation_resources_query"
 
 rm -f ${TEMP_LOG}
 # Test Case 7: csm_allocation_delete
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 7: Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 7:   Calling csm_allocation_delete on Allocation ID = ${allocation_id}"
 
 rm -f ${TEMP_LOG}
 # Test Case 8: csm_allocation_query_active_all (failure after delete)
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Test Case 8: Calling csm_allocation_query_active_all (failure after delete)"
+check_return_exit $? 4 "Test Case 8:   Calling csm_allocation_query_active_all (failure after delete)"
 
 rm -f ${TEMP_LOG}
 # Test Case 9: csm_allocation_query_details
 ${CSM_PATH}/csm_allocation_query_details -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 9: Calling csm_allocation_query_details on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 9:   Calling csm_allocation_query_details on Allocation ID = ${allocation_id}"
 
 # Test Case 10: check csm_allocation_query_details for state=complete
 check_all_output "complete"
-check_return_flag_value $? 0 "Test Case 10: Checking csm_allocation_query_details for state=complete"
+check_return_flag_value $? 0 "Test Case 10:  Checking csm_allocation_query_details for state=complete"
 
 rm -f ${TEMP_LOG}
 # Test Case 11: csm_allocation_update_history
 ${CSM_PATH}/csm_allocation_update_history -a ${allocation_id} -c "test_comment" > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 11: Calling csm_allocation_update_history on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 11:  Calling csm_allocation_update_history on Allocation ID = ${allocation_id}"
 
 rm -f ${TEMP_LOG}
 # Test Case 12: check csm_allocation_query return and output for test_comment
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Test Case 12: Calling csm_allocation_query on Allocation ID = ${allocation_id}"
+check_return_exit $? 0 "Test Case 12:  Calling csm_allocation_query on Allocation ID = ${allocation_id}"
 check_all_output "test_comment"
-check_return_flag_value $? 0 "Test Case 12: Checking allocation history table updated with test_comment..."
+check_return_flag_value $? 0 "Test Case 12:  Checking allocation history table updated with test_comment..."
 
 # Test Case 13: csm_allocation_create with launch node input
 # Get utility node name
 utility_node=`nodels utility | head -1`
 ${CSM_PATH}/csm_allocation_create -j 1 -n ${SINGLE_COMPUTE} -l ${utility_node} > ${TEMP_LOG} 2>&1
-check_return_flag_value $? 0 "Test Case 13: csm_allocation_create with launch node input"
+check_return_flag_value $? 0 "Test Case 13:  csm_allocation_create with launch node input"
 
 # Test Case 13: Validate launch node in csm_allocation_query
 # Get allocation ID
 allocation_id=`grep allocation_id ${TEMP_LOG} | awk -F': ' '{print $2}'`
 ${CSM_PATH}/csm_allocation_query -a ${allocation_id} > ${TEMP_LOG} 2>&1
 check_all_output "launch_node_name:               ${utility_node}"
-check_return_flag_value $? 0 "Test Case 13: Validate launch node in csm_allocation_query"
+check_return_flag_value $? 0 "Test Case 13:  Validate launch node in csm_allocation_query"
+
+# Test Case 1a: SSH to a compute node in the allocation, does get put into the CSM system cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 0 "Test Case 1a:  SSH to node in the allocation, does get put into the CSM system cgroup"
+
+# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
+xdsh ${SINGLE_COMPUTE} "cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
+check_return_flag_value $? 1 "Test Case 1b:  SSH to node in the allocation, does not get put into the allocation cgroup"
 
 # Clean Up allocation
 ${CSM_PATH}/csm_allocation_delete -a ${allocation_id} > ${TEMP_LOG} 2>&1
-check_return_exit $? 0 "Clean up allocation"
+check_return_exit $? 0 "               Clean up allocation"
 ${CSM_PATH}/csm_allocation_query_active_all > ${TEMP_LOG} 2>&1
-check_return_exit $? 4 "Validating no active allocations"
+check_return_exit $? 4 "               Validating no active allocations"
 
 echo "------------------------------------------------------------" >> ${LOG}
 echo "           Basic Allocation Bucket Passed" >> ${LOG}

--- a/csmtest/setup/csm_install.sh
+++ b/csmtest/setup/csm_install.sh
@@ -249,6 +249,9 @@ fi
 xdcp csm_comp -p /opt/ibm/csm/share/prologs/* /opt/ibm/csm/prologs
 xdsh csm_comp,utility "/usr/bin/cp -p /opt/ibm/csm/share/recovery/soft_failure_recovery /opt/ibm/csm/recovery/soft_failure_recovery"
 
+# Set up the pam modules on the CSM compute nodes
+xdsh csm_comp "if [ -e /usr/lib64/security/libcsmpam.so ] ; then sed -i '/libcsmpam.so/s/^#*//g' /etc/pam.d/sshd ; fi"
+
 # Start Daemons
 systemctl start csmd-master
 xdsh ${AGGREGATOR_A} "systemctl start csmd-aggregator"

--- a/csmtest/setup/csm_uninstall.sh
+++ b/csmtest/setup/csm_uninstall.sh
@@ -44,6 +44,10 @@ compute_node_list=`nodels csm_comp`
 # Get list of utility nodes
 utility_node_list=`nodels utility`
 
+# Comment out any entries for libcsmpam.so in /etc/pam.d/sshd
+xdsh all "sed -i '/libcsmpam.so/s/^#*/#/g' /etc/pam.d/sshd"
+sleep 1
+
 # Stop CSM daemons on Master
 systemctl is-active csmd-master > /dev/null
 if [ $? -eq 0 ]


### PR DESCRIPTION
…n. Making sure the allocations are in the right cgroups.

# Purpose
_Add logical testing to ensure the allocations are being placed in the right cgroups when isolated cores are requested_

# How to Test
1. Recreate some of the manual test cases to understand the problem associate to issue #946.
    - Create allocations with isolated cores, etc.
    - Modify the `/etc/pam.d/sshd` (comment and uncomment the lines below)
      `account    required     libcsmpam.so` &
      `session    required     libcsmpam.so`
2. Place some of the logical checks within our current CSM FVT regression bucket(s).
3. Added in a setup section to the `csm_install.sh` script that makes sure the `/etc/pam.d/sshd` is configured properly.
4. Added in a section to the `csm_uninstall.sh` script that makes sure the `/etc/pam.d/sshd` is configured properly while uninstalling CSM on the test nodes.

# Screenshots
#### 1. Creating an allocation with the `/etc/pam.d/sshd` script commented out (both libcsmpam.so lines):
```
[root@c650f99p06 bin]# /opt/ibm/csm/bin/csm_allocation_create -n c650f99p18 -j 1 -u wcmorris --isolated_cores 2
---
allocation_id: 17
num_nodes: 1
- compute_nodes: c650f99p18
user_name: wcmorris
user_id: 9999163
state: running
type: user-managed
job_submit_time: 2020-09-23 16:36:02
...
```
#### Check to see if we are correctly placed into the allocation/system cgroup (logged in as the user):
```
[wcmorris@c650f99p18 ~]$ cat /proc/self/cgroup | egrep "allocation|csm"
7:cpuset:/csm_system
4:cpu,cpuacct:/csm_system
[wcmorris@c650f99p18 ~]$ echo $?
0
[wcmorris@c650f99p18 ~]$ cat /proc/self/cgroup | egrep csm_system
7:cpuset:/csm_system
4:cpu,cpuacct:/csm_system
[wcmorris@c650f99p18 ~]$ echo $?
0
```
#### 2. Creating an allocation with the `/etc/pam.d/sshd` script uncommented (both libcsmpam.so lines):
```
[root@c650f99p06 bin]# /opt/ibm/csm/bin/csm_allocation_create -n c650f99p18 -j 1 -u wcmorris --isolated_cores 2
---
allocation_id: 16
num_nodes: 1
- compute_nodes: c650f99p18
user_name: wcmorris
user_id: 9999163
state: running
type: user-managed
job_submit_time: 2020-09-23 16:24:50
...
```
#### Check to see if we are correctly placed into the allocation/system cgroup (logged in as the user):
(This looks better)
```
[wcmorris@c650f99p18 ~]$ cat /proc/self/cgroup | egrep "allocation|csm"
7:cpuset:/allocation_16
6:devices:/allocation_16
4:cpu,cpuacct:/allocation_16
3:memory:/allocation_16
[wcmorris@c650f99p18 ~]$ echo $?
0
[wcmorris@c650f99p18 ~]$ cat /proc/self/cgroup | egrep csm_system
[wcmorris@c650f99p18 ~]$ echo $?
1
```
#### After the test was done I manually cleaned up the allocation
```
[root@c650f99p06 bin]# /opt/ibm/csm/bin/csm_allocation_delete -a 16
---
# Allocation ID: 16 successfully deleted
...
```
Example of a check to verify if the allocation is put into the right cgroup: (`/csmtest/buckets/advanced/allocation.sh` script)
```
# Test Case 1a: SSH to a compute node in the allocation, does not get put into the CSM system cgroup?
su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep csm_system" > ${TEMP_LOG} 2>&1
check_return_flag_value $? 1 "Test Case 1a: (Section B) SSH to node in the allocation, does not get put into the CSM system cgroup"

# Test Case 1b: SSH to a compute node in the allocation, does it get put into the allocation cgroup?
su - ${USER} -c "ssh ${SINGLE_COMPUTE} cat /proc/self/cgroup | egrep allocation" > ${TEMP_LOG} 2>&1
check_return_flag_value $? 0 "Test Case 1b: (Section B) SSH to node in the allocation, does it get put into the allocation cgroup"
```

### This is check of the compute nodes after I ran `csm_install.sh`
```
[root@c650f99p06 advanced]# xdsh csm_comp "grep csm /etc/pam.d/sshd" | sort
c650f99p18: account    required     libcsmpam.so
c650f99p18: session    required     libcsmpam.so
c650f99p26: account    required     libcsmpam.so
c650f99p26: session    required     libcsmpam.so
c650f99p28: account    required     libcsmpam.so
c650f99p28: session    required     libcsmpam.so
c650f99p36: account    required     libcsmpam.so
c650f99p36: session    required     libcsmpam.so
```
This is a check after the `csm_uninstall.sh` script was executed:
<details><summary>Expand for Details</summary>
<p>

```
[root@c650f99p06 setup]# xdsh csm_comp "cat /etc/pam.d/sshd"
c650f99p36: #%PAM-1.0
c650f99p36: auth       substack     password-auth
c650f99p36: auth       include      postlogin
c650f99p36: account    required     pam_sepermit.so
c650f99p36: account    required     pam_nologin.so
c650f99p36: account    include      password-auth
c650f99p36: password   include      password-auth
c650f99p36: # pam_selinux.so close should be the first session rule
c650f99p36: session    required     pam_selinux.so close
c650f99p36: session    required     pam_loginuid.so
c650f99p36: # pam_selinux.so open should only be followed by sessions to be executed in the user context
c650f99p36: session    required     pam_selinux.so open env_params
c650f99p36: session    required     pam_namespace.so
c650f99p36: session    optional     pam_keyinit.so force revoke
c650f99p36: session    optional     pam_motd.so
c650f99p36: session    include      password-auth
c650f99p36: session    include      postlogin
c650f99p26: #%PAM-1.0
c650f99p26: auth       substack     password-auth
c650f99p26: auth       include      postlogin
c650f99p26: account    required     pam_sepermit.so
c650f99p26: account    required     pam_nologin.so
c650f99p26: account    include      password-auth
c650f99p26: password   include      password-auth
c650f99p26: # pam_selinux.so close should be the first session rule
c650f99p26: session    required     pam_selinux.so close
c650f99p26: session    required     pam_loginuid.so
c650f99p26: # pam_selinux.so open should only be followed by sessions to be executed in the user context
c650f99p26: session    required     pam_selinux.so open env_params
c650f99p26: session    required     pam_namespace.so
c650f99p26: session    optional     pam_keyinit.so force revoke
c650f99p26: session    optional     pam_motd.so
c650f99p26: session    include      password-auth
c650f99p26: session    include      postlogin
c650f99p18: #%PAM-1.0
c650f99p18: auth       substack     password-auth
c650f99p18: auth       include      postlogin
c650f99p18: account    required     pam_sepermit.so
c650f99p18: account    required     pam_nologin.so
c650f99p18: account    include      password-auth
c650f99p18: password   include      password-auth
c650f99p18: # pam_selinux.so close should be the first session rule
c650f99p18: session    required     pam_selinux.so close
c650f99p18: session    required     pam_loginuid.so
c650f99p18: # pam_selinux.so open should only be followed by sessions to be executed in the user context
c650f99p18: session    required     pam_selinux.so open env_params
c650f99p18: session    required     pam_namespace.so
c650f99p18: session    optional     pam_keyinit.so force revoke
c650f99p18: session    optional     pam_motd.so
c650f99p18: session    include      password-auth
c650f99p18: session    include      postlogin
c650f99p28: #%PAM-1.0
c650f99p28: auth       substack     password-auth
c650f99p28: auth       include      postlogin
c650f99p28: account    required     pam_sepermit.so
c650f99p28: account    required     pam_nologin.so
c650f99p28: account    include      password-auth
c650f99p28: password   include      password-auth
c650f99p28: # pam_selinux.so close should be the first session rule
c650f99p28: session    required     pam_selinux.so close
c650f99p28: session    required     pam_loginuid.so
c650f99p28: # pam_selinux.so open should only be followed by sessions to be executed in the user context
c650f99p28: session    required     pam_selinux.so open env_params
c650f99p28: session    required     pam_namespace.so
c650f99p28: session    optional     pam_keyinit.so force revoke
c650f99p28: session    optional     pam_motd.so
c650f99p28: session    include      password-auth
c650f99p28: session    include      postlogin
```
</p>
</details>

## Open Questions and Pre-Merge TODOs
- [ ] Assign @besaw for code review
- [x] Assign @williammorrison2 to review (full regression)
