### PR TITLE
Skip token of newline in getLocalReadWrite to avoid stoull(newline)

### DIFF
--- a/bb/src/usage.cc
+++ b/bb/src/usage.cc
@@ -300,8 +300,7 @@ int proxy_GetDeviceUsage(uint32_t devicenum, BBDeviceUsage_t& usage)
         string name = tokens[0];
         string val  = tokens[1];
         size_t index;
-        name.erase(name.find_last_not_of("\t")+1);
-        name.erase(name.find_last_not_of(" ")+1);
+        name.erase(name.find_last_not_of(" \t")+1); //remove trailing  spaces and tabs
         while((index = val.find_first_not_of(".0123456789")) != string::npos)
         {
             val.erase(index,1);

--- a/bb/src/usage.cc
+++ b/bb/src/usage.cc
@@ -300,6 +300,7 @@ int proxy_GetDeviceUsage(uint32_t devicenum, BBDeviceUsage_t& usage)
         string name = tokens[0];
         string val  = tokens[1];
         size_t index;
+        name.erase(name.find_last_not_of("\t")+1);
         name.erase(name.find_last_not_of(" ")+1);
         while((index = val.find_first_not_of(".0123456789")) != string::npos)
         {
@@ -322,11 +323,11 @@ int proxy_GetDeviceUsage(uint32_t devicenum, BBDeviceUsage_t& usage)
     copyd(temperature);
     copyd(available_spare);
     copyd(percentage_used);
-    copyi(data_read);
-    copyi(data_written);
-    copyi(num_read_commands);
-    copyi(num_write_commands);
-    copyi(busy_time);
+    usage.data_read = stoull(field["data_units_read"]);
+    usage.data_written = stoull(field["data_units_written"]);
+    usage.num_read_commands = stoull(field["host_read_commands"]);
+    usage.num_write_commands  = stoull(field["host_write_commands"]);
+    usage.busy_time  = stoull(field["controller_busy_time"]);
     copyi(power_cycles);
     copyi(power_on_hours);
     copyi(unsafe_shutdowns);

--- a/bb/src/usage.cc
+++ b/bb/src/usage.cc
@@ -323,11 +323,11 @@ int proxy_GetDeviceUsage(uint32_t devicenum, BBDeviceUsage_t& usage)
     copyd(temperature);
     copyd(available_spare);
     copyd(percentage_used);
-    usage.data_read = stoull(field["data_units_read"]);
-    usage.data_written = stoull(field["data_units_written"]);
-    usage.num_read_commands = stoull(field["host_read_commands"]);
-    usage.num_write_commands  = stoull(field["host_write_commands"]);
-    usage.busy_time  = stoull(field["controller_busy_time"]);
+    copyi(data_read);
+    copyi(data_written);
+    copyi(num_read_commands);
+    copyi(num_write_commands);
+    copyi(busy_time);
     copyi(power_cycles);
     copyi(power_on_hours);
     copyi(unsafe_shutdowns);

--- a/bb/src/usage.cc
+++ b/bb/src/usage.cc
@@ -11,7 +11,7 @@
  |    restricted by GSA ADP Schedule Contract with IBM Corp.
  *******************************************************************************/
 
-
+#include <stdexcept> 
 #include <pthread.h>
 #include <semaphore.h>
 #include <stdio.h>
@@ -150,8 +150,16 @@ private:
         vector<uint64_t> values;
         boost::char_separator<char> sep(" ");
         tokenizer< boost::char_separator<char>  > tok(line_str, sep);
-        for(tokenizer< boost::char_separator<char> >::iterator beg=tok.begin(); beg!=tok.end();++beg)
-            values.push_back(stoull(*beg));
+        try {
+            for(tokenizer< boost::char_separator<char> >::iterator beg=tok.begin(); beg!=tok.end();++beg){
+              if ( beg->compare("\n")==0  ) continue;
+              values.push_back(stoull(*beg));
+            }
+        }
+        catch (invalid_argument& e)
+        {
+           LOG(bb,info) <<"file="<<__FILE__<<" "<< __FUNCTION__<<":"<< __LINE__<<":"<<e.what();
+        }
 
         pLocalRead       = values[6-4] * sectorsize;
         pLocalWrite      = values[10-4] * sectorsize;


### PR DESCRIPTION
Compiled in 8.4 docker, used local tools to create a repo and uninstall/install RPMS and start up daemons.  Ran against robot from Jenkins for testing.