### PR TITLE
For bbcmd OPEN_SERVER message to bbproxy, fix bbproxy connecting via SSL to named 

### DIFF
--- a/bb/ansible/bbCheck.yml
+++ b/bb/ansible/bbCheck.yml
@@ -18,6 +18,7 @@
     command:  /bin/systemctl status bbserver.service 
     register: bbserver_service_result
     ignore_errors: yes
+    changed_when: false
 
   - debug:
       msg:  bbserver.service is not running
@@ -29,6 +30,7 @@
     command:  /bin/systemctl status bbproxy.service 
     register: bbproxy_service_result
     ignore_errors: yes
+    changed_when: false
 
   - debug:
       msg:  bbproxy.service is not running
@@ -38,8 +40,10 @@
     shell: lsmod |grep export_layout 
     register: export_layout_loaded
     ignore_errors: yes
+    changed_when: false
 
-  - debug:
+  - name:  check export_layout module is NOT loaded
+    ansible.builtin.debug:
       msg: export_layout module is NOT loaded
     when:  export_layout_loaded.rc != 0 
    

--- a/bb/ansible/bbInstall.yml
+++ b/bb/ansible/bbInstall.yml
@@ -26,10 +26,12 @@
 
 - hosts: server
   tasks:
-  - name: Skip any activation if bbserver is running
+  - name: Skip RPM installs if bbserver is running
     command:  /bin/systemctl status bbserver.service 
     register: bbserver_service_result
     ignore_errors: yes
+    changed_when: false
+    failed_when: "bbserver_service_result.rc != 4"
 
   - name: Install BB RPMs on ESS
     shell: "dnf install -y ibm-burstbuffer"
@@ -44,6 +46,7 @@
     shell: lsmod |grep export_layout 
     register: export_layout_loaded
     ignore_errors: yes
+    changed_when: false
 
   - name: install export RPM on Compute
     shell: "dnf install -y ibm-export_layout"
@@ -56,10 +59,12 @@
     shell: lsmod |grep export_layout 
     any_errors_fatal: true
     
-  - name: Skip any activation if bbproxy is running
+  - name: Skip RPM installs if bbproxy is running
     command:  /bin/systemctl status bbproxy.service 
     register: bbproxy_service_result
     ignore_errors: yes
+    changed_when: false
+    failed_when: "bbproxy_service_result.rc != 4"
 
   - name: install BB RPMs on Compute
     shell: "dnf install -y ibm-burstbuffer ibm-burstbuffer-tools ibm-burstbuffer-tests"

--- a/bb/ansible/bbStart.yml
+++ b/bb/ansible/bbStart.yml
@@ -18,6 +18,9 @@
     command:  /bin/systemctl status bbserver.service 
     register: bbserver_service_result
     ignore_errors: yes
+    changed_when: false
+    failed_when: "bbserver_service_result.rc != 3"
+
 
   - name: Start bbServer
     command: /opt/ibm/bb/scripts/bbactivate --server {{BBACTIVATE_PARMS}}
@@ -26,8 +29,8 @@
 
   - name: Fail if bbserver daemon is not now running
     command:  /bin/systemctl status bbserver.service 
-    register: bbserver_service_result
     any_errors_fatal: true  
+    changed_when: false
 
 - hosts: compute
   tasks:
@@ -35,6 +38,7 @@
     shell: lsmod |grep export_layout 
     register: export_layout_loaded
     ignore_errors: yes
+    changed_when: false 
 
   - name: modprobe export_layout module 
     command: modprobe export_layout 
@@ -45,6 +49,8 @@
     command:  /bin/systemctl status bbproxy.service 
     register: bbproxy_service_result
     ignore_errors: yes
+    changed_when: false
+    failed_when: "bbproxy_service_result.rc != 3"
 
   - name: Start BB on computes
     command: /opt/ibm/bb/scripts/bbactivate --cn {{BBACTIVATE_PARMS}}
@@ -54,6 +60,7 @@
     command:  /bin/systemctl status bbproxy.service 
     register: bbproxy_service_result
     any_errors_fatal: true
+    changed_when: false
 
   - name: Waiting for bbProxy to start accepting bbcmd connections
     wait_for:

--- a/bb/ansible/bbUninstall.yml
+++ b/bb/ansible/bbUninstall.yml
@@ -17,34 +17,27 @@
   - name: Check if bbproxy daemon is running
     command:  /bin/systemctl status bbproxy.service 
     register: bbproxy_service_status
-    ignore_errors: yes
+    changed_when: false
+    failed_when: bbproxy_service_status.rc == 0
 
-  - fail:  
-     msg: bbproxy daemon is still running 
-    when: bbproxy_service_status.rc == 0
-
-  - name: remove old mount directories on /mnt/bb_
-    shell: rmdir /mnt/bb_*
-    args:
-      warn: false # set warn=false to prevent warning
-    ignore_errors: yes
-
-  - name: check for directories /mnt/bb)  
-    shell: "ls /mnt/bb_*"
+  - name: check for directories /mnt/bb_  
+    shell: "ls /mnt |grep -c bb_"
     register: ls_result
     ignore_errors: yes
+    changed_when: false
+    failed_when: false  
 
   - name: unmount all old burst buffer volumes
     shell: umount /mnt/bb_*
     ignore_errors: yes
-    when: ls_result.rc == 2
+    when: ls_result.stdout|int != 0
 
   - name: remove unmounted directories on /mnt/bb_
     shell: rmdir /mnt/bb_*
     args:
       warn: false # set warn=false to prevent warning
     ignore_errors: yes
-    when: ls_result.rc == 2
+    when: ls_result.stdout|int != 0
 
 - hosts: server
   tasks:
@@ -52,10 +45,8 @@
     command:  /bin/systemctl status bbserver.service 
     register: bbserver_service_status
     ignore_errors: yes
-
-  - fail:  
-     msg: bbserver daemon is still running 
-    when: bbserver_service_status.rc == 0
+    changed_when: false
+    failed_when: bbserver_service_status.rc == 0
 
 - hosts: all
   tasks:
@@ -73,7 +64,8 @@
       warn: false # set warn=false to prevent warning
     register: csmcore_result
     ignore_errors: yes
-    
+    changed_when: false
+    failed_when: false
 
   - name: remove ibm flightlog RPM if no csm-core installed
     shell: dnf erase -y ibm-flightlog 
@@ -94,13 +86,12 @@
     shell: lsmod |grep export_layout 
     register: export_layout_loaded
     ignore_errors: yes  
+    changed_when: false
 
-  - debug: 
+# No longer fail but do warn since export_layout rarely changes but testers may be using sandbox bb code
+  - name: Warn if export_layout module is still loaded
+    ansible.builtin.debug: 
       msg: export_layout module STILL loaded
-    when:  export_layout_loaded.rc == 0
-
-  - fail: 
-     msg: failing since export_layout module STILL loaded
     when: export_layout_loaded.rc == 0
 
 

--- a/bb/ansible/certificates.yml
+++ b/bb/ansible/certificates.yml
@@ -16,19 +16,22 @@
 
 - hosts: localhost
   tasks:
-    - debug: 
-       msg:  "key file={{FQP_KEYFILE}}"
-    - debug: 
-       msg:  "certificate file={{FQP_CERTFILE}}"   
+    - name: show key file and certificate file names via debug msg
+      debug: 
+        msg:  
+        - "key file={{FQP_KEYFILE}}"
+        - "certificate file={{FQP_CERTFILE}}"   
 
 
     - name: Check for certificate key file 
       command: ls -l {{FQP_KEYFILE}}
       any_errors_fatal: true
+      changed_when: false
 
     - name: Check for certificate file 
       command: ls -l {{FQP_CERTFILE}} 
-      any_errors_fatal: true     
+      any_errors_fatal: true    
+      changed_when: false 
  
 - hosts: server compute
   tasks:

--- a/bb/ansible/nodelist.yml
+++ b/bb/ansible/nodelist.yml
@@ -34,6 +34,7 @@
   - name: echo hostname
     shell: echo "{{ inventory_hostname }}"
     register: hostnamevar
+    changed_when: false
 
   - name: build host list
     lineinfile:

--- a/bb/src/bbproxy.cc
+++ b/bb/src/bbproxy.cc
@@ -5005,11 +5005,14 @@ int doAuthenticate(const string& name){
     rc = ((txp::Attr_int32*)msg->retrieveAttrs()->at(txp::resultCode))->getData();
     if (rc) {
         stringstream errorText;
-        errorText <<"CORAL_AUTHENICATE(SSL) failed contribid=" << contribid \
+        errorText <<"<== CORAL_AUTHENICATE(SSL) failed contribid=" << contribid \
         << ", process_whoami=" << process_whoami.c_str() << ", process_instance=" << process_instance.c_str() \
         << ", msg#=" << msg->getMsgNumber() << ", rqstmsg#=" << msg->getRequestMsgNumber() << ", rc=" << rc;
         LOG_ERROR_TEXT_ERRNO(errorText, EINVAL);
         SET_RC_AND_RAS(rc, bb.net.authfailed);
+    }
+    else {
+        LOG(bb,info) << "<== Received CORAL_AUTHENTICATE(SSL) rsp from " << name.c_str();
     }
 
     delete msg;

--- a/bb/src/connections.cc
+++ b/bb/src/connections.cc
@@ -1154,7 +1154,7 @@ int makeConnection2bbserver(const std::string& pName)
         return ENOTCONN;
     }
     addToConnectionMapsWithDoorbell(newconnection_sock);
-    sleep(1);//Wait a second for any outstanding SSL (re)negotiations to complete (avoid SSL read lockup)
+    sleep(1);//Wait a second for any outstanding SSL (re)negotiations to complete 
     std::string l_newconnection_name = newconnection_sock->getConnectName();
     int rc=xchgWithBBserver(l_newconnection_name);
     return rc;

--- a/bb/src/connections.cc
+++ b/bb/src/connections.cc
@@ -406,6 +406,7 @@ void connection_authenticate(txp::Id id, txp::Connex* conn, txp::Msg*& msg)
 #ifdef BBSERVER
 		    std::string l_newconnection_name = string(receivedFromWhoami) + string(".") + to_string(++newconnection_name_sequence_number)
             + " (" + conn->getRemoteAddrString() + ")";
+            LOG(bb,info) << "<== Received CORAL_AUTHENTICATE(SSL) from " << l_newconnection_name.c_str();
 #else
 		    std::string l_newconnection_name = string(receivedFromWhoami) + string(instance);
 #endif
@@ -429,6 +430,9 @@ void connection_authenticate(txp::Id id, txp::Connex* conn, txp::Msg*& msg)
     txp::Attr_int32 resultcode(txp::resultCode, rc);
     response->addAttribute(&resultcode);
     if (rc) {addBBErrorToMsg(response);}
+#ifdef BBSERVER
+    LOG(bb,info) << "==>  CORAL_AUTHENTICATE(SSL) rsp to" << conn->getRemoteAddrString() << " rc="<<rc;
+#endif    
     int rc_write=conn->write(response);
     if (rc_write <= 0) {
         conn->disconnect();
@@ -1150,6 +1154,7 @@ int makeConnection2bbserver(const std::string& pName)
         return ENOTCONN;
     }
     addToConnectionMapsWithDoorbell(newconnection_sock);
+    sleep(1);//Wait a second for any outstanding SSL (re)negotiations to complete (avoid SSL read lockup)
     std::string l_newconnection_name = newconnection_sock->getConnectName();
     int rc=xchgWithBBserver(l_newconnection_name);
     return rc;
@@ -1569,7 +1574,6 @@ int setupBBproxyListener(string whoami)
                 delete sslSock;
                 return -1;
             }
-
             sslSock->setLocalAddr(iplocal, port);
             try{
                 sslSock->loadCertificates(cert,key);
@@ -1886,14 +1890,23 @@ void* responseThread(void* ptr)
                         lockConnectionMaps("responseThread - accept remote SSL connection");
                         {
                             (connections[pollinfo[idx].fd])->accept(newsock);
-                            newsock->keepAlive();
-                            connections[newsock->getSockfd()] = newsock;
+                            if (newsock){
+                              newsock->keepAlive();  //assumes newsock is valid
+                              connections[newsock->getSockfd()] = newsock;
+                            }
+                            
                         }
                         unlockConnectionMaps("responseThread - accept remote SSL connection");
-
+                        
                         bberror.clear();
-
-                        FL_Write(FLConn, FL_AcceptDoneSSL, "Remote SSL connection was connected.  fd=%ld",newsock->getSockfd(),0,0,0);
+                        if (newsock) {
+                            FL_Write(FLConn, FL_AcceptDoneSSL, "Remote SSL connection was connected.  fd=%ld",newsock->getSockfd(),0,0,0);
+                        }
+                        else {
+                            FL_Write(FLConn, FL_RejectSSL, "Remote SSL connection was rejected.", 0,0,0,0);
+                            LOG(bb,error) << "Remote SSL connection was rejected.";
+                        }
+                        
                     }
                     else if( __glibc_unlikely(pollinfo[idx].fd == unix_listen_socket) )
                     {
@@ -2004,6 +2017,9 @@ void* responseThread(void* ptr)
                                     }
                                 }
                             }
+                        }
+                        else if (rc== (-EAGAIN) ){//-1 on reading message, errno=EAGAIN
+                           LOG(bb,info) << " EAGAIN for fd="<<pollinfo[idx].fd<<" connection="<< connections[pollinfo[idx].fd]->getInfoString();
                         }
                         else //rc!=0
                         {

--- a/transport/include/CnxSock.h
+++ b/transport/include/CnxSock.h
@@ -98,7 +98,7 @@ struct sockaddr_in {
                    return "CnxSock=(L)"+getLocalAddr4withPort()+"/(R)"+ getRemoteAddr4withPort();
                 }
 
-		inline void setNoDelay(bool value) {
+		inline void setNoDelay(int value) {
 			int val = value;//1 for on, 0 for off
 			if (setsockopt(_sockfd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) != 0) {
 				printf("%s setsockopt failed errno=%d(%s)\n",__PRETTY_FUNCTION__,errno,strerror(errno));

--- a/transport/src/CnxSock.cc
+++ b/transport/src/CnxSock.cc
@@ -132,7 +132,7 @@ int CnxSock::accept(txp::Connex* &pNewSock) {
 
 int CnxSock::acceptRemote() {
 	if (accept()==-1) return -errno;
-        setNoDelay(true);
+        setNoDelay(1);
         
 	return 0;
 }
@@ -184,6 +184,7 @@ int CnxSock::connect2Remote(){
 	if (_rcLast<0) {
 		LOG(txp,warning)<< __PRETTY_FUNCTION__<<"_rcLast"<< _rcLast<< " errno="<<errno<<", "<<strerror(errno);
 	} else {
+		setNoDelay(1);
 		_sockaddrlen=sizeof(_sockaddrLocal);
 		int RCgetsockname = getsockname(_sockfd, &_sockaddrLocal, &_sockaddrlen);
         if (RCgetsockname) {


### PR DESCRIPTION
Tested under bbrobot fvt and now works.
Improved ansible processing for updating burst buffer RPMs.
Track AUTHENTICATE message in logs.
LOG SSL_errror if it occurs on SSL_accept, SSL_connect, etc.

When processing OPEN_SERVER from bbcmd, bbproxy sleeps one second after SSL_connect to give SSL (re)negotiation to complete before sending AUTHENTICATE message to bbserver.  The SSL protocol and the application use the same socket for read/write.  The sleep(1) gives the open SSL protocol engine time to complete any hand shake between bbproxy and bbserver.  

Fix rare exception for a null pointer in connect.cc when a connection object is not returned because connect failed.