### PR TITLE
Fix exception bbcmd no arguments at bbcmd.cc:1026 strchr(argv[1]

### DIFF
--- a/bb/src/bbcmd.cc
+++ b/bb/src/bbcmd.cc
@@ -1023,7 +1023,7 @@ int main(int orig_argc, const char** orig_argv)
     map<int, string> contribResults;
 
 
-    if(strstr(argv[1], "^") != NULL)
+    if( (orig_argc>1) && ( strstr(argv[1], "^") != NULL) )
     {
         carrotTokens = buildTokens(argv[1], "^");
         command = argv[0];


### PR DESCRIPTION
gdb of bbcmd <noargs>
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff6e88e94 in __strchr_power7 () from /lib64/libc.so.6

gdb) bt
#0  0x00007ffff6e88e94 in __strchr_power7 () from /lib64/libc.so.6
#1  0x0000000010022d84 in strstr (__needle=0x10066cc0 "^", __haystack=<optimized out>) at /usr/include/string.h:333
#2  main (orig_argc=<optimized out>, orig_argv=0x7ffffffff148) at /u/meaho/CAST/bb/src/bbcmd.cc:1026

CAST/bb/src/bbcmd.cc:1026
if(strstr(argv[1], "^") != NULL)
argv[1] is NULL

