### PR TITLE
Prefer xcat name if available over hostname

### DIFF
--- a/bb/src/bbcmd.cc
+++ b/bb/src/bbcmd.cc
@@ -1211,6 +1211,14 @@ int main(int orig_argc, const char** orig_argv)
         config = curConfig.getTree();
 
         initializeLogging("bb.cmd.log", config);
+        //int orig_argc, const char** orig_argv
+        string received = orig_argv[0];
+        string space = " ";
+        for(int i=1;i<orig_argc;i++){
+            string tmp = orig_argv[i];
+            received+=space+tmp;
+        }
+        LOG(bb,info)<<"Received line\n"<<received;
 
         // NOTE:  The final support for send_to requires a proxy running on the FEN that forwards the request to the correct
         //        bbproxy server.  That has not been provided yet...

--- a/bb/src/nodecontroller.h
+++ b/bb/src/nodecontroller.h
@@ -40,12 +40,15 @@ enum LVState
 // Control System abstraction class
 //
 class NodeController
-{
+{ private:
+    std::string _hostname;
+    std::string _xcatname;
   public:
     /**
      * \brief Destructor
      */
     NodeController();
+    void getXCATname();
     virtual ~NodeController();
 
     virtual int gethostname(std::string& pHostName);


### PR DESCRIPTION
Unit testing on f5n05 and ln01.  Code impacts running of bbcmd on compute node.  

Previous errors of "no data" have gone away.  

Materials from a bsub run are in:
/ESS/gpfst/meaho/workdir/30925
```[0907][meaho@ln01:/ESS/gpfst/meaho/workdir/30925]
$ ls -l
total 70
-rw-r--r-- 1 root  root  6563 Nov 12 20:07 30925-cat.txt
-rw------- 1 meaho meaho 7446 Nov 12 20:04 30925.env
-rw-rw-r-- 1 meaho meaho  167 Nov 12 20:06 30925.err
-rw------- 1 meaho meaho 1207 Nov 12 20:05 30925.log
-rw-rw-r-- 1 meaho meaho 2065 Nov 12 20:06 30925.out
drwxr-xr-x 2 root  root  4096 Nov 13 09:04 bbcmd-fn05
drwxr-xr-x 2 root  root  4096 Nov 13 08:45 bbcmd-ln01
-rw-r--r-- 1 root  root  5024 Nov 13 08:54 bb_stagein-30925.log
-rw-r--r-- 1 root  root  3793 Nov 13 08:54 bb_stageout-30925.log
-rw-rw-r-- 1 meaho meaho 5008 Nov 13 09:07 bhist-l-30925.txt```