### PR TITLE
Do csm init of structures, use local string for config get vg name

### DIFF
--- a/bb/src/nodecontroller_csm.cc
+++ b/bb/src/nodecontroller_csm.cc
@@ -178,7 +178,7 @@ NodeController_CSM::NodeController_CSM():
     vg.ssd_info[0]    = &ssdinfo;
 
     LOG(bb,info) << "Trying to create volume group:  ssd=" << nvmssd << "  vgfree=" << vgfree 
-                 << "  vgtotal=" << vgtotal << " volumeGroup="<< volumeGroup;
+                 << "  vgtotal=" << vgtotal << " volumeGroup="<< volumeGroup << "hostname=" << myhostname;
     rc = _csm_bb_vg_create_func(&csmhandle, &vg);
     LOG(bb,info) << "csm_bb_vg_create() rc=" << rc;
 
@@ -369,6 +369,8 @@ int NodeController_CSM::lvcreate(const string& lvname, enum LVState state, size_
     csmi_allocation_t allocinfo;
     char statechar;
 
+    string volumeGroup = config.get(process_whoami+".volumegroup", "bb");
+
     LOG(bb,info) << "Created logical volume for Uuid '" << lvname << "'  size=" << current_size << "  state=" << state << "  mountpath=" << mountpath << "   fstype=" << fstype;
 
     convertState(state, statechar);
@@ -379,7 +381,7 @@ int NodeController_CSM::lvcreate(const string& lvname, enum LVState state, size_
     bbargs.logical_volume_name = (char*)lvname.c_str();
     bbargs.node_name           = (char*)myhostname.c_str();
     bbargs.allocation_id       = allocinfo.allocation_id;
-    bbargs.vg_name             = (char*)config.get(process_whoami+".volumegroup", "bb").c_str();
+    bbargs.vg_name             = (char*)volumeGroup.c_str();
     bbargs.state               = statechar;
     bbargs.current_size        = current_size;
     bbargs.file_system_mount   = (char*)mountpath.c_str();

--- a/bb/src/nodecontroller_csm.cc
+++ b/bb/src/nodecontroller_csm.cc
@@ -178,7 +178,7 @@ NodeController_CSM::NodeController_CSM():
     vg.ssd_info[0]    = &ssdinfo;
 
     LOG(bb,info) << "Trying to create volume group:  ssd=" << nvmssd << "  vgfree=" << vgfree 
-                 << "  vgtotal=" << vgtotal << " volumeGroup="<< volumeGroup << "hostname=" << myhostname;
+                 << "  vgtotal=" << vgtotal << " volumeGroup="<< volumeGroup << " hostname=" << myhostname;
     rc = _csm_bb_vg_create_func(&csmhandle, &vg);
     LOG(bb,info) << "csm_bb_vg_create() rc=" << rc;
 

--- a/bb/src/nodecontroller_csm.h
+++ b/bb/src/nodecontroller_csm.h
@@ -33,6 +33,10 @@ typedef int (*csm_bb_vg_create_t)(csm_api_object **handle, csm_bb_vg_create_inpu
 typedef int (*csm_bb_lv_create_t)(csm_api_object **handle, csm_bb_lv_create_input_t* input);
 typedef int (*csm_bb_lv_delete_t)(csm_api_object **handle, csm_bb_lv_delete_input_t* input);
 typedef int (*csm_bb_lv_update_t)(csm_api_object **handle, csm_bb_lv_update_input_t* input);
+//csmi/include/csmi_type_bb_funct.h:369:void init_csm_bb_vg_create_input_t( csm_bb_vg_create_input_t *target );
+typedef void (*init_csm_bb_vg_create_input_type)(csm_bb_vg_create_input_t *target);
+//csmi/include/csmi_type_bb_funct.h:121:void init_csmi_bb_vg_ssd_info_t( csmi_bb_vg_ssd_info_t *target );
+typedef void (*init_csmi_bb_vg_ssd_info_type)(csmi_bb_vg_ssd_info_t  *target);
 
 
 typedef int (*csm_bb_cmd_t)(csm_api_object **handle, csm_bb_cmd_input_t* input, csm_bb_cmd_output_t** output);
@@ -71,6 +75,8 @@ class NodeController_CSM : public NodeController
     csm_allocation_query_t   _csm_allocation_query_func;
     csm_allocation_query_active_all_t _csm_allocation_query_active_all_func;
     free_csm_allocation_query_active_all_output_t_t free_csm_allocation_query_active_all_output_t_func;
+    init_csm_bb_vg_create_input_type _init_csm_bb_vg_create_input_t_func;
+    init_csmi_bb_vg_ssd_info_type _init_csmi_bb_vg_ssd_info_t_func;
     csm_api_object* csmhandle;
     std::string myhostname;
     std::map< std::pair<uint64_t,uint32_t>, csmi_allocation_t* > job2allocationmap;


### PR DESCRIPTION
Unit tested that db entry has bb for volume group on IST systems f5n01 and f5n05.
