### PR TITLE
csm fvt error injection test bucket improvement related to messaging …

### DIFF
--- a/csmtest/buckets/error_injection/messaging.sh
+++ b/csmtest/buckets/error_injection/messaging.sh
@@ -28,6 +28,7 @@ CSM_PATH=/opt/ibm/csm/bin
 TEMP_LOG=${LOG_PATH}/buckets/error_injection/messaging_tmp.log
 FLAG_LOG=${LOG_PATH}/buckets/error_injection/messaging_flags.log
 ERROR_INJECT=${CAST_PATH}/.build/csmd/src/daemon/tests/error_inject
+export LD_LIBRARY_PATH=/opt/ibm/csm/lib/:/opt/ibm/flightlog/lib
 
 if [ -f "${BASH_SOURCE%/*}/../../include/functions.sh" ]
 then


### PR DESCRIPTION
…protocol and library path

# Issue
The error_injection test bucket should be improved to not be so sensitive to library locations.

Work around this problem by adding this to the LD_LIBRARY_PATH:
`export LD_LIBRARY_PATH=/opt/ibm/csm/lib/:/opt/ibm/flightlog/lib`

After this change, this bucket passed successfully.

## Open Questions and Pre-Merge TODOs
- [ ] @williammorrison2  (CSM FVT Regression)
- [ ] @besawn (code and function review)

