### PR TITLE
Sort compute node output for csm_allocation_query and CSM/JSM launch.

### DIFF
--- a/csmd/src/daemon/src/CMakeLists.txt
+++ b/csmd/src/daemon/src/CMakeLists.txt
@@ -171,6 +171,7 @@ file(GLOB CSM_DAEMON_SRC
   csmi_request_handler/csmi_mcast/CSMIMcastBB.cc
 
   # JSRUN
+  csmi_request_handler/csmi_sort_hosts.cc
   csmi_request_handler/CSMIJSRUNCMD.cc
   csmi_request_handler/CSMIJSRUNCMDAgentState.cc
   csmi_request_handler/csmi_mcast/CSMIMcastJSRUN.cc

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationQuery.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIAllocationQuery.cc
@@ -16,6 +16,8 @@
 #include "CSMIAllocationQuery.h"
 #include "csmi_stateful_db/CSMIStatefulDBRecvSend.h"
 
+#include "csmi_sort_hosts.h"
+
 #define STATE_NAME "CSMIAllocationQuery:"
 // Use this to make changing struct names easier.
 #define INPUT_STRUCT csm_allocation_query_input_t
@@ -197,8 +199,6 @@ bool CSMIAllocationQuery::CreateResponsePayload(
         csm::db::DBReqContent *dbReq = new csm::db::DBReqContent( stmt, paramCount );
         dbReq->AddNumericParam<int64_t>(allocation->allocation_id);
         *dbPayload = dbReq;
-
-
     }
     else
     {
@@ -237,14 +237,15 @@ bool CSMIAllocationQuery::CreateByteArray(
         if ( numRecords > 0 )
         {
             output.allocation->compute_nodes = (char **)malloc(sizeof(char *) * numRecords);
-        }
 
-        for(uint32_t i = 0; i < numRecords; ++i)
-        {
-            if ( tuples[i] && tuples[i]->data)
+            for(uint32_t i = 0; i < numRecords; ++i)
             {
-                output.allocation->compute_nodes[i] = strdup(tuples[i]->data[0]);
+                if ( tuples[i] && tuples[i]->data)
+                {
+                    output.allocation->compute_nodes[i] = strdup(tuples[i]->data[0]);
+                }
             }
+            qsort(output.allocation->compute_nodes, numRecords, sizeof(char *), &csmi_hostname_compare);
         }
 
         // Serialize and free.

--- a/csmd/src/daemon/src/csmi_request_handler/CSMIJSRUNCMD.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/CSMIJSRUNCMD.cc
@@ -24,6 +24,8 @@
 
 #include "csmi_stateful_db/CSMIStatefulDBInit.h"
 
+#include "csmi_sort_hosts.h"
+
 #define STATE_NAME "CSMIJSRUNCMD"
 
 // Use this to make changing struct names easier.
@@ -206,6 +208,7 @@ bool CSMIJSRUNCMD_Master::ParseAuthQuery(
                 nodeStr = strtok_r(NULL, ",\"{}", &saveptr);
             }
             mcast_ctx->num_nodes = i;
+            qsort(mcast_ctx->compute_nodes, mcast_ctx->num_nodes, sizeof(char *), &csmi_hostname_compare);
         }
         else
         {

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_sort_hosts.cc
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_sort_hosts.cc
@@ -1,0 +1,16 @@
+#include <string.h> // strverscmp()
+
+#include "csmi_sort_hosts.h"
+
+int
+csmi_hostname_compare(const void *hosta, const void *hostb) {
+  const char *p1, *p2;
+
+  p1 = *(char **)hosta; p2 = *(char **)hostb;
+  // handle degenrate cases that should never happen:
+  if (p1 && !p2) { return -1; }
+  else if (p2 && !p1) { return 1; }
+  else if (!p1 && !p2) { return 0; }
+
+  return strverscmp(p1, p2);
+}

--- a/csmd/src/daemon/src/csmi_request_handler/csmi_sort_hosts.h
+++ b/csmd/src/daemon/src/csmi_request_handler/csmi_sort_hosts.h
@@ -1,0 +1,6 @@
+#ifndef _CSMI_SORT_HOSTS
+#define _CSMI_SORT_HOSTS
+
+int csmi_hostname_compare(const void *hosta, const void *hostb);
+
+#endif


### PR DESCRIPTION
Currently, each compute node jsmd has to sort this list to make sure it is in a consistent ordering.
Instead of sorting it on each jsmd node, sort this via the sql query, which is probably more efficient.