### PR TITLE
fixed numpy dependency for python2 in ibm-csm-tools rpm

### DIFF
--- a/csmd/setupRPM.cmake
+++ b/csmd/setupRPM.cmake
@@ -14,9 +14,9 @@
 #================================================================================
 
 # This file is used to override rpm defaults defined in scripts/setupRPM.cmake
-# when non-default behavior is needed for csm rpms 
+# when non-default behavior is needed for csm rpms
 
-# Note: when shipping libraries to a new directory location via cmake "install ...", 
+# Note: when shipping libraries to a new directory location via cmake "install ...",
 # the new directory must be added to the CMAKE_INSTALL_RPATH in scripts/setupRPATH.cmake
 
 # ibm-csm-core rpm settings
@@ -41,4 +41,8 @@ set(CPACK_RPM_csm-hcdiag_PACKAGE_REQUIRES "perl-YAML")
 
 # ibm-csm-tools rpm settings
 set(CPACK_RPM_csm-tools_PACKAGE_ARCHITECTURE "noarch")
-set(CPACK_RPM_csm-tools_PACKAGE_REQUIRES "numpy")
+if(${EXPLICIT_PYTHON_VERSION})
+    set(CPACK_RPM_csm-tools_PACKAGE_REQUIRES "python2-numpy")
+else()
+    set(CPACK_RPM_csm-tools_PACKAGE_REQUIRES "numpy")
+endif()

--- a/csmutil/csm_log_utility/API_Statistics.py
+++ b/csmutil/csm_log_utility/API_Statistics.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python2
 import os
 import errno
 import subprocess
@@ -47,7 +48,7 @@ args = parser.parse_args()
 if(args.directory_path):
     logs_path = args.directory_path
 else:
-    logs_path = "/var/log/ibm/csm"   
+    logs_path = "/var/log/ibm/csm"
 
 #---------- Takes in user Command Line Arguments----------
 # Format: YYYY-MM-DD HH:MM::SS
@@ -118,7 +119,7 @@ for subdirectory in subdirs:
             filename = subdirectory + "/" + file
             if ("compute" in filename or "aggregator" in filename or "master" in filename or "utility" in filename) and ".log" in filename and 'Error' not in filename and '.txt' not in filename:
             # if 'log.old.5' in filename and 'txt' not in filename:
-            	file_list.append(filename)
+              file_list.append(filename)
 
 print file_list
 

--- a/csmutil/csm_log_utility/CMakeLists.txt
+++ b/csmutil/csm_log_utility/CMakeLists.txt
@@ -17,12 +17,19 @@ add_subdirectory(Helper_Files)
 add_subdirectory(Logs)
 add_subdirectory(Reports)
 
-
+# non executable files
 file(GLOB INSTALL_SCRIPTS
     "ReadMe.md"
-    "API_Statistics.py"
 )
 
 install(FILES ${INSTALL_SCRIPTS} COMPONENT csm-tools DESTINATION csm/tools)
 
-# CPACK_RPM settings for the csm-tools rpm are managed in csmd/setupRPM.cmake 
+# Files that should be executable when shipped
+
+file(GLOB INSTALL_PROGRAMS
+  "API_Statistics.py"
+)
+
+install(PROGRAMS ${INSTALL_PROGRAMS} COMPONENT csm-tools DESTINATION csm/tools)
+
+# CPACK_RPM settings for the csm-tools rpm are managed in csmd/setupRPM.cmake


### PR DESCRIPTION
# Purpose
_additional checking needed to install the right python package for the ibm-csm-tool package_

Issue #959 explains the details of specific issue.

# How to Test
_This section will help the regression tester._
1. Run: `yum install ibm-csm-tools-1.8.2-3557.noarch.rpm`
2. Run: `/opt/ibm/csm/tools/API_Statistics.py` (to see if the script is working as expected)
3. Run some tests to populate statistical information
   a. `/csm_allocation_query_active_all`
   b. `/csm_cluster_query_state`

# Screenshots
#### running `./csm_cluster_query_state` to view the state of the nodes in the test cluster.
```
[root@c650f99p06 bin]# ./csm_cluster_query_state
---
# node_name  | collection_time            | update_time                | state      | type       | num_allocs - allocs - states - shared
#            +                            +                            +            +            +
# c650f99p06 | 2020-10-07 10:55:32.633377 | 2020-10-07 10:55:37.614277 | DISCOVERED | aggregator |  0
# c650f99p16 | 2020-10-07 10:55:34.702025 | 2020-10-07 10:55:34.96512  | DISCOVERED | utility    |  0
# c650f99p18 | 2020-10-07 10:55:36.035228 | 2020-10-07 10:55:37.619655 | DISCOVERED | compute    |  0
# c650f99p26 | 2020-10-07 10:55:35.826109 | 2020-10-07 10:55:37.616991 | DISCOVERED | compute    |  0
# c650f99p28 | 2020-10-07 10:55:35.821918 | 2020-10-07 10:55:36.082632 | DISCOVERED | compute    |  0
# c650f99p30 | 2020-10-07 10:55:33.725008 | 2020-10-07 10:55:33.956479 | DISCOVERED | aggregator |  0
# c650f99p36 | 2020-10-07 10:55:35.771102 | 2020-10-07 10:55:36.091247 | DISCOVERED | compute    |  0
...
```
#### running `./csm_allocation_query_active_all` to view if there are any active allocations on the system.
```
[root@c650f99p06 tools]# ../bin/csm_allocation_query_active_all
---
num_allocations: 0
# No matching records found.
...
[root@c650f99p06 tools]# ../bin/csm_allocation_query_active_all
---
num_allocations: 0
# No matching records found.
...
[root@c650f99p06 tools]# ../bin/csm_allocation_query_active_all
---
num_allocations: 0
# No matching records found.
...
```
#### running `./API_Statistics.py` to view statistical information from the log files.
```
[root@c650f99p06 tools]# ./API_Statistics.py
Search from:  1000-01-01 00:00:00 to 9999-01-01 00:00:00
['/var/log/ibm/csm/csm_aggregator.log', '/var/log/ibm/csm/csm_master.log']
Aggregate: /var/log/ibm/csm/csm_aggregator.log
Master: /var/log/ibm/csm/csm_master.log
+++++++++++++++++++++++++++++++++++++++++++++++++++Aggregator Log++++++++++++++++++++++++++++++++++++++++++++++++++
----------------------------------------/var/log/ibm/csm/csm_aggregator.log----------------------------------------
Api Function                                       Frequency   Mean      Median    Min       Max       Std
Total Calls:  0
Total Errors: 0

Run Time: 0.00492596626282

+++++++++++++++++++++++++++++++++++++++++++++++++++++Master Log++++++++++++++++++++++++++++++++++++++++++++++++++++
------------------------------------------/var/log/ibm/csm/csm_master.log------------------------------------------
------------------File Start: 2020-10-07 10:55:31.607989 and File End: 2020-10-08 08:46:23.582522------------------
Api Function                                       Frequency   Mean      Median    Min       Max       Std
csm_allocation_query_active_all                             3  0.002038  0.001674  0.001612  0.002829  0.000560
csm_cluster_query_state                                     1  0.001775  0.001775  0.001775  0.001775  0.000000
Total Calls:  4
Total Errors: 0

Run Time: 0.00805401802063
```

## Open Questions and Pre-Merge TODOs
- [ ] Assign @williammorrison2 to review (check regression)
- [ ] Assign @besawn (code review)
