### PR TITLE
Add volumegroup and tcp transport options

### DIFF
--- a/bb/ansible/bbserverIPlist.yml
+++ b/bb/ansible/bbserverIPlist.yml
@@ -63,6 +63,14 @@
 
 - hosts: compute server
   tasks:
+  - name: Create /etc/ibm directory if it does not exist
+    file:   
+      path: /etc/ibm
+      state: directory
+      mode: '0755'
+      owner: root
+      group: root
+
   - name: Copy server ip list to compute/server  nodes
     copy:
         src: /tmp/serverlist

--- a/bb/ansible/nodelist.yml
+++ b/bb/ansible/nodelist.yml
@@ -45,6 +45,14 @@
       
 - hosts: compute
   tasks:
+  - name: Create /etc/ibm directory if it does not exist
+    file:   
+      path: /etc/ibm
+      state: directory
+      mode: '0755'
+      owner: root
+      group: root
+
   - name: Copy nodelist to compute nodes
     copy:
         src: /tmp/nodelist

--- a/bb/scripts/bbactivate.pl
+++ b/bb/scripts/bbactivate.pl
@@ -140,6 +140,7 @@ GetOptions(
     "nodelist=s"      => \$CFG{"nodelist"},
     "esslist=s"       => \$CFG{"esslist"},
     "configtempl=s"   => \$CFG{"configtempl"},
+    "volumegroup=s"   => \$CFG{"volumegroup"},
     "nvmetempl=s"     => \$CFG{"nvmetempl"},
     "outputconfig=s"  => \$CFG{"outputconfig"},
     "interfacename=s" => \$CFG{"interfacename"},
@@ -246,6 +247,7 @@ sub setDefaults
     &def("envdir",           1, "HOME");
     &def("lsfdir",           1, "");
     &def("skip",             1, "");
+    &def("volumegroup",      1, "bb");
     &def("configtempl",      2, "$SCRIPTPATH/bb.cfg");
     &def("nvmetempl",        2, "$SCRIPTPATH/nvmet.json");
 
@@ -417,6 +419,8 @@ sub makeProxyConfigFile
     {
         $json->{"bb"}{"proxy"}{"controller"} = "csm";
     }
+    $json->{"bb"}{"proxy"}{"volumegroup"} = $CFG{"volumegroup"};
+    
     $json->{"bb"}{"cmd"}{"controller"} = "none";    # disable on compute nodes
 
     $json->{"bb"}{"server0"}{"sslcertif"} = $CFG{"sslcert"} if($CFG{"sslcert"} ne "default");

--- a/bb/src/serial.cc
+++ b/bb/src/serial.cc
@@ -172,6 +172,10 @@ void look4NVMFinitiator(){
                             {
                                 files.push_back("address");
                             }
+                            else if(line == string("tcp"))
+                            {
+                                files.push_back("address");
+                            }
                         }
                         if(files[index] == "address")
                         {
@@ -292,6 +296,11 @@ void look4NVMFtargetDevices(){
                                 {
                                 }
                                 else if(line == string("rdma"))
+                                {
+                                    files.push_back("addr_traddr");
+                                    files.push_back("addr_trsvcid");
+                                }
+                                else if(line == string("tcp"))
                                 {
                                     files.push_back("addr_traddr");
                                     files.push_back("addr_trsvcid");


### PR DESCRIPTION
Support bbactivate option to override LV volumegroup in the configuration file, and handle NVMf tcp transports
