### PR TITLE
CSM BDS logstash dependency fixes

### DIFF
--- a/csm_big_data/logstash/CMakeLists.txt
+++ b/csm_big_data/logstash/CMakeLists.txt
@@ -24,6 +24,7 @@ file(GLOB INSTALL_PROGRAMS
   "config-scripts/deployConfigs.sh"
   "config-scripts/removeConfigs.sh"
   "patches/csm_logstash_6-8-1_patch.sh"
+  "patches/csm_logstash_patch_jruby_9.2.8.sh"
 )
 
 install(PROGRAMS ${INSTALL_PROGRAMS} COMPONENT ${BDS_RPM_NAME} DESTINATION ${BDS_BASE_NAME}/${SUBDIR})

--- a/csm_big_data/logstash/patches/csm_logstash_patch_jruby_9.2.8.sh
+++ b/csm_big_data/logstash/patches/csm_logstash_patch_jruby_9.2.8.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+#================================================================================
+#
+#    csm_logstash_patch_9.2.8.sh
+#
+#    © Copyright IBM Corporation 2021. All Rights Reserved
+#
+#    This program is licensed under the terms of the Eclipse Public License
+#    v1.0 as published by the Eclipse Foundation and available at
+#    http://www.eclipse.org/legal/epl-v10.html
+#
+#    U.S. Government Users Restricted Rights:  Use, duplication or disclosure
+#    restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+#================================================================================
+
+
+
+#=================
+#
+# Reason for this patch: 
+#
+# When the JRuby Application (logstash) is loaded a LoadError is thrown by ffi/ffi. The bubbled error message is somewhat vague (to a user ignorant to JRuby).
+#
+# [2019-05-03T10:41:38,701][ERROR][org.logstash.Logstash    ] 
+# java.lang.IllegalStateException: Logstash stopped processing because of an error: 
+# (LoadError) load error: ffi/ffi -- java.lang.NullPointerException: null
+#
+# I was able to trace the bug to jruby/lib/ruby/stdlib/ffi/platform/powerpc64-linux/. It looks
+# as though the platform.conf file was not created for this platform. Copying the types.conf file to platform.conf appears to resolve the problem.
+#
+# GitHub Issue: https://github.com/elastic/logstash/issues/10755
+#
+#==================
+
+
+STARTDIR=$(pwd)
+JARDIR="/usr/share/logstash/logstash-core/lib/jars"
+JAR="jruby-complete-9.2.8.0.jar"
+
+JRUBYDIR="${JAR}-dir"
+PLATDIR="META-INF/jruby.home/lib/ruby/stdlib/ffi/platform/powerpc64le-linux"
+
+cd ${JARDIR}
+unzip -d ${JRUBYDIR} ${JAR}
+cd "${JRUBYDIR}/${PLATDIR}"
+cp -n types.conf platform.conf
+cd "${JARDIR}/${JRUBYDIR}"
+
+zip -r jruby-complete-9.2.8.0.jar *
+mv  -f jruby-complete-9.2.8.0.jar ..
+cd ${JARDIR}
+rm -rf ${JRUBYDIR}
+
+sync
+sync
+cd ${STARTDIR}

--- a/csm_big_data/logstash/patches/csm_logstash_patch_jruby_9.2.8.sh
+++ b/csm_big_data/logstash/patches/csm_logstash_patch_jruby_9.2.8.sh
@@ -2,7 +2,7 @@
 
 #================================================================================
 #
-#    csm_logstash_patch_9.2.8.sh
+#    csm_logstash_patch_jruby_9.2.8.sh
 #
 #    © Copyright IBM Corporation 2021. All Rights Reserved
 #

--- a/csm_big_data/logstash/plugins/csm_event_correlator/Gemfile
+++ b/csm_big_data/logstash/plugins/csm_event_correlator/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gemspec
 gem "logstash", github => "elastic/logstash", :branch => "2.3"
+gem 'jar-dependencies', '~> 0.4.0'

--- a/csm_big_data/logstash/plugins/csm_event_correlator/build.sh
+++ b/csm_big_data/logstash/plugins/csm_event_correlator/build.sh
@@ -28,7 +28,8 @@ mv logstash-filter-csm-event-correlator-*.gem logstash/
 
 # Fetch all of the dependencies.
 cd logstash/dependencies
-gem fetch logstash-codec-plain
+gem fetch logstash-codec-plain -v 3.0.6
+gem install jar-dependencies -v 0.4.0
 
 # Return home and zip the file.
 cd ${SCRIPT_HOME}


### PR DESCRIPTION
# Purpose
This fixes the dependency/compatibility issues with logstash that we are testing with
`logstash-7.5.1-1_ol001.el8.ppc64le.rpm`

additional prerequisite:
`java-11` is also needed.

Needed dependencies while setting up:
* logstash-codec-plain -v 3.0.6
* jar-dependencies -v 0.4.0

The `csm_big_data/logstash/plugins/csm_event_correlator/build.sh` script would try to pull in the latest versions of
* logstash-codec-plain 3.1.0
* jar-dependencies 0.4.1

This was the error message while trying to install the CSM BDS RPMS `ibm-csm-bds-`, `ibm-csm-bds-logstash-`
```
ERROR: An error occured when installing the: file:///opt/ibm/csm/bigdata/logstash/plugins/logstash-filter-csm-event-correlator.zip, to have more information about the error add a DEBUG=1 before running the command., message: You have requested:
  logstash-codec-plain = 3.1.0

The bundle currently has logstash-codec-plain locked at 3.0.6.
Try running `bundle update logstash-codec-plain`

If you are updating multiple gems in your Gemfile at once,
```

# How to Test
1. Modify and create the appropriate files:
*  `csm_big_data/logstash/CMakeLists.txt` (added in the jruby patch script as an executable)
*  `csm_big_data/logstash/patches/csm_logstash_patch_jruby_9.2.8.sh` (added this script The user might need to patch the jruby jar to a new level due to the included jar file having a back level)
*  csm_big_data/logstash/plugins/csm_event_correlator/Gemfile (added in gem 'jar-dependencies', '~> 0.4.0')
*  csm_big_data/logstash/plugins/csm_event_correlator/build.sh (added in following lines)
```
gem fetch logstash-codec-plain -v 3.0.6
gem install jar-dependencies -v 0.4.0
```
2. Build CSM against the changes that were implemented.
3. Install the CSM and BDS environment
4. Run some CSM allocations through the pipeline to ensure the whole ELK stack is working.
5. View the details of the allocations in the Kibana GUI.
Here are some useful links:
### Logstash
[logstash-7-5-1 download](https://www.elastic.co/downloads/past-releases/logstash-7-5-1)
[logstash-7-5-1 guide](https://www.elastic.co/guide/en/logstash/7.5/logstash-7-5-1.html)
### RubyJems
[logstash-codec-plain 3.0.6](https://rubygems.org/gems/logstash-codec-plain/versions/3.0.6)
[jar-dependencies 0.4.0](https://rubygems.org/gems/jar-dependencies/versions/0.4.0)
[jruby-jars 9.2.8.0](https://rubygems.org/gems/jruby-jars/versions/9.2.8.0)

## Open Questions and Pre-Merge TODOs
- [ ] @besawn to review code.
- [x] @thanh-lam to review code (IST Test).
- [x] @williammorrison2 to review testing and CSM FVT regression.